### PR TITLE
Allow use of un-aliased Tulip fonts in LVGL

### DIFF
--- a/docs/tulip_api.md
+++ b/docs/tulip_api.md
@@ -202,6 +202,9 @@ def run(screen):
     screen.deactivate_callback = None # called when you switch away from the app
     screen.quit_callback = None # called when the quit button is pressed. Note: deactivate_callback is called first on quit
     screen.handle_keyboard = False # if you set up UI components that accept keyboard input
+
+    screen.group.set_style_text_font(lv.font_tulip_11,0) # Set the default font for the entire app if you want
+
     # Set up your UI with screen.add(), adding UIElement objects
     screen.add(tulip.UILabel("hello there"), x=500,y=100)
     # You can use LVGL alignment to add objects in relation to the last object added
@@ -242,6 +245,8 @@ You can see running multitasking apps with `tulip.running_apps`, which is a dict
 You can summon a touch keyboard with `tulip.keyboard()`. Tapping the keyboard icon dismisses it, or you can use `tulip.keyboard()` again to remove it. 
 
 We boot a launcher for common operations. It's available via the small grey icon on the bottom right.
+
+For LVGL fonts, you can use default [LVGL `montserrat` fonts](https://docs.lvgl.io/master/details/main-modules/font.html), e.g. `font=lv.font_montserrat_12`, or the built in Tulip BG fonts, e.g. `font=lv.tulip_font_13`. 
 
 ```python
 tulip.keyboard() # open or close the soft keyboard
@@ -751,7 +756,7 @@ tulip.bg_roundrect(x,y, w,h, r, pal_idx, filled)
 tulip.bg_rect(x,y, w,h, pal_idx, filled)
 tulip.bg_triangle(x0,y0, x1,y1, x2,y2, pal_idx, filled)
 tulip.bg_fill(x,y,pal_idx) # Flood fill starting at x,y
-tulip.bg_str(string, x, y, pal_idx, font) # same as char, but with a string. x and y are the bottom left
+tulip.bg_str(string, x, y, pal_idx, font) # same as char, but with a string. x and y are the bottom left. font is a number, 0-18
 tulip.bg_str(string, x, y, pal_idx, font, w, h) # Will center the text inside w,h
 
 """
@@ -781,10 +786,15 @@ tulip.bg_scroll_y_offset(line, y_offset)
 tulip.bg_swap()
 ```
 
-We currently ship some fonts with Tulip to use for the BG. These are aside from the fonts that come with LVGL for the UI. You can see them all by running `fonts.py`, which also shows how to address them:
+### Fonts
+
+There are three types of fonts built into Tulip. 
+
+ - TFB font: we ship one fixed size font for the TFB (see below). This cannot be changed at runtime.
+ - LVGL fonts: [LVGL ships a few fonts like `lv.font_montserrat_12`](https://docs.lvgl.io/master/details/main-modules/font.html). These fonts have more glyphs, can handle some unicode characters, and also ship with symbols (like the ones we show in the Tulip launcher). 
+ - Tulip fonts: we ship 19 fonts to use with `bg_str` etc, and they can also be used in LVGL widgets by referencing them like `lv.tulip_font_13`.
 
 ![IMG_3339](https://user-images.githubusercontent.com/76612/229381546-46ec4c50-4c4a-4f3a-9aec-c77d439081b2.jpeg)
-
 
 
 ## Text frame buffer (TFB)

--- a/lv_binding_micropython_tulip/lv_conf.h
+++ b/lv_binding_micropython_tulip/lv_conf.h
@@ -447,8 +447,8 @@ extern void mp_lv_init_gc();
 */
 
 /*Always set a default font*/
-//#define LV_FONT_DEFAULT &lv_font_montserrat_12
-#define LV_FONT_DEFAULT &lv_font_tulip_11
+#define LV_FONT_DEFAULT &lv_font_montserrat_12
+//#define LV_FONT_DEFAULT &lv_font_tulip_11
 
 /*Enable handling large font and/or fonts with a lot of characters.
  *The limit depends on the font size, font face and bpp.

--- a/lv_binding_micropython_tulip/lv_conf.h
+++ b/lv_binding_micropython_tulip/lv_conf.h
@@ -447,8 +447,8 @@ extern void mp_lv_init_gc();
 */
 
 /*Always set a default font*/
-#define LV_FONT_DEFAULT &lv_font_montserrat_12
-//#define LV_FONT_DEFAULT &lv_font_tulip_11
+//#define LV_FONT_DEFAULT &lv_font_montserrat_12
+#define LV_FONT_DEFAULT &lv_font_tulip_11
 
 /*Enable handling large font and/or fonts with a lot of characters.
  *The limit depends on the font size, font face and bpp.

--- a/lv_binding_micropython_tulip/lvgl/src/font/lv_font.h
+++ b/lv_binding_micropython_tulip/lvgl/src/font/lv_font.h
@@ -191,10 +191,8 @@ void lv_font_set_kerning(lv_font_t * font, lv_font_kerning_t kerning);
 
 #define LV_FONT_DECLARE(font_name) LV_ATTRIBUTE_EXTERN_DATA extern const lv_font_t font_name;
 
-extern lv_font_t lv_font_tulip_11;
-//LV_FONT_DECLARE(lv_font_tulip_0);
 
-/*
+extern lv_font_t lv_font_tulip_0;
 extern lv_font_t lv_font_tulip_1;
 extern lv_font_t lv_font_tulip_2;
 extern lv_font_t lv_font_tulip_3;
@@ -213,7 +211,7 @@ extern lv_font_t lv_font_tulip_15;
 extern lv_font_t lv_font_tulip_16;
 extern lv_font_t lv_font_tulip_17;
 extern lv_font_t lv_font_tulip_18;
-*/
+
 
 #if LV_FONT_MONTSERRAT_8
 LV_FONT_DECLARE(lv_font_montserrat_8)

--- a/lv_binding_micropython_tulip/lvgl/src/font/lv_font.h
+++ b/lv_binding_micropython_tulip/lvgl/src/font/lv_font.h
@@ -190,8 +190,11 @@ void lv_font_set_kerning(lv_font_t * font, lv_font_kerning_t kerning);
  **********************/
 
 #define LV_FONT_DECLARE(font_name) LV_ATTRIBUTE_EXTERN_DATA extern const lv_font_t font_name;
+
+extern lv_font_t lv_font_tulip_11;
+//LV_FONT_DECLARE(lv_font_tulip_0);
+
 /*
-extern lv_font_t lv_font_tulip_0;
 extern lv_font_t lv_font_tulip_1;
 extern lv_font_t lv_font_tulip_2;
 extern lv_font_t lv_font_tulip_3;

--- a/tulip/shared/display.c
+++ b/tulip/shared/display.c
@@ -994,7 +994,7 @@ void my_log_cb(lv_log_level_t level, const char * buf)
     fprintf(stderr, "%s\n", buf);
 }
 
-/*
+
 extern void get_lvgl_font_from_tulip(uint8_t font_no, lv_font_t *outfont);
 
 lv_font_t lv_font_tulip_0;
@@ -1016,7 +1016,7 @@ lv_font_t lv_font_tulip_15;
 lv_font_t lv_font_tulip_16;
 lv_font_t lv_font_tulip_17;
 lv_font_t lv_font_tulip_18;
-*/
+
 
 lv_indev_t * indev;
 lv_indev_t * indev_kb;
@@ -1046,7 +1046,7 @@ void setup_lvgl() {
     indev_kb = lv_indev_create();
     lv_indev_set_type(indev_kb, LV_INDEV_TYPE_KEYPAD);
     lv_indev_set_read_cb(indev_kb, lvgl_input_kb_read_cb);  
-/*
+
     get_lvgl_font_from_tulip(0, &lv_font_tulip_0);
     get_lvgl_font_from_tulip(1, &lv_font_tulip_1);
     get_lvgl_font_from_tulip(2, &lv_font_tulip_2);
@@ -1066,7 +1066,7 @@ void setup_lvgl() {
     get_lvgl_font_from_tulip(16, &lv_font_tulip_16);
     get_lvgl_font_from_tulip(17, &lv_font_tulip_17);
     get_lvgl_font_from_tulip(18, &lv_font_tulip_18);
-    */
+    
 }
 
 

--- a/tulip/shared/lvgl_u8g2.c
+++ b/tulip/shared/lvgl_u8g2.c
@@ -39,8 +39,8 @@ bool my_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out, 
     dsc_out->adv_w = adv;        /*Horizontal space required by the glyph in [px]*/
 
     // ufont height/width are swapped
-    dsc_out->box_w = ufont.font_info.max_char_height;      /*Width of the bitmap in [px]*/
-    dsc_out->box_h = ufont.font_info.max_char_width;       /*Width of the bitmap in [px]*/
+    dsc_out->box_w = ufont.font_info.max_char_width;      /*Width of the bitmap in [px]*/
+    dsc_out->box_h = ufont.font_info.max_char_height;       /*Width of the bitmap in [px]*/
 
     dsc_out->ofs_x = 0;                            /*X offset of the bitmap in [pf]*/
     dsc_out->ofs_y = 0;
@@ -65,8 +65,8 @@ void get_lvgl_font_from_tulip(uint32_t font_no, lv_font_t * outfont) {
     
     outfont->get_glyph_dsc = my_get_glyph_dsc_cb;        /*Set a callback to get info about glyphs*/
     outfont->get_glyph_bitmap = my_get_glyph_bitmap_cb;  /*Set a callback to get bitmap of a glyph*/
-    outfont->line_height = ufont.font_info.max_char_height;                       /*The real line height where any text fits*/
-    outfont->base_line = abs(ufont.font_info.y_offset); // base_line;                      /*Base line measured from the top of line_height*/
+    outfont->line_height = ufont.font_info.max_char_width;                       /*The real line height where any text fits*/
+    outfont->base_line = 0;//abs(ufont.font_info.y_offset); // base_line;                      /*Base line measured from the top of line_height*/
     //outfont->fallback = &lv_font_montserrat_12;
     void *ptr = malloc(sizeof(uint32_t));
     *((uint32_t*)ptr) = font_no;

--- a/tulip/shared/lvgl_u8g2.c
+++ b/tulip/shared/lvgl_u8g2.c
@@ -39,22 +39,41 @@ bool my_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out, 
     u8g2_SetFont(&ufont, tulip_fonts[font_no]);
     for(uint16_t i=0;i<(MAX_FONT_H*MAX_FONT_W);i++) { databuf[i] = 0; }
     int16_t adv = u8g2_DrawGlyph_target(&ufont, unicode_letter, databuf);
+    //uint16_t c = 0;
+    //uint16_t tick = 0;
     u8g2_font_decode_t font_decode = u8g2_GetGlyphInfo(&ufont, unicode_letter);
-    
-    // debug
-       
-/*
-    if((unicode_letter=='*' || unicode_letter=='j' || unicode_letter=='i' || unicode_letter=='o') && font_no==11) {
-        fprintf(stderr, "fn %d %c adv %d height %d width %d x %d y %d tx %d ty %d\n", 
-            font_no, unicode_letter, adv,font_decode.glyph_height, font_decode.glyph_width, font_decode.x, font_decode.y, 
-            font_decode.target_x, font_decode.target_y );
+    /*
+    for(uint16_t i = 0; i< (MAX_FONT_H*MAX_FONT_W);i++) {
+        if(databuf[i]!=0) tick++;
     }
-*/    
+    fprintf(stderr, "[[%c]] width %d height %d tick %d\n", unicode_letter, font_decode.glyph_width, font_decode.glyph_height, tick);
+    for(uint16_t y=0;y<ufont.font_info.max_char_height;y++) {
+        fprintf(stderr, "%02d: |", y);
+        for(uint16_t x=0;x<font_decode.glyph_width*2;x++) {
+            if(databuf[c++]){
+                fprintf(stderr, "#");
+            } else {
+                fprintf(stderr, " ");
+            }
+
+        }   
+        fprintf(stderr, "|\n");
+    }
+    */
+    /*
+    if((unicode_letter=='*' || unicode_letter=='-' || unicode_letter=='_' || unicode_letter=='y' || unicode_letter=='A') && font_no==11) {
+        fprintf(stderr, "fn %d %c adv %d height %d width %d x %d y %d tx %d ty %d FONT: mcw %d mch %d, xoff %d yoff %d, aA %d dg %d\n", 
+            font_no, unicode_letter, adv,font_decode.glyph_height, font_decode.glyph_width, font_decode.x, font_decode.y, 
+            font_decode.target_x, font_decode.target_y, ufont.font_info.max_char_width, ufont.font_info.max_char_height, 
+            ufont.font_info.x_offset, ufont.font_info.y_offset, ufont.font_info.ascent_A, ufont.font_info.descent_g );
+
+    }
+    */
     dsc_out->adv_w = adv;        /*Horizontal space required by the glyph in [px]*/
-    dsc_out->box_h = font_decode.glyph_height*2;           /*Height of the bitmap in [px]*/
-    dsc_out->box_w = (font_decode.glyph_width+abs(font_decode.target_x))*2 ;         /*Width of the bitmap in [px]*/
-    dsc_out->ofs_x = 1; //font_decode.target_x;                              /*X offset of the bitmap in [pf]*/
-    dsc_out->ofs_y = -font_decode.glyph_height; 
+    dsc_out->box_w = ufont.font_info.max_char_height;//(font_decode.glyph_width)-(ufont.font_info.x_offset); //)*2 ;         /*Width of the bitmap in [px]*/
+    dsc_out->box_h = ufont.font_info.max_char_width;//(font_decode.glyph_height-(ufont.font_info.y_offset));//) ;         /*Width of the bitmap in [px]*/
+    dsc_out->ofs_x = 0;                            /*X offset of the bitmap in [pf]*/
+    dsc_out->ofs_y = 0;
     dsc_out->format= LV_FONT_GLYPH_FORMAT_A1;
     dsc_out->gid.index = unicode_letter; 
     return true;                /*true: glyph found; false: glyph was not found*/
@@ -62,7 +81,24 @@ bool my_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out, 
 
 const void * my_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf)
 {
+    /*
     for(uint16_t i=0;i<g_dsc->box_w*g_dsc->box_h;i++) draw_buf->data[i] = 0;
+    uint16_t c =0;
+    
+    fprintf(stderr, "gid: %c. w %d h %d ox %d oy %d\n", g_dsc->gid.index, g_dsc->box_w, g_dsc->box_h, g_dsc->ofs_x, g_dsc->ofs_y);
+    for(uint16_t y=0;y<g_dsc->box_h;y++) {
+        fprintf(stderr, "%02d: |", y);
+        for(uint16_t x=0;x<g_dsc->box_w;x++) {
+            if(databuf[c]){
+                fprintf(stderr, "#");
+            } else {
+                fprintf(stderr, " ");
+            }
+            draw_buf->data[y*g_dsc->box_w + x] = databuf[c++];
+        }   
+        fprintf(stderr, "|\n");
+    }
+    */
     memcpy(draw_buf->data, databuf, g_dsc->box_w*g_dsc->box_h);
     return draw_buf;
 }
@@ -79,7 +115,7 @@ void get_lvgl_font_from_tulip(uint32_t font_no, lv_font_t * outfont) {
     outfont->get_glyph_dsc = my_get_glyph_dsc_cb;        /*Set a callback to get info about glyphs*/
     outfont->get_glyph_bitmap = my_get_glyph_bitmap_cb;  /*Set a callback to get bitmap of a glyph*/
     outfont->line_height = ufont.font_info.max_char_height;                       /*The real line height where any text fits*/
-    outfont->base_line = 0;//abs(ufont.font_info.descent_g); ///ascent_A // base_line;                      /*Base line measured from the top of line_height*/
+    outfont->base_line = abs(ufont.font_info.y_offset); // base_line;                      /*Base line measured from the top of line_height*/
     //outfont->fallback = &lv_font_montserrat_12;
     void *ptr = malloc(sizeof(uint32_t));
     *((uint32_t*)ptr) = font_no;

--- a/tulip/shared/lvgl_u8g2.c
+++ b/tulip/shared/lvgl_u8g2.c
@@ -1,12 +1,9 @@
 // lvgl_u8g2.c
 // render u8g2 fonts in lvgl 
-
-
 #include "lvgl.h"
 #include "u8g2_fonts.h"
 
 
-//lv_font_t lv_u8g2_font_helvB14_tr;
 // will make this less nasty asap
 #define MAX_FONT_W 50
 #define MAX_FONT_H 80
@@ -25,8 +22,7 @@ bool my_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out, 
     // unfortunately this function seems to be called 3 times per glyph, so maybe try to not draw so much
 
     // BDF fonts only have lower ascii i think
-    // Also, there's some bug where * and ' can't be drawn in a list without segfault
-    if(unicode_letter>127) {// || unicode_letter=='*' || unicode_letter == '\'') {
+    if(unicode_letter>127) {
         return false;
     }
 
@@ -39,39 +35,13 @@ bool my_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out, 
     u8g2_SetFont(&ufont, tulip_fonts[font_no]);
     for(uint16_t i=0;i<(MAX_FONT_H*MAX_FONT_W);i++) { databuf[i] = 0; }
     int16_t adv = u8g2_DrawGlyph_target(&ufont, unicode_letter, databuf);
-    //uint16_t c = 0;
-    //uint16_t tick = 0;
     u8g2_font_decode_t font_decode = u8g2_GetGlyphInfo(&ufont, unicode_letter);
-    /*
-    for(uint16_t i = 0; i< (MAX_FONT_H*MAX_FONT_W);i++) {
-        if(databuf[i]!=0) tick++;
-    }
-    fprintf(stderr, "[[%c]] width %d height %d tick %d\n", unicode_letter, font_decode.glyph_width, font_decode.glyph_height, tick);
-    for(uint16_t y=0;y<ufont.font_info.max_char_height;y++) {
-        fprintf(stderr, "%02d: |", y);
-        for(uint16_t x=0;x<font_decode.glyph_width*2;x++) {
-            if(databuf[c++]){
-                fprintf(stderr, "#");
-            } else {
-                fprintf(stderr, " ");
-            }
-
-        }   
-        fprintf(stderr, "|\n");
-    }
-    */
-    /*
-    if((unicode_letter=='*' || unicode_letter=='-' || unicode_letter=='_' || unicode_letter=='y' || unicode_letter=='A') && font_no==11) {
-        fprintf(stderr, "fn %d %c adv %d height %d width %d x %d y %d tx %d ty %d FONT: mcw %d mch %d, xoff %d yoff %d, aA %d dg %d\n", 
-            font_no, unicode_letter, adv,font_decode.glyph_height, font_decode.glyph_width, font_decode.x, font_decode.y, 
-            font_decode.target_x, font_decode.target_y, ufont.font_info.max_char_width, ufont.font_info.max_char_height, 
-            ufont.font_info.x_offset, ufont.font_info.y_offset, ufont.font_info.ascent_A, ufont.font_info.descent_g );
-
-    }
-    */
     dsc_out->adv_w = adv;        /*Horizontal space required by the glyph in [px]*/
-    dsc_out->box_w = ufont.font_info.max_char_height;//(font_decode.glyph_width)-(ufont.font_info.x_offset); //)*2 ;         /*Width of the bitmap in [px]*/
-    dsc_out->box_h = ufont.font_info.max_char_width;//(font_decode.glyph_height-(ufont.font_info.y_offset));//) ;         /*Width of the bitmap in [px]*/
+
+    // ufont height/width are swapped
+    dsc_out->box_w = ufont.font_info.max_char_height;      /*Width of the bitmap in [px]*/
+    dsc_out->box_h = ufont.font_info.max_char_width;       /*Width of the bitmap in [px]*/
+
     dsc_out->ofs_x = 0;                            /*X offset of the bitmap in [pf]*/
     dsc_out->ofs_y = 0;
     dsc_out->format= LV_FONT_GLYPH_FORMAT_A1;
@@ -81,29 +51,10 @@ bool my_get_glyph_dsc_cb(const lv_font_t * font, lv_font_glyph_dsc_t * dsc_out, 
 
 const void * my_get_glyph_bitmap_cb(lv_font_glyph_dsc_t * g_dsc, lv_draw_buf_t * draw_buf)
 {
-    /*
-    for(uint16_t i=0;i<g_dsc->box_w*g_dsc->box_h;i++) draw_buf->data[i] = 0;
-    uint16_t c =0;
-    
-    fprintf(stderr, "gid: %c. w %d h %d ox %d oy %d\n", g_dsc->gid.index, g_dsc->box_w, g_dsc->box_h, g_dsc->ofs_x, g_dsc->ofs_y);
-    for(uint16_t y=0;y<g_dsc->box_h;y++) {
-        fprintf(stderr, "%02d: |", y);
-        for(uint16_t x=0;x<g_dsc->box_w;x++) {
-            if(databuf[c]){
-                fprintf(stderr, "#");
-            } else {
-                fprintf(stderr, " ");
-            }
-            draw_buf->data[y*g_dsc->box_w + x] = databuf[c++];
-        }   
-        fprintf(stderr, "|\n");
-    }
-    */
     memcpy(draw_buf->data, databuf, g_dsc->box_w*g_dsc->box_h);
     return draw_buf;
 }
 
-//uint32_t font_no= 5;
 void get_lvgl_font_from_tulip(uint32_t font_no, lv_font_t * outfont) {
     u8g2_font_t ufont;
     ufont.font = NULL; 

--- a/tulip/shared/py/voices.py
+++ b/tulip/shared/py/voices.py
@@ -142,8 +142,10 @@ class ListColumn(tulip.UIElement):
         self.group.set_size(width,height)
         self.group.remove_flag(lv.obj.FLAG.SCROLLABLE)
         self.label = lv.label(self.group)
+        #self.label.set_style_text_font(lv.font_tulip_11)
         self.label.set_text(name)
         self.list = lv.list(self.group)
+        #self.list.set_style_text_font(lv.font_tulip_11)
         self.list.set_size(width-25,height-20)
         self.list.align_to(self.label,lv.ALIGN.OUT_BOTTOM_LEFT,0,5)
         self.buttons = []
@@ -318,6 +320,7 @@ def run(screen):
     app.quit_callback = quit
     app.activate_callback = activate
     app.deactivate_callback = deactivate
+    app.group.set_style_text_font(lv.font_tulip_11,0)
 
     # Skip 10, drums
     app.channels = ListColumn('channel',["1","2","3","4","5","6","7","8","9","11","12","13","14","15","16"], selected=0, width=100)

--- a/tulip/shared/py/worldui.py
+++ b/tulip/shared/py/worldui.py
@@ -91,7 +91,7 @@ class TextEntry(tulip.UIElement):
         self.ta = lv.textarea(self.group)
         self.group.set_size(H_RES-40,h)
         self.ta.set_size(H_RES-80, h)
-        self.ta.set_style_text_font(lv.font_montserrat_18, 0)
+        self.ta.set_style_text_font(lv.font_tulip_13, 0)
         self.ta.set_style_bg_color(tulip.pal_to_lv(bgcolor), lv.PART.MAIN)
         self.ta.set_style_text_color(tulip.pal_to_lv(255),0)
         self.ta.set_style_border_color(tulip.pal_to_lv(255), lv.PART.CURSOR | lv.STATE.FOCUSED)
@@ -113,7 +113,7 @@ class TextSection(tulip.UIElement):
         self.ta.set_style_border_color(tulip.pal_to_lv(0), lv.PART.CURSOR | lv.STATE.FOCUSED)
 
         self.label = lv.label(self.group)
-        self.label.set_style_text_font(lv.font_montserrat_18, 0)
+        self.label.set_style_text_font(lv.font_tulip_13, 0)
         self.label.set_text(name)
         self.label.set_style_text_color(tulip.pal_to_lv(255),0)
         self.label.align_to(self.ta, lv.ALIGN.OUT_TOP_LEFT, 0, 0)

--- a/tulip/shared/u8g2_fonts.c
+++ b/tulip/shared/u8g2_fonts.c
@@ -294,6 +294,8 @@ void drawPixel_target(int16_t x, int16_t y, uint8_t *target, uint16_t target_wid
   uint16_t new_y = y + target_height;
   if(new_y < target_height && x < target_width) {
     target[x + new_y*target_width] = 0xff;
+  } else {
+    //fprintf(stderr, "bad %d %d %d [%d %d]\n", x,y,new_y, target_width, target_height);
   }
 }
 
@@ -510,16 +512,10 @@ static void u8g2_font_decode_len_target(u8g2_font_t *u8g2, uint8_t len, uint8_t 
     if ( cnt < rem )
       current = cnt;
     
-    
-    /* now draw the line, but apply the rotation around the glyph target position */
-    //u8g2_font_decode_draw_pixel(u8g2, lx,ly,current, is_foreground);
 
     /* get target position */
-        /* get target position */
     x = decode->target_x;
-    //y = decode->target_y;
-    //x = decode->target_x+   u8g2->font_info.x_offset  ;
-    y = decode->target_y +   u8g2->font_info.y_offset  ;
+    y = decode->target_y+   u8g2->font_info.y_offset  ;
 
     /* apply rotation */
     x = u8g2_add_vector_x(x, lx, ly, decode->dir);
@@ -529,9 +525,9 @@ static void u8g2_font_decode_len_target(u8g2_font_t *u8g2, uint8_t len, uint8_t 
       {
         if ( is_foreground )
           {
-            // These are swapped??! 
-            uint16_t target_width = u8g2->font_info.max_char_height; 
-            uint16_t target_height =u8g2->font_info.max_char_width; 
+            //fprintf(stderr, "mcw %d mch %d \n", u8g2->font_info.max_char_width, u8g2->font_info.max_char_height);
+            uint16_t target_width = u8g2->font_info.max_char_width; 
+            uint16_t target_height =u8g2->font_info.max_char_height; 
             u8g2_draw_hv_line_target(u8g2, x, y, current, decode->dir, target, target_width, target_height);
           }
       }    

--- a/tulip/shared/u8g2_fonts.c
+++ b/tulip/shared/u8g2_fonts.c
@@ -292,7 +292,9 @@ static int16_t u8g2_add_vector_x(int16_t dx, int8_t x, int8_t y, uint8_t dir)
 
 void drawPixel_target(int16_t x, int16_t y, uint8_t *target, uint16_t target_width, uint16_t target_height) {
   uint16_t new_y = y + target_height;
-  target[x + new_y*target_width] = 0xff;
+  if(new_y < target_height && x < target_width) {
+    target[x + new_y*target_width] = 0xff;
+  }
 }
 
 void drawLine_target(short x0, short y0,short x1, short y1, uint8_t *target, uint16_t target_width, uint16_t target_height) {
@@ -323,10 +325,8 @@ void drawLine_target(short x0, short y0,short x1, short y1, uint8_t *target, uin
   for (; x0<=x1; x0++) {
     if (steep) { // swap x and y. 
         drawPixel_target(y0, x0, target, target_width, target_height);
-        //target[y0 + 1 + (((target_height/2)+x0)*target_width)] = 0xff;
     } else {
         drawPixel_target(x0, y0, target, target_width, target_height);
-        //target[x0 + 1 + (((target_height/2)+y0)*target_width)] = 0xff;
     }
     err -= dy;
     if (err < 0) {


### PR DESCRIPTION
This fixes #203 (finally!)
This lets you use Tulip bitmap fonts in LVGL. We've updated the API docs. See `voices.py` to see how we use it. 
