### PR TITLE
Add tulip desktop audio device information on Mac OS X to docs

### DIFF
--- a/docs/tulip_desktop.md
+++ b/docs/tulip_desktop.md
@@ -77,9 +77,29 @@ cd tulip/linux
 
 ## Windows build of Tulip Desktop
 
-We've heard this works fine under WSL2 using the Linux instructions. We'd love a native build! 
+We've heard this works fine under WSL2 using the Linux instructions. We'd love a native build!
 
+## Troubleshooting
 
+Tulip on Mac OS X selects which audio device it will use for output when it starts. If you get no audio, you can check the available audio devices with
+
+```shell
+$ <path_to_app_bundle>/Tulip\ Desktop.app/Contents/MacOS/tulip -l
+0 - DELL U2715H
+1 - DELL U2715H
+2 - External Headphones
+3 - MacBook Pro Speakers
+4 - Microsoft Teams Audio
+5 - ZoomAudioDevice
+```
+
+And then select the device that you want to use with the `-d <device_number>` option, for example
+
+```shell
+$ <path_to_app_bundle>/Tulip\ Desktop.app/Contents/MacOS/tulip -d 2
+```
+
+For more details see <https://github.com/shorepine/tulipcc/issues/103>.
 ## Questions
 
 Any questions? [Chat with us on our discussions page.](https://github.com/shorepine/tulipcc/discussions)


### PR DESCRIPTION
From a discussion on Discord, it is possible that Tulip Desktop doesn't select a reasonable audio device on startup on Mac OS X and might give no output. The solution is straightforward, but this just makes it more visible in the documentation.