### PR TITLE
Update tulip_desktop.md

### DIFF
--- a/docs/tulip_desktop.md
+++ b/docs/tulip_desktop.md
@@ -56,17 +56,14 @@ cd tulipcc
 Install the dependencies:
 
 ```bash
-# Ubuntu etc
-sudo apt install libsdl2-dev libffi-dev
+# Ubuntu, Debian, etc., including Windows 11 in WSL2
+sudo apt install build-essential libsdl2-dev libffi-dev alsa-utils
 
-# Fedora etc
-sudo yum install SDL2-devel libffi-devel
+# Fedora 40+, etc.
+sudo dnf install gcc make SDL2-devel libffi-devel alsa-utils
 
 # Arch
 sudo pacman -S sdl2 libffi
-
-# WSL 
-sudo apt install libsdl2-dev libffi-dev make gcc alsa-utils
 ```
 
 Build and run:


### PR DESCRIPTION
Updated Linux build dependencies for Ubuntu / Debian and Fedora. I just ran these a few minutes ago. I can do openSUSE Tumbleweed too if you want, although I rarely use it.