### PR TITLE
voices.py: fix error when menu changes to be shorter than stored sele…

### DIFF
--- a/tulip/shared/py/voices.py
+++ b/tulip/shared/py/voices.py
@@ -167,7 +167,7 @@ class ListColumn(tulip.UIElement):
                 self.button_texts.append(i)
 
     def select(self, index, defer=False):
-        if(self.selected is not None):
+        if self.selected is not None and self.selected < len(self.buttons):
             self.buttons[self.selected].set_style_bg_color(tulip.pal_to_lv(self.default_bg), 0)
         self.selected = index
         if index is not None:


### PR DESCRIPTION
…ction.

The error: 
 * open voices
 * Select e.g. 4th entry on patch list
 * Switch synth to "misc" (which doesn't have a 4th entry)
 * Click on 1st entry on patch list
Code used to try to unselect the 4th entry on the list which crashed with an index error.
This fix skips the unselect code if the list doesn't have the requested entry.