### PR TITLE
midi.py: Add `midi.config.reset()` to release & reset all synths/voices.

### DIFF
--- a/tulip/shared/py/midi.py
+++ b/tulip/shared/py/midi.py
@@ -21,6 +21,13 @@ class MidiConfig:
             patch = patch_per_channel[channel] if channel in patch_per_channel else None
             self.add_synth(channel=channel, synth=Synth(patch_number=patch, num_voices=num_voices))
 
+    def reset(self):
+        """Clear the midi config, release all the synths."""
+        for channel in self.synth_per_channel.keys():
+            self.release_synth_for_channel(channel)
+        # For now, for convenience, reset the whole system too, clearing any synth definitions.
+        Synth.reset()
+
     def release_synth_for_channel(self, channel):
         if channel in self.synth_per_channel:
             # Old Synth allocated - Expicitly return the amy_voices to the pool.


### PR DESCRIPTION
The new dpwe piano wants 25 oscs per voice, and this went badly unless I fully release all the default Synths (and reset the voices system) before attempting `midi.config.add_synth(channel=1, synth=Synth(patch_number=256, num_voices=4))`.  So this command releases any Synths known to midi.config, then calls `Synth.reset()`, which in turn calls `amy.resetI()`.