### PR TITLE
fix for editor bug #105

### DIFF
--- a/tulip/shared/editor.c
+++ b/tulip/shared/editor.c
@@ -408,6 +408,8 @@ void editor_save() {
                         text[c++] = text_lines[i][j];
                     }
                     text[c++] = '\n';
+                } else {
+                    text[c++] = '\n';
                 }
             }
         }


### PR DESCRIPTION
Add a newline back to lines that start with `\0` in them. we no longer store the `\n` in these lines, so the saving function has to add them back in