### PR TITLE
midi.py: Fix to remove repeated note from sustained_notes

### DIFF
--- a/tulip/shared/py/midi.py
+++ b/tulip/shared/py/midi.py
@@ -317,11 +317,13 @@ class Synth:
             raise ValueError('Synth note on with no voices - synth has been released?')
         if velocity == 0:
             self.note_off(note, time=time, sequence=sequence)
-        else:
-            # Velocity > 0, note on.
+        else:  # Velocity > 0, note on.
             if note in self.voice_of_note:
                 # Send another note-on to the voice already playing this note.
                 new_voice = self.voice_of_note[note]
+                # Remove pending note-off from sustain, if any.
+                if note in self.sustained_notes:
+                    self.sustained_notes.remove(note)
             else:
                 new_voice = self._get_next_voice()
                 self.active_voices.put(new_voice)


### PR DESCRIPTION
Fixes a problem with prematurely terminating a note on pedal-up (release of piano sustain).   Previously, the sequence [pedal down, play & release notes (they sustain), play one of the sounding notes again, hold it down but release the pedal] would execute a note-off for the note that was being held down, because its note-off from the release of the first chord was still pending.  

With this fix, note-on ensures the note in question is not in the list of deferred note-offs, so it is not prematurely terminated.

Thanks to matt-har-vey for identifying the problem and providing the fix!
