### PR TITLE
midi.py, music.md, ..: Add midi.config.get_synth(), rename polyphony

### DIFF
--- a/docs/tulip_api.md
+++ b/docs/tulip_api.md
@@ -491,7 +491,7 @@ By default, Tulip boots into a live MIDI synthesizer mode. Any note-ons, note-of
 
 By default, MIDI notes on channel 1 will map to Juno-6 patch 0. And MIDI notes on channel 10 will play the PCM samples (like a drum machine).
 
-You can adjust which voices are sent with `midi.config.add_synth(channel, patch, polyphony)`. For example, you can have Tulip play DX7 patch 129 on channel 2 with `midi.config.add_synth(channel=2, patch=129, polyphony=1)`. The `2`, channel, is a MIDI channel (we use 1-16 indexing), the patch `129` is an AMY patch number, `1` is the number of voices (polyphony) you want to support for that channel and patch. 
+You can adjust which voices are sent with `midi.config.add_synth(channel, patch_number, num_voices)`. For example, you can have Tulip play DX7 patch 129 on channel 2 with `midi.config.add_synth(channel=2, patch_number=129, num_voices=1)`. `channel=2` is a MIDI channel (we use 1-16 indexing), `patch=129` is an AMY patch number, `num_voices=1` is the number of voices (polyphony) you want to support for that channel and patch. 
 
 (A good rule of thumb is Tulip CC can support about 6 simultaneous total voices for Juno-6, 8-10 for DX7, and 20-30 total voices for PCM and more for other simpler oscillator patches.)
 

--- a/tulip/shared/py/voices.py
+++ b/tulip/shared/py/voices.py
@@ -265,7 +265,7 @@ def update_map():
         channel_patch, amy_voices = midi.config.channel_info(channel)
         channel_polyphony = 0 if amy_voices is None else len(amy_voices)
         if (channel_patch, channel_polyphony) != (patch_no, polyphony):
-            midi.config.add_synth(channel=channel, patch=patch_no, polyphony=polyphony)
+            midi.config.add_synth(channel=channel, patch_number=patch_no, num_voices=polyphony)
 
 
 # populate the patches dialog from patches.py


### PR DESCRIPTION
This adds a couple of cleanups to the music.md tutorial, with associated code changes.

`midi.config.get_synth()` replaces direct access of `midi.config.synth_per_channel` which was seemingly endorsing direct access of internal data.

`midi.config.add_synth()` gains defaults for all args, and polyphony becomes `num_voices` for consistency with lower levels.

Use of `synth.program_change()` is replaced by `patch_number=X` in the `Synth` constructor.

Python style guide spaces around args.