### PR TITLE
midi.config.add_synth now subsumes add_synth_object.

### DIFF
--- a/docs/music.md
+++ b/docs/music.md
@@ -171,7 +171,7 @@ You may want to programatically change the MIDI to synth mapping. One example wo
 You can change the parameters of channel synths like this:
 
 ```python
-midi.config.add_synth(channel=c, patch_number=p, num_voices=n)
+midi.config.add_synth(channel=c, synth=midi.Synth(patch_number=p, num_voices=n))
 ```
 
 Note that `add_synth` will stop any running Synth on that channel and boot a new one in its place. 

--- a/tulip/shared/py/voices.py
+++ b/tulip/shared/py/voices.py
@@ -265,7 +265,7 @@ def update_map():
         channel_patch, amy_voices = midi.config.channel_info(channel)
         channel_polyphony = 0 if amy_voices is None else len(amy_voices)
         if (channel_patch, channel_polyphony) != (patch_no, polyphony):
-            midi.config.add_synth(channel=channel, patch_number=patch_no, num_voices=polyphony)
+            midi.config.add_synth(channel=channel, synth=midi.Synth(patch_number=patch_no, num_voices=polyphony))
 
 
 # populate the patches dialog from patches.py


### PR DESCRIPTION
Originally we had `midi.config.add_synth()` which took a patch number and voices count.
Then we created the `Synth()` object which handled the patch number.  But `add_synth` called it.
Then we added `add_synth_object` so you could construct your own `Synth` object and add it to MIDI.
But users were confused about how synths were created since `midi.config.add_synth()` was doing it for them.

This change alters `midi.config.add_synth()` to accept a `Synth` object, and to prefer that pattern.  This makes it obvious to the user that `Synth` objects are the core concept.

The problem here, I realize, is that in order to manage the limited `voices` resources, it's best to `release` any existing synth before creating the new `Synth` object.  However, if the `Synth` is passed as an instantiated object it will already have grabbed its voices.   Maybe we can fix with some kind of deferred initialization in the `Synth` object.