### PR TITLE
macos desktop control-D quits and restores termios

### DIFF
--- a/tulip/macos/main.c
+++ b/tulip/macos/main.c
@@ -542,6 +542,7 @@ int main(int argc, char **argv) {
     return main_(argc, argv);
 }
 */
+extern int8_t unix_display_flag;
 
 extern void setup_lvgl();
 
@@ -886,7 +887,7 @@ soft_reset_exit:
     }
     #endif
     #endif
-
+    unix_display_flag=-1;
     // printf("total bytes = %d\n", m_get_total_bytes_allocated());
     //return ret & 0xff;
     return 0;
@@ -894,7 +895,6 @@ soft_reset_exit:
 
 
 
-extern int8_t unix_display_flag;
 
 #include "lvgl.h"
 
@@ -971,6 +971,7 @@ display_jump:
     }
 
     // We're done. join the threads?
+    mp_hal_stdio_mode_orig();
     return 0;
 }
 

--- a/tulip/shared/desktop/unix_mphal.c
+++ b/tulip/shared/desktop/unix_mphal.c
@@ -121,7 +121,7 @@ void mp_hal_stdio_mode_raw(void) {
     termios.c_cc[VMIN] = 0; //1;
     termios.c_cc[VTIME] = 0;
     tcsetattr(0, TCSAFLUSH, &termios);
-    
+
 }
 
 void mp_hal_stdio_mode_orig(void) {


### PR DESCRIPTION

This prevents bash from getting messed up on exit. You can also quit TD with control-D now.

