### PR TITLE
fixes for #318

### DIFF
--- a/docs/tulip_api.md
+++ b/docs/tulip_api.md
@@ -709,7 +709,7 @@ tulip.tfb_restore()
 
 # You can copy what the TFB prints to your local terminal or ESP monitor for debugging
 # On Tulip CC you can also type into the ESP monitor, but not yet on Tulip Desktop 
-tulip.tfb_log_start() # starts copying TFB to local stderr
+tulip.tfb_log_start() # starts copying TFB to local stderr, on by default
 tulip.tfb_log_stop() # stops
 ```
 

--- a/tulip/esp32s3/mpconfigport.h
+++ b/tulip/esp32s3/mpconfigport.h
@@ -53,7 +53,7 @@
 #define MICROPY_STREAMS_POSIX_API           (1)
 #define MICROPY_USE_INTERNAL_ERRNO          (0) // errno.h from xtensa-esp32-elf/sys-include/sys
 #define MICROPY_USE_INTERNAL_PRINTF         (0) // ESP32 SDK requires its own printf
-#define MICROPY_SCHEDULER_DEPTH             (32)
+#define MICROPY_SCHEDULER_DEPTH             (128)
 #define MICROPY_VFS                         (1)
 
 // control over Python builtins

--- a/tulip/shared/display.c
+++ b/tulip/shared/display.c
@@ -50,7 +50,7 @@ uint32_t **bg_lines;//[V_RES];
 // Defaults for runtime display params
 uint16_t PIXEL_CLOCK_MHZ = DEFAULT_PIXEL_CLOCK_MHZ;
 uint8_t tfb_active = 1;
-uint8_t tfb_log = 0;
+uint8_t tfb_log = 1;
 uint8_t gpu_log = 0;
 
 int16_t lvgl_is_repl = 0;

--- a/tulip/shared/midi.h
+++ b/tulip/shared/midi.h
@@ -15,7 +15,7 @@ extern mp_obj_t midi_callback;
 
 //void tulip_midi_isr();
 #define MAX_MIDI_BYTES_PER_MESSAGE 3
-#define MIDI_QUEUE_DEPTH 48
+#define MIDI_QUEUE_DEPTH 1024
 extern uint8_t last_midi[MIDI_QUEUE_DEPTH][MAX_MIDI_BYTES_PER_MESSAGE];
 extern uint8_t last_midi_len[MIDI_QUEUE_DEPTH];
 extern int16_t midi_queue_tail;

--- a/tulip/shared/py/midi.py
+++ b/tulip/shared/py/midi.py
@@ -561,6 +561,11 @@ WARNED_MISSING_CHANNELS = set()
 def midi_event_cb(midi_message):
     """Callback that takes MIDI note on/off to create Note objects."""
     ensure_midi_config()
+
+    # Ignore single value messages (clock, etc) for now.
+    if(len(midi_message)<2): 
+        return
+
     message = midi_message[0] & 0xF0
     channel = (midi_message[0] & 0x0F) + 1
     control = midi_message[1]
@@ -571,9 +576,9 @@ def midi_event_cb(midi_message):
         GLOBAL_MIDI_CC_BINDINGS[control](value)
         return  # Early exit
     if channel not in config.synth_per_channel:
-        if channel not in WARNED_MISSING_CHANNELS:
-            print("Warning: No synth configured for MIDI channel", channel)
-            WARNED_MISSING_CHANNELS.add(channel)
+        #if channel not in WARNED_MISSING_CHANNELS:
+        #    print("Warning: No synth configured for MIDI channel %d. message was %s %s" %(channel, hex(midi_message[0]), hex(midi_message[1])))
+        #    WARNED_MISSING_CHANNELS.add(channel)
         return  # Early exit
     # We have a populated channel.
     synth = config.synth_per_channel[channel]
@@ -621,10 +626,11 @@ def c_fired_midi_event(x):
         for c in MIDI_CALLBACKS:
             c(m)
 
-        # Are there more events waiting?
-        m = m[3:]
-        if len(m) == 0:
-            m = tulip.midi_in()
+        m = tulip.midi_in()
+        ## Are there more events waiting?
+        #m = m[3:]
+        #if len(m) == 0:
+        #    m = tulip.midi_in()
 
 
 # Keep this -- this is a tulip API 


### PR DESCRIPTION
- ignore 1 byte midi messages in `midi.py` (for now!)
- increase scheduler depth for fast midi scheduling
- increate `midi.c` queue length for fast midi scheduling
- stop looking for multiple midi messages in a single message -- we don't get those
- turn on tfb logging by default too