### PR TITLE
Tulip side AMY instruments & MIDI

### DIFF
--- a/docs/tulip_flashing.md
+++ b/docs/tulip_flashing.md
@@ -61,7 +61,7 @@ Linux:
 sudo apt install cmake ninja-build dfu-util virtualenv
 ```
 
-For both macOS & Linux, next, download the supported version of ESP-IDF. That is currently a pre-release of 5.4. You need to get this with `git`, so install that if you don't already have it. Once Espressif updates the release, we can provide a direct download link that's a bit easier. 
+For both macOS & Linux, next, download the supported version of ESP-IDF. That is release 5.4.1. You need to get this with `git`, so install that if you don't already have it. Once Espressif updates the release, we can provide a direct download link that's a bit easier. 
 
 I like to keep them in `~/esp/`, as you'll likely want to use different versions eventually. So we'll assume it's in `~/esp/esp-idf`.
 
@@ -73,7 +73,7 @@ mkdir esp
 cd esp
 git clone https://github.com/espressif/esp-idf.git
 cd esp-idf
-git checkout 70f222e5d29df8ffe5da25057601708c8097bcd1
+git checkout 5.4.1
 git submodule update --init --recursive
 ./install.sh esp32s3
 source export.sh

--- a/tulip/esp32s3/esp32_common.cmake
+++ b/tulip/esp32s3/esp32_common.cmake
@@ -179,15 +179,14 @@ list(APPEND MICROPY_SOURCE_EXTMOD
     ${TULIP_SHARED_DIR}/editor.c
     ${TULIP_SHARED_DIR}/keyscan.c
     ${TULIP_SHARED_DIR}/help.c
-    ${TULIP_SHARED_DIR}/alles.c
     ${TULIP_SHARED_DIR}/ui.c
-    ${TULIP_SHARED_DIR}/midi.c
     ${TULIP_SHARED_DIR}/sounds.c
     ${TULIP_SHARED_DIR}/tsequencer.c
     ${TULIP_SHARED_DIR}/lodepng.c
     ${TULIP_SHARED_DIR}/lvgl_u8g2.c
     ${TULIP_SHARED_DIR}/u8fontdata.c
     ${TULIP_SHARED_DIR}/u8g2_fonts.c
+    ${TULIP_SHARED_DIR}/amy_connector.c
     ${AMY_DIR}/src/dsps_biquad_f32_ae32.S
     ${AMY_DIR}/src/algorithms.c
     ${AMY_DIR}/src/custom.c
@@ -198,12 +197,16 @@ list(APPEND MICROPY_SOURCE_EXTMOD
     ${AMY_DIR}/src/envelope.c
     ${AMY_DIR}/src/filters.c
     ${AMY_DIR}/src/oscillators.c
+    ${AMY_DIR}/src/midi.c
     ${AMY_DIR}/src/transfer.c
     ${AMY_DIR}/src/sequencer.c
     ${AMY_DIR}/src/partials.c
     ${AMY_DIR}/src/pcm.c
+    ${AMY_DIR}/src/i2s.c
     ${AMY_DIR}/src/log2_exp2.c
     ${AMY_DIR}/src/interp_partials.c
+    ${AMY_DIR}/src/parse.c
+    ${AMY_DIR}/src/instrument.c
     ${ULAB_DIR}/scipy/integrate/integrate.c
     ${ULAB_DIR}/scipy/linalg/linalg.c
     ${ULAB_DIR}/scipy/optimize/optimize.c

--- a/tulip/esp32s3/esp32_common.cmake
+++ b/tulip/esp32s3/esp32_common.cmake
@@ -131,6 +131,7 @@ list(APPEND MICROPY_SOURCE_PORT
     ${MICROPY_PORT_DIR}/help.c
     ${MICROPY_PORT_DIR}/build/lv_mpy.c
     ${MICROPY_PORT_DIR}/network_common.c
+    ${MICROPY_PORT_DIR}/network_wlan.c
     ${MICROPY_PORT_DIR}/esp_lcd_touch.c
     ${MICROPY_PORT_DIR}/modsocket.c
     ${MICROPY_PORT_DIR}/mphalport.c
@@ -150,7 +151,6 @@ list(APPEND MICROPY_SOURCE_PORT
     ${MICROPY_ESP32_DIR}/machine_dac.c
     ${MICROPY_ESP32_DIR}/machine_i2c.c
     ${MICROPY_ESP32_DIR}/network_lan.c
-    ${MICROPY_ESP32_DIR}/network_wlan.c
     ${MICROPY_ESP32_DIR}/modesp.c
     ${MICROPY_ESP32_DIR}/esp32_nvs.c
     ${MICROPY_ESP32_DIR}/esp32_partition.c

--- a/tulip/esp32s3/main.c
+++ b/tulip/esp32s3/main.c
@@ -232,10 +232,10 @@ void mp_task(void *pvParameter) {
     
     machine_init();
 
-    //esp_err_t err = esp_event_loop_create_default();
-    //if (err != ESP_OK) {
-    //    ESP_LOGE("esp_init", "can't create event loop: 0x%x\n", err);
-    //}
+    esp_err_t err = esp_event_loop_create_default();
+    if (err != ESP_OK) {
+        ESP_LOGE("esp_init", "can't create event loop: 0x%x\n", err);
+    }
 
     heap_caps_register_failed_alloc_callback(esp_alloc_failed);
     uint32_t caps = MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM;

--- a/tulip/esp32s3/main.c
+++ b/tulip/esp32s3/main.c
@@ -368,27 +368,7 @@ StaticTask_t static_mp_handle;
 TaskHandle_t amy_handle;
 
 
-void run_amy() {
-    //uint64_t initial_sp = 0;
-    amy_config_t amy_config = amy_default_config();
-    amy_config.has_audio_in = 0;
-    amy_config.has_midi_uart = 1;
-    amy_config.set_default_synth = 1;
-    amy_config.cores = 2;
-    amy_config.i2s_lrc = CONFIG_I2S_LRCLK;
-    amy_config.i2s_bclk = CONFIG_I2S_BCLK;
-    amy_config.i2s_dout = CONFIG_I2S_DIN; // badly named
-    amy_config.midi_out = MIDI_OUT_PIN;
-    amy_config.midi_in = MIDI_IN_PIN;
-    amy_start(amy_config);
-    amy_live_start();
-    //uint32_t c = 0;
-    while(1) {
-        vTaskDelay(10);
-        //if(c++ % 500 == 0) fprintf(stderr, "stack size for %s [%d] is actually %d\n",AMY_TASK_NAME,AMY_TASK_STACK_SIZE,(uint16_t)(initial_sp-get_stack_pointer() ));
-
-    }
-}
+extern void run_amy();
 
 void startup_amy() {
     //esp_err_t err = esp_event_loop_create_default();

--- a/tulip/esp32s3/mpconfigport.h
+++ b/tulip/esp32s3/mpconfigport.h
@@ -11,7 +11,10 @@
 #include "freertos/FreeRTOS.h"
 #include "driver/i2s_std.h"
 #include "esp_wifi_types.h"
-
+// Modifier for function which doesn't return
+#ifndef MP_NORETURN
+#define MP_NORETURN __attribute__((noreturn))
+#endif
 
 // This is Tulip specific stuff. Unfortunately we cannot override some of this in ports/esp32, 
 // so we have to copy it over there as a build step.

--- a/tulip/esp32s3/network_common.c
+++ b/tulip/esp32s3/network_common.c
@@ -45,7 +45,7 @@
 #include "lwip/sockets.h"
 #include "lwip/dns.h"
 
-NORETURN void esp_exceptions_helper(esp_err_t e) {
+MP_NORETURN void esp_exceptions_helper(esp_err_t e) {
     switch (e) {
         case ESP_ERR_WIFI_NOT_INIT:
             mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Wifi Not Initialized"));
@@ -77,6 +77,8 @@ NORETURN void esp_exceptions_helper(esp_err_t e) {
             mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Wifi Would Block"));
         case ESP_ERR_WIFI_NOT_CONNECT:
             mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Wifi Not Connected"));
+        case ESP_ERR_NO_MEM:
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("WiFi Out of Memory"));
         default:
             mp_raise_msg_varg(&mp_type_RuntimeError, MP_ERROR_TEXT("Wifi Unknown Error 0x%04x"), e);
     }
@@ -337,11 +339,3 @@ static mp_obj_t esp_phy_mode(size_t n_args, const mp_obj_t *args) {
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(esp_network_phy_mode_obj, 0, 1, esp_phy_mode);
-
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
-_Static_assert(WIFI_AUTH_MAX == 14, "Synchronize WIFI_AUTH_XXX constants with the ESP-IDF. Look at esp-idf/components/esp_wifi/include/esp_wifi_types.h");
-#elif ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 5) && ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 1, 0) || ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 2)
-_Static_assert(WIFI_AUTH_MAX == 11, "Synchronize WIFI_AUTH_XXX constants with the ESP-IDF. Look at esp-idf/components/esp_wifi/include/esp_wifi_types.h");
-#else
-_Static_assert(WIFI_AUTH_MAX == 10, "Synchronize WIFI_AUTH_XXX constants with the ESP-IDF. Look at esp-idf/components/esp_wifi/include/esp_wifi_types.h");
-#endif

--- a/tulip/esp32s3/network_wlan.c
+++ b/tulip/esp32s3/network_wlan.c
@@ -247,7 +247,6 @@ void esp_initialise_wifi(void) {
 
 static mp_obj_t network_wlan_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 0, 1, false);
-
     esp_initialise_wifi();
 
     int idx = (n_args > 0) ? mp_obj_get_int(args[0]) : ESP_IF_WIFI_STA;

--- a/tulip/esp32s3/network_wlan.c
+++ b/tulip/esp32s3/network_wlan.c
@@ -1,0 +1,795 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * Development of the code in this file was sponsored by Microbric Pty Ltd
+ * and Mnemote Pty Ltd
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016, 2017 Nick Moore @mnemote
+ * Copyright (c) 2017 "Eric Poulsen" <eric@zyxod.com>
+ *
+ * Based on esp8266/modnetwork.c which is Copyright (c) 2015 Paul Sokolovsky
+ * And the ESP IDF example code which is Public Domain / CC0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <string.h>
+
+#include "py/objlist.h"
+#include "py/runtime.h"
+#include "py/mphal.h"
+#include "extmod/modnetwork.h"
+#include "modnetwork.h"
+
+#include "esp_wifi.h"
+#include "esp_log.h"
+#include "esp_psram.h"
+
+#ifndef NO_QSTR
+#include "mdns.h"
+#endif
+
+#if MICROPY_PY_NETWORK_WLAN
+
+#if (WIFI_MODE_STA & WIFI_MODE_AP != WIFI_MODE_NULL || WIFI_MODE_STA | WIFI_MODE_AP != WIFI_MODE_APSTA)
+#error WIFI_MODE_STA and WIFI_MODE_AP are supposed to be bitfields!
+#endif
+
+typedef base_if_obj_t wlan_if_obj_t;
+
+static wlan_if_obj_t wlan_sta_obj;
+static wlan_if_obj_t wlan_ap_obj;
+
+// Set to "true" if esp_wifi_start() was called
+static bool wifi_started = false;
+
+// Set to "true" if the STA interface is requested to be connected by the
+// user, used for automatic reassociation.
+static bool wifi_sta_connect_requested = false;
+
+// Set to "true" if the STA interface is connected to wifi and has IP address.
+static bool wifi_sta_connected = false;
+
+// Store the current status. 0 means None here, safe to do so as first enum value is WIFI_REASON_UNSPECIFIED=1.
+static uint8_t wifi_sta_disconn_reason = 0;
+
+#if MICROPY_HW_ENABLE_MDNS_QUERIES || MICROPY_HW_ENABLE_MDNS_RESPONDER
+// Whether mDNS has been initialised or not
+static bool mdns_initialised = false;
+#endif
+
+static uint8_t conf_wifi_sta_reconnects = 0;
+static uint8_t wifi_sta_reconnects;
+
+// This function is called by the system-event task and so runs in a different
+// thread to the main MicroPython task.  It must not raise any Python exceptions.
+static void network_wlan_wifi_event_handler(void *event_handler_arg, esp_event_base_t event_base, int32_t event_id, void *event_data) {
+    switch (event_id) {
+        case WIFI_EVENT_STA_START:
+            ESP_LOGI("wifi", "STA_START");
+            wlan_sta_obj.active = true;
+            wifi_sta_reconnects = 0;
+            break;
+
+        case WIFI_EVENT_STA_STOP:
+            wlan_sta_obj.active = false;
+            break;
+
+        case WIFI_EVENT_STA_CONNECTED:
+            ESP_LOGI("network", "CONNECTED");
+            break;
+
+        case WIFI_EVENT_STA_DISCONNECTED: {
+            // This is a workaround as ESP32 WiFi libs don't currently
+            // auto-reassociate.
+
+            wifi_event_sta_disconnected_t *disconn = event_data;
+            char *message = "";
+            wifi_sta_disconn_reason = disconn->reason;
+            switch (disconn->reason) {
+                case WIFI_REASON_BEACON_TIMEOUT:
+                    // AP has dropped out; try to reconnect.
+                    message = "beacon timeout";
+                    break;
+                case WIFI_REASON_NO_AP_FOUND:
+                    // AP may not exist, or it may have momentarily dropped out; try to reconnect.
+                    message = "no AP found";
+                    break;
+                case WIFI_REASON_NO_AP_FOUND_IN_RSSI_THRESHOLD:
+                    // No AP with RSSI within given threshold exists, or it may have momentarily dropped out; try to reconnect.
+                    message = "no AP with RSSI within threshold found";
+                    break;
+                case WIFI_REASON_NO_AP_FOUND_IN_AUTHMODE_THRESHOLD:
+                    // No AP with authmode within given threshold exists, or it may have momentarily dropped out; try to reconnect.
+                    message = "no AP with authmode within threshold found";
+                    break;
+                case WIFI_REASON_NO_AP_FOUND_W_COMPATIBLE_SECURITY:
+                    // No AP with compatible security exists, or it may have momentarily dropped out; try to reconnect.
+                    message = "no AP with compatible security found";
+                    break;
+                case WIFI_REASON_AUTH_FAIL:
+                    // Password may be wrong, or it just failed to connect; try to reconnect.
+                    message = "authentication failed";
+                    break;
+                default:
+                    // Let other errors through and try to reconnect.
+                    break;
+            }
+            ESP_LOGI("wifi", "STA_DISCONNECTED, reason:%d:%s", disconn->reason, message);
+
+            wifi_sta_connected = false;
+            if (wifi_sta_connect_requested) {
+                wifi_mode_t mode;
+                if (esp_wifi_get_mode(&mode) != ESP_OK) {
+                    break;
+                }
+                if (!(mode & WIFI_MODE_STA)) {
+                    break;
+                }
+                if (conf_wifi_sta_reconnects) {
+                    ESP_LOGI("wifi", "reconnect counter=%d, max=%d",
+                        wifi_sta_reconnects, conf_wifi_sta_reconnects);
+                    if (++wifi_sta_reconnects >= conf_wifi_sta_reconnects) {
+                        break;
+                    }
+                }
+                esp_err_t e = esp_wifi_connect();
+                if (e != ESP_OK) {
+                    ESP_LOGI("wifi", "error attempting to reconnect: 0x%04x", e);
+                }
+            }
+            break;
+        }
+
+        case WIFI_EVENT_AP_START:
+            wlan_ap_obj.active = true;
+            break;
+
+        case WIFI_EVENT_AP_STOP:
+            wlan_ap_obj.active = false;
+            break;
+
+        default:
+            break;
+    }
+}
+
+static void network_wlan_ip_event_handler(void *event_handler_arg, esp_event_base_t event_base, int32_t event_id, void *event_data) {
+    switch (event_id) {
+        case IP_EVENT_STA_GOT_IP:
+            ESP_LOGI("network", "GOT_IP");
+            wifi_sta_connected = true;
+            wifi_sta_disconn_reason = 0; // Success so clear error. (in case of new error will be replaced anyway)
+            #if MICROPY_HW_ENABLE_MDNS_QUERIES || MICROPY_HW_ENABLE_MDNS_RESPONDER
+            if (!mdns_initialised) {
+                mdns_init();
+                #if MICROPY_HW_ENABLE_MDNS_RESPONDER
+                mdns_hostname_set(mod_network_hostname_data);
+                mdns_instance_name_set(mod_network_hostname_data);
+                #endif
+                mdns_initialised = true;
+            }
+            #endif
+            break;
+
+        default:
+            break;
+    }
+}
+
+static void require_if(mp_obj_t wlan_if, int if_no) {
+    wlan_if_obj_t *self = MP_OBJ_TO_PTR(wlan_if);
+    if (self->if_id != if_no) {
+        mp_raise_msg(&mp_type_OSError, if_no == ESP_IF_WIFI_STA ? MP_ERROR_TEXT("STA required") : MP_ERROR_TEXT("AP required"));
+    }
+}
+
+void esp_initialise_wifi(void) {
+    static int wifi_initialized = 0;
+    if (!wifi_initialized) {
+        esp_exceptions(esp_event_handler_instance_register(WIFI_EVENT, ESP_EVENT_ANY_ID, network_wlan_wifi_event_handler, NULL, NULL));
+        esp_exceptions(esp_event_handler_instance_register(IP_EVENT, ESP_EVENT_ANY_ID, network_wlan_ip_event_handler, NULL, NULL));
+
+        wlan_sta_obj.base.type = &esp_network_wlan_type;
+        wlan_sta_obj.if_id = ESP_IF_WIFI_STA;
+        wlan_sta_obj.netif = esp_netif_create_default_wifi_sta();
+        wlan_sta_obj.active = false;
+
+        wlan_ap_obj.base.type = &esp_network_wlan_type;
+        wlan_ap_obj.if_id = ESP_IF_WIFI_AP;
+        wlan_ap_obj.netif = esp_netif_create_default_wifi_ap();
+        wlan_ap_obj.active = false;
+
+        wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+        #if CONFIG_SPIRAM_IGNORE_NOTFOUND
+        if (!esp_psram_is_initialized()) {
+            // If PSRAM failed to initialize, disable "Wi-Fi Cache TX Buffers"
+            // (default SPIRAM config ESP32_WIFI_CACHE_TX_BUFFER_NUM==32, this is 54,400 bytes of heap)
+            cfg.cache_tx_buf_num = 0;
+            cfg.feature_caps &= ~CONFIG_FEATURE_CACHE_TX_BUF_BIT;
+
+            // Set some other options back to the non-SPIRAM default values
+            // to save more RAM.
+            //
+            // These can be determined from ESP-IDF components/esp_wifi/Kconfig and the
+            // WIFI_INIT_CONFIG_DEFAULT macro
+            cfg.tx_buf_type = 1; // Dynamic, this "magic number" is defined in IDF KConfig
+            cfg.static_tx_buf_num = 0; // Probably don't need, due to tx_buf_type
+            cfg.dynamic_tx_buf_num = 32; // ESP-IDF default value (maximum)
+        }
+        #endif
+        ESP_LOGD("modnetwork", "Initializing WiFi");
+        esp_exceptions(esp_wifi_init(&cfg));
+        esp_exceptions(esp_wifi_set_storage(WIFI_STORAGE_RAM));
+
+        ESP_LOGD("modnetwork", "Initialized");
+        wifi_initialized = 1;
+    }
+}
+
+static mp_obj_t network_wlan_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 0, 1, false);
+
+    esp_initialise_wifi();
+
+    int idx = (n_args > 0) ? mp_obj_get_int(args[0]) : ESP_IF_WIFI_STA;
+    if (idx == ESP_IF_WIFI_STA) {
+        return MP_OBJ_FROM_PTR(&wlan_sta_obj);
+    } else if (idx == ESP_IF_WIFI_AP) {
+        return MP_OBJ_FROM_PTR(&wlan_ap_obj);
+    } else {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid WLAN interface identifier"));
+    }
+}
+
+static mp_obj_t network_wlan_active(size_t n_args, const mp_obj_t *args) {
+    wlan_if_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+
+    wifi_mode_t mode;
+    if (!wifi_started) {
+        mode = WIFI_MODE_NULL;
+    } else {
+        esp_exceptions(esp_wifi_get_mode(&mode));
+    }
+
+    int bit = (self->if_id == ESP_IF_WIFI_STA) ? WIFI_MODE_STA : WIFI_MODE_AP;
+
+    if (n_args > 1) {
+        bool active = mp_obj_is_true(args[1]);
+        mode = active ? (mode | bit) : (mode & ~bit);
+        if (mode == WIFI_MODE_NULL) {
+            if (wifi_started) {
+                esp_exceptions(esp_wifi_stop());
+                wifi_started = false;
+            }
+        } else {
+            esp_exceptions(esp_wifi_set_mode(mode));
+            if (!wifi_started) {
+                esp_exceptions(esp_wifi_start());
+                wifi_started = true;
+            }
+        }
+
+        // Wait for the interface to be in the correct state.
+        while (self->active != active) {
+            MICROPY_EVENT_POLL_HOOK;
+        }
+    }
+
+    return (mode & bit) ? mp_const_true : mp_const_false;
+}
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(network_wlan_active_obj, 1, 2, network_wlan_active);
+
+static mp_obj_t network_wlan_connect(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_ssid, ARG_key, ARG_bssid };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_, MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        { MP_QSTR_, MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        { MP_QSTR_bssid, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+    };
+
+    // parse args
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    wifi_config_t wifi_sta_config = {0};
+
+    // configure any parameters that are given
+    if (n_args > 1) {
+        size_t len;
+        const char *p;
+        if (args[ARG_ssid].u_obj != mp_const_none) {
+            p = mp_obj_str_get_data(args[ARG_ssid].u_obj, &len);
+            memcpy(wifi_sta_config.sta.ssid, p, MIN(len, sizeof(wifi_sta_config.sta.ssid)));
+        }
+        if (args[ARG_key].u_obj != mp_const_none) {
+            p = mp_obj_str_get_data(args[ARG_key].u_obj, &len);
+            memcpy(wifi_sta_config.sta.password, p, MIN(len, sizeof(wifi_sta_config.sta.password)));
+        }
+        if (args[ARG_bssid].u_obj != mp_const_none) {
+            p = mp_obj_str_get_data(args[ARG_bssid].u_obj, &len);
+            if (len != sizeof(wifi_sta_config.sta.bssid)) {
+                mp_raise_ValueError(NULL);
+            }
+            wifi_sta_config.sta.bssid_set = 1;
+            memcpy(wifi_sta_config.sta.bssid, p, sizeof(wifi_sta_config.sta.bssid));
+        }
+        esp_exceptions(esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_sta_config));
+    }
+
+    esp_exceptions(esp_netif_set_hostname(wlan_sta_obj.netif, mod_network_hostname_data));
+
+    wifi_sta_reconnects = 0;
+    // connect to the WiFi AP
+    MP_THREAD_GIL_EXIT();
+    esp_exceptions(esp_wifi_connect());
+    MP_THREAD_GIL_ENTER();
+    wifi_sta_connect_requested = true;
+
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_KW(network_wlan_connect_obj, 1, network_wlan_connect);
+
+static mp_obj_t network_wlan_disconnect(mp_obj_t self_in) {
+    wifi_sta_connect_requested = false;
+    esp_exceptions(esp_wifi_disconnect());
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(network_wlan_disconnect_obj, network_wlan_disconnect);
+
+static mp_obj_t network_wlan_status(size_t n_args, const mp_obj_t *args) {
+    wlan_if_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+    if (n_args == 1) {
+        if (self->if_id == ESP_IF_WIFI_STA) {
+            // Case of no arg is only for the STA interface
+            if (wifi_sta_connected) {
+                // Happy path, connected with IP
+                return MP_OBJ_NEW_SMALL_INT(STAT_GOT_IP);
+            } else if (wifi_sta_disconn_reason == WIFI_REASON_NO_AP_FOUND) {
+                return MP_OBJ_NEW_SMALL_INT(WIFI_REASON_NO_AP_FOUND);
+            } else if (wifi_sta_disconn_reason == WIFI_REASON_NO_AP_FOUND_IN_RSSI_THRESHOLD) {
+                return MP_OBJ_NEW_SMALL_INT(WIFI_REASON_NO_AP_FOUND_IN_RSSI_THRESHOLD);
+            } else if (wifi_sta_disconn_reason == WIFI_REASON_NO_AP_FOUND_IN_AUTHMODE_THRESHOLD) {
+                return MP_OBJ_NEW_SMALL_INT(WIFI_REASON_NO_AP_FOUND_IN_AUTHMODE_THRESHOLD);
+            } else if (wifi_sta_disconn_reason == WIFI_REASON_NO_AP_FOUND_W_COMPATIBLE_SECURITY) {
+                return MP_OBJ_NEW_SMALL_INT(WIFI_REASON_NO_AP_FOUND_W_COMPATIBLE_SECURITY);
+            } else if ((wifi_sta_disconn_reason == WIFI_REASON_AUTH_FAIL) || (wifi_sta_disconn_reason == WIFI_REASON_CONNECTION_FAIL)) {
+                // wrong password
+                return MP_OBJ_NEW_SMALL_INT(WIFI_REASON_AUTH_FAIL);
+            } else if (wifi_sta_disconn_reason == WIFI_REASON_ASSOC_LEAVE) {
+                // After wlan.disconnect()
+                return MP_OBJ_NEW_SMALL_INT(STAT_IDLE);
+            } else if (wifi_sta_connect_requested
+                       && (conf_wifi_sta_reconnects == 0
+                           || wifi_sta_reconnects < conf_wifi_sta_reconnects)) {
+                // No connection or error, but is requested = Still connecting
+                return MP_OBJ_NEW_SMALL_INT(STAT_CONNECTING);
+            } else if (wifi_sta_disconn_reason == 0) {
+                // No activity, No error = Idle
+                return MP_OBJ_NEW_SMALL_INT(STAT_IDLE);
+            } else {
+                // Simply pass the error through from ESP-identifier
+                return MP_OBJ_NEW_SMALL_INT(wifi_sta_disconn_reason);
+            }
+        }
+        return mp_const_none;
+    }
+
+    // one argument: return status based on query parameter
+    switch ((uintptr_t)args[1]) {
+        case (uintptr_t)MP_OBJ_NEW_QSTR(MP_QSTR_stations): {
+            // return list of connected stations, only if in soft-AP mode
+            require_if(args[0], ESP_IF_WIFI_AP);
+            wifi_sta_list_t station_list;
+            esp_exceptions(esp_wifi_ap_get_sta_list(&station_list));
+            wifi_sta_info_t *stations = (wifi_sta_info_t *)station_list.sta;
+            mp_obj_t list = mp_obj_new_list(0, NULL);
+            for (int i = 0; i < station_list.num; ++i) {
+                mp_obj_tuple_t *t = mp_obj_new_tuple(1, NULL);
+                t->items[0] = mp_obj_new_bytes(stations[i].mac, sizeof(stations[i].mac));
+                mp_obj_list_append(list, t);
+            }
+            return list;
+        }
+        case (uintptr_t)MP_OBJ_NEW_QSTR(MP_QSTR_rssi): {
+            // return signal of AP, only in STA mode
+            require_if(args[0], ESP_IF_WIFI_STA);
+
+            wifi_ap_record_t info;
+            esp_exceptions(esp_wifi_sta_get_ap_info(&info));
+            return MP_OBJ_NEW_SMALL_INT(info.rssi);
+        }
+        default:
+            mp_raise_ValueError(MP_ERROR_TEXT("unknown status param"));
+    }
+
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(network_wlan_status_obj, 1, 2, network_wlan_status);
+
+static mp_obj_t network_wlan_scan(mp_obj_t self_in) {
+    // check that STA mode is active
+    wifi_mode_t mode;
+    esp_exceptions(esp_wifi_get_mode(&mode));
+    if ((mode & WIFI_MODE_STA) == 0) {
+        mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("STA must be active"));
+    }
+
+    mp_obj_t list = mp_obj_new_list(0, NULL);
+    wifi_scan_config_t config = { 0 };
+    config.show_hidden = true;
+    MP_THREAD_GIL_EXIT();
+    esp_err_t status = esp_wifi_scan_start(&config, 1);
+    MP_THREAD_GIL_ENTER();
+    if (status == 0) {
+        uint16_t count = 0;
+        esp_exceptions(esp_wifi_scan_get_ap_num(&count));
+        if (count == 0) {
+            // esp_wifi_scan_get_ap_records must be called to free internal buffers from the scan.
+            // But it returns an error if wifi_ap_records==NULL.  So allocate at least 1 AP entry.
+            // esp_wifi_scan_get_ap_records will then return the actual number of APs in count.
+            count = 1;
+        }
+        wifi_ap_record_t *wifi_ap_records = calloc(count, sizeof(wifi_ap_record_t));
+        esp_exceptions(esp_wifi_scan_get_ap_records(&count, wifi_ap_records));
+        for (uint16_t i = 0; i < count; i++) {
+            mp_obj_tuple_t *t = mp_obj_new_tuple(6, NULL);
+            uint8_t *x = memchr(wifi_ap_records[i].ssid, 0, sizeof(wifi_ap_records[i].ssid));
+            int ssid_len = x ? x - wifi_ap_records[i].ssid : sizeof(wifi_ap_records[i].ssid);
+            t->items[0] = mp_obj_new_bytes(wifi_ap_records[i].ssid, ssid_len);
+            t->items[1] = mp_obj_new_bytes(wifi_ap_records[i].bssid, sizeof(wifi_ap_records[i].bssid));
+            t->items[2] = MP_OBJ_NEW_SMALL_INT(wifi_ap_records[i].primary);
+            t->items[3] = MP_OBJ_NEW_SMALL_INT(wifi_ap_records[i].rssi);
+            t->items[4] = MP_OBJ_NEW_SMALL_INT(wifi_ap_records[i].authmode);
+            t->items[5] = mp_const_false; // XXX hidden?
+            mp_obj_list_append(list, MP_OBJ_FROM_PTR(t));
+        }
+        free(wifi_ap_records);
+    }
+    return list;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(network_wlan_scan_obj, network_wlan_scan);
+
+static mp_obj_t network_wlan_isconnected(mp_obj_t self_in) {
+    wlan_if_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    if (self->if_id == ESP_IF_WIFI_STA) {
+        return mp_obj_new_bool(wifi_sta_connected);
+    } else {
+        wifi_sta_list_t sta;
+        esp_wifi_ap_get_sta_list(&sta);
+        return mp_obj_new_bool(sta.num != 0);
+    }
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(network_wlan_isconnected_obj, network_wlan_isconnected);
+
+static mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
+    if (n_args != 1 && kwargs->used != 0) {
+        mp_raise_TypeError(MP_ERROR_TEXT("either pos or kw args are allowed"));
+    }
+
+    wlan_if_obj_t *self = MP_OBJ_TO_PTR(args[0]);
+
+    bool is_wifi = self->if_id == ESP_IF_WIFI_AP || self->if_id == ESP_IF_WIFI_STA;
+
+    wifi_config_t cfg;
+    if (is_wifi) {
+        esp_exceptions(esp_wifi_get_config(self->if_id, &cfg));
+    }
+
+    if (kwargs->used != 0) {
+        if (!is_wifi) {
+            goto unknown;
+        }
+
+        for (size_t i = 0; i < kwargs->alloc; i++) {
+            if (mp_map_slot_is_filled(kwargs, i)) {
+                int req_if = -1;
+
+                switch (mp_obj_str_get_qstr(kwargs->table[i].key)) {
+                    case MP_QSTR_mac: {
+                        mp_buffer_info_t bufinfo;
+                        mp_get_buffer_raise(kwargs->table[i].value, &bufinfo, MP_BUFFER_READ);
+                        if (bufinfo.len != 6) {
+                            mp_raise_ValueError(MP_ERROR_TEXT("invalid buffer length"));
+                        }
+                        esp_exceptions(esp_wifi_set_mac(self->if_id, bufinfo.buf));
+                        break;
+                    }
+                    case MP_QSTR_ssid:
+                    case MP_QSTR_essid: {
+                        req_if = ESP_IF_WIFI_AP;
+                        size_t len;
+                        const char *s = mp_obj_str_get_data(kwargs->table[i].value, &len);
+                        len = MIN(len, sizeof(cfg.ap.ssid));
+                        memcpy(cfg.ap.ssid, s, len);
+                        cfg.ap.ssid_len = len;
+                        break;
+                    }
+                    case MP_QSTR_hidden: {
+                        req_if = ESP_IF_WIFI_AP;
+                        cfg.ap.ssid_hidden = mp_obj_is_true(kwargs->table[i].value);
+                        break;
+                    }
+                    case MP_QSTR_security:
+                    case MP_QSTR_authmode: {
+                        req_if = ESP_IF_WIFI_AP;
+                        cfg.ap.authmode = mp_obj_get_int(kwargs->table[i].value);
+                        break;
+                    }
+                    case MP_QSTR_key:
+                    case MP_QSTR_password: {
+                        req_if = ESP_IF_WIFI_AP;
+                        size_t len;
+                        const char *s = mp_obj_str_get_data(kwargs->table[i].value, &len);
+                        len = MIN(len, sizeof(cfg.ap.password) - 1);
+                        memcpy(cfg.ap.password, s, len);
+                        cfg.ap.password[len] = 0;
+                        break;
+                    }
+                    case MP_QSTR_channel: {
+                        uint8_t channel = mp_obj_get_int(kwargs->table[i].value);
+                        if (self->if_id == ESP_IF_WIFI_AP) {
+                            cfg.ap.channel = channel;
+                        } else {
+                            // This setting is only used to determine the
+                            // starting channel for a scan, so it can result in
+                            // slightly faster connection times.
+                            cfg.sta.channel = channel;
+
+                            // This additional code to directly set the channel
+                            // on the STA interface is only relevant for ESP-NOW
+                            // (when there is no STA connection attempt.)
+                            uint8_t old_primary;
+                            wifi_second_chan_t secondary;
+                            // Get the current value of secondary
+                            esp_exceptions(esp_wifi_get_channel(&old_primary, &secondary));
+                            esp_err_t err = esp_wifi_set_channel(channel, secondary);
+                            if (err == ESP_ERR_INVALID_ARG) {
+                                // May need to swap secondary channel above to below or below to above
+                                secondary = (
+                                    (secondary == WIFI_SECOND_CHAN_ABOVE)
+                                    ? WIFI_SECOND_CHAN_BELOW
+                                    : (secondary == WIFI_SECOND_CHAN_BELOW)
+                                    ? WIFI_SECOND_CHAN_ABOVE
+                                    : WIFI_SECOND_CHAN_NONE);
+                                err = esp_wifi_set_channel(channel, secondary);
+                            }
+                            esp_exceptions(err);
+                            if (channel != old_primary) {
+                                // Workaround the ESP-IDF Wi-Fi stack sometimes taking a moment to change channels
+                                mp_hal_delay_ms(1);
+                            }
+                        }
+                        break;
+                    }
+                    case MP_QSTR_hostname:
+                    case MP_QSTR_dhcp_hostname: {
+                        // TODO: Deprecated. Use network.hostname(name) instead.
+                        mod_network_hostname(1, &kwargs->table[i].value);
+                        break;
+                    }
+                    case MP_QSTR_max_clients: {
+                        req_if = ESP_IF_WIFI_AP;
+                        cfg.ap.max_connection = mp_obj_get_int(kwargs->table[i].value);
+                        break;
+                    }
+                    case MP_QSTR_reconnects: {
+                        int reconnects = mp_obj_get_int(kwargs->table[i].value);
+                        req_if = ESP_IF_WIFI_STA;
+                        // parameter reconnects == -1 means to retry forever.
+                        // here means conf_wifi_sta_reconnects == 0 to retry forever.
+                        conf_wifi_sta_reconnects = (reconnects == -1) ? 0 : reconnects + 1;
+                        break;
+                    }
+                    case MP_QSTR_txpower: {
+                        int8_t power = (mp_obj_get_float(kwargs->table[i].value) * 4);
+                        esp_exceptions(esp_wifi_set_max_tx_power(power));
+                        break;
+                    }
+                    case MP_QSTR_protocol: {
+                        esp_exceptions(esp_wifi_set_protocol(self->if_id, mp_obj_get_int(kwargs->table[i].value)));
+                        break;
+                    }
+                    case MP_QSTR_pm: {
+                        esp_exceptions(esp_wifi_set_ps(mp_obj_get_int(kwargs->table[i].value)));
+                        break;
+                    }
+                    default:
+                        goto unknown;
+                }
+
+                // We post-check interface requirements to save on code size
+                if (req_if >= 0) {
+                    require_if(args[0], req_if);
+                }
+            }
+        }
+
+        esp_exceptions(esp_wifi_set_config(self->if_id, &cfg));
+
+        return mp_const_none;
+    }
+
+    // Get config
+
+    if (n_args != 2) {
+        mp_raise_TypeError(MP_ERROR_TEXT("can query only one param"));
+    }
+
+    int req_if = -1;
+    mp_obj_t val = mp_const_none;
+
+    switch (mp_obj_str_get_qstr(args[1])) {
+        case MP_QSTR_mac: {
+            uint8_t mac[6];
+            switch (self->if_id) {
+                case ESP_IF_WIFI_AP: // fallthrough intentional
+                case ESP_IF_WIFI_STA:
+                    esp_exceptions(esp_wifi_get_mac(self->if_id, mac));
+                    return mp_obj_new_bytes(mac, sizeof(mac));
+                default:
+                    goto unknown;
+            }
+        }
+        case MP_QSTR_ssid:
+        case MP_QSTR_essid:
+            switch (self->if_id) {
+                case ESP_IF_WIFI_STA:
+                    val = mp_obj_new_str_from_cstr((char *)cfg.sta.ssid);
+                    break;
+                case ESP_IF_WIFI_AP:
+                    val = mp_obj_new_str((char *)cfg.ap.ssid, cfg.ap.ssid_len);
+                    break;
+                default:
+                    req_if = ESP_IF_WIFI_AP;
+            }
+            break;
+        case MP_QSTR_hidden:
+            req_if = ESP_IF_WIFI_AP;
+            val = mp_obj_new_bool(cfg.ap.ssid_hidden);
+            break;
+        case MP_QSTR_security:
+        case MP_QSTR_authmode:
+            req_if = ESP_IF_WIFI_AP;
+            val = MP_OBJ_NEW_SMALL_INT(cfg.ap.authmode);
+            break;
+        case MP_QSTR_channel: {
+            uint8_t channel;
+            wifi_second_chan_t second;
+            esp_exceptions(esp_wifi_get_channel(&channel, &second));
+            val = MP_OBJ_NEW_SMALL_INT(channel);
+            break;
+        }
+        case MP_QSTR_ifname: {
+            val = esp_ifname(self->netif);
+            break;
+        }
+        case MP_QSTR_hostname:
+        case MP_QSTR_dhcp_hostname: {
+            // TODO: Deprecated. Use network.hostname() instead.
+            req_if = ESP_IF_WIFI_STA;
+            val = mod_network_hostname(0, NULL);
+            break;
+        }
+        case MP_QSTR_max_clients: {
+            val = MP_OBJ_NEW_SMALL_INT(cfg.ap.max_connection);
+            break;
+        }
+        case MP_QSTR_reconnects:
+            req_if = ESP_IF_WIFI_STA;
+            int rec = conf_wifi_sta_reconnects - 1;
+            val = MP_OBJ_NEW_SMALL_INT(rec);
+            break;
+        case MP_QSTR_txpower: {
+            int8_t power;
+            esp_exceptions(esp_wifi_get_max_tx_power(&power));
+            val = mp_obj_new_float(power * 0.25);
+            break;
+        }
+        case MP_QSTR_protocol: {
+            uint8_t protocol_bitmap;
+            esp_exceptions(esp_wifi_get_protocol(self->if_id, &protocol_bitmap));
+            val = MP_OBJ_NEW_SMALL_INT(protocol_bitmap);
+            break;
+        }
+        case MP_QSTR_pm: {
+            wifi_ps_type_t ps_type;
+            esp_exceptions(esp_wifi_get_ps(&ps_type));
+            val = MP_OBJ_NEW_SMALL_INT(ps_type);
+            break;
+        }
+        default:
+            goto unknown;
+    }
+
+    // We post-check interface requirements to save on code size
+    if (req_if >= 0) {
+        require_if(args[0], req_if);
+    }
+
+    return val;
+
+unknown:
+    mp_raise_ValueError(MP_ERROR_TEXT("unknown config param"));
+}
+MP_DEFINE_CONST_FUN_OBJ_KW(network_wlan_config_obj, 1, network_wlan_config);
+
+static const mp_rom_map_elem_t wlan_if_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_active), MP_ROM_PTR(&network_wlan_active_obj) },
+    { MP_ROM_QSTR(MP_QSTR_connect), MP_ROM_PTR(&network_wlan_connect_obj) },
+    { MP_ROM_QSTR(MP_QSTR_disconnect), MP_ROM_PTR(&network_wlan_disconnect_obj) },
+    { MP_ROM_QSTR(MP_QSTR_status), MP_ROM_PTR(&network_wlan_status_obj) },
+    { MP_ROM_QSTR(MP_QSTR_scan), MP_ROM_PTR(&network_wlan_scan_obj) },
+    { MP_ROM_QSTR(MP_QSTR_isconnected), MP_ROM_PTR(&network_wlan_isconnected_obj) },
+    { MP_ROM_QSTR(MP_QSTR_config), MP_ROM_PTR(&network_wlan_config_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ifconfig), MP_ROM_PTR(&esp_network_ifconfig_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ipconfig), MP_ROM_PTR(&esp_nic_ipconfig_obj) },
+
+    // Constants
+    { MP_ROM_QSTR(MP_QSTR_IF_STA), MP_ROM_INT(WIFI_IF_STA)},
+    { MP_ROM_QSTR(MP_QSTR_IF_AP), MP_ROM_INT(WIFI_IF_AP)},
+
+    { MP_ROM_QSTR(MP_QSTR_SEC_OPEN), MP_ROM_INT(WIFI_AUTH_OPEN) },
+    { MP_ROM_QSTR(MP_QSTR_SEC_WEP), MP_ROM_INT(WIFI_AUTH_WEP) },
+    { MP_ROM_QSTR(MP_QSTR_SEC_WPA), MP_ROM_INT(WIFI_AUTH_WPA_PSK) },
+    { MP_ROM_QSTR(MP_QSTR_SEC_WPA2), MP_ROM_INT(WIFI_AUTH_WPA2_PSK) },
+    { MP_ROM_QSTR(MP_QSTR_SEC_WPA_WPA2), MP_ROM_INT(WIFI_AUTH_WPA_WPA2_PSK) },
+    { MP_ROM_QSTR(MP_QSTR_SEC_WPA2_ENT), MP_ROM_INT(WIFI_AUTH_WPA2_ENTERPRISE) },
+    { MP_ROM_QSTR(MP_QSTR_SEC_WPA3), MP_ROM_INT(WIFI_AUTH_WPA3_PSK) },
+    { MP_ROM_QSTR(MP_QSTR_SEC_WPA2_WPA3), MP_ROM_INT(WIFI_AUTH_WPA2_WPA3_PSK) },
+    { MP_ROM_QSTR(MP_QSTR_SEC_WAPI), MP_ROM_INT(WIFI_AUTH_WAPI_PSK) },
+    { MP_ROM_QSTR(MP_QSTR_SEC_OWE), MP_ROM_INT(WIFI_AUTH_OWE) },
+    { MP_ROM_QSTR(MP_QSTR_SEC_WPA3_ENT_192), MP_ROM_INT(WIFI_AUTH_WPA3_ENT_192) },
+    { MP_ROM_QSTR(MP_QSTR_SEC_WPA3_EXT_PSK), MP_ROM_INT(WIFI_AUTH_WPA3_EXT_PSK) },
+    { MP_ROM_QSTR(MP_QSTR_SEC_WPA3_EXT_PSK_MIXED_MODE), MP_ROM_INT(WIFI_AUTH_WPA3_EXT_PSK_MIXED_MODE) },
+    #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
+    { MP_ROM_QSTR(MP_QSTR_SEC_DPP), MP_ROM_INT(WIFI_AUTH_DPP) },
+    #endif
+    #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
+    { MP_ROM_QSTR(MP_QSTR_SEC_WPA3_ENT), MP_ROM_INT(WIFI_AUTH_WPA3_ENTERPRISE) },
+    { MP_ROM_QSTR(MP_QSTR_SEC_WPA2_WPA3_ENT), MP_ROM_INT(WIFI_AUTH_WPA2_WPA3_ENTERPRISE) },
+    #endif
+
+    { MP_ROM_QSTR(MP_QSTR_PM_NONE), MP_ROM_INT(WIFI_PS_NONE) },
+    { MP_ROM_QSTR(MP_QSTR_PM_PERFORMANCE), MP_ROM_INT(WIFI_PS_MIN_MODEM) },
+    { MP_ROM_QSTR(MP_QSTR_PM_POWERSAVE), MP_ROM_INT(WIFI_PS_MAX_MODEM) },
+};
+static MP_DEFINE_CONST_DICT(wlan_if_locals_dict, wlan_if_locals_dict_table);
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
+_Static_assert(WIFI_AUTH_MAX == 16, "Synchronize WIFI_AUTH_XXX constants with the ESP-IDF. Look at esp-idf/components/esp_wifi/include/esp_wifi_types_generic.h");
+#elif ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
+_Static_assert(WIFI_AUTH_MAX == 14, "Synchronize WIFI_AUTH_XXX constants with the ESP-IDF. Look at esp-idf/components/esp_wifi/include/esp_wifi_types_generic.h");
+#elif ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
+_Static_assert(WIFI_AUTH_MAX == 13, "Synchronize WIFI_AUTH_XXX constants with the ESP-IDF. Look at esp-idf/components/esp_wifi/include/esp_wifi_types.h");
+#else
+#error "Error in macro logic, all supported versions should be covered."
+#endif
+
+MP_DEFINE_CONST_OBJ_TYPE(
+    esp_network_wlan_type,
+    MP_QSTR_WLAN,
+    MP_TYPE_FLAG_NONE,
+    make_new, network_wlan_make_new,
+    locals_dict, &wlan_if_locals_dict
+    );
+
+#endif // MICROPY_PY_NETWORK_WLAN

--- a/tulip/esp32s3/tasks.h
+++ b/tulip/esp32s3/tasks.h
@@ -17,7 +17,7 @@
 //#define TULIP_MP_TASK_PRIORITY (ESP_TASK_PRIO_MAX - 2)
 #define TULIP_MP_TASK_PRIORITY (ESP_TASK_PRIO_MIN + 1)
 
-#define MIDI_TASK_PRIORITY (ESP_TASK_PRIO_MAX - 2)
+//#define MIDI_TASK_PRIORITY (ESP_TASK_PRIO_MAX - 2)
 
 //#define ALLES_TASK_PRIORITY (ESP_TASK_PRIO_MIN + 2)
 
@@ -32,7 +32,7 @@
 #define TOUCHSCREEN_TASK_COREID  (0)
 #define TULIP_MP_TASK_COREID (1)
 #define SEQUENCER_TASK_COREID (0)
-#define MIDI_TASK_COREID (0)
+//#define MIDI_TASK_COREID (0)
 #define ALLES_TASK_COREID (1)
 #define ALLES_PARSE_TASK_COREID (0)
 #define ALLES_RECEIVE_TASK_COREID (1)
@@ -44,7 +44,7 @@
 #define TOUCHSCREEN_TASK_STACK_SIZE (4 * 1024)
 #define TULIP_MP_TASK_STACK_SIZE      (32 * 1024)
 #define SEQUENCER_TASK_STACK_SIZE (2 * 1024)
-#define MIDI_TASK_STACK_SIZE (4 * 1024)
+//#define MIDI_TASK_STACK_SIZE (4 * 1024)
 #define ALLES_TASK_STACK_SIZE    (4 * 1024) 
 #define ALLES_PARSE_TASK_STACK_SIZE (8 * 1024)
 #define ALLES_RECEIVE_TASK_STACK_SIZE (4 * 1024)
@@ -58,7 +58,7 @@
 #define TOUCHSCREEN_TASK_NAME       "tscreen_task"
 #define SEQUENCER_TASK_NAME         "seq_task"
 #define TULIP_MP_TASK_NAME          "tulip_mp_task"
-#define MIDI_TASK_NAME              "midi_task"
+//#define MIDI_TASK_NAME              "midi_task"
 #define ALLES_TASK_NAME             "alles_task"
 #define ALLES_PARSE_TASK_NAME       "alles_par_task"
 #define ALLES_RECEIVE_TASK_NAME     "alles_rec_task"
@@ -72,7 +72,7 @@ extern TaskHandle_t usb_handle;
 extern TaskHandle_t sequencer_handle;
 extern TaskHandle_t touchscreen_handle;
 extern TaskHandle_t tulip_mp_handle;
-extern TaskHandle_t midi_handle;
+//extern TaskHandle_t midi_handle;
 extern TaskHandle_t alles_handle;
 extern TaskHandle_t alles_parse_handle;
 extern TaskHandle_t alles_receive_handle;

--- a/tulip/esp32s3/tasks.h
+++ b/tulip/esp32s3/tasks.h
@@ -5,21 +5,12 @@
 #include "alles.h"
 
 // All of the ESP tasks that we create in one place
-//#define DISPLAY_TASK_PRIORITY (ESP_TASK_PRIO_MAX - 2) //(ESP_TASK_PRIO_MIN + 5)
 #define DISPLAY_TASK_PRIORITY (ESP_TASK_PRIO_MIN)
-
 #define USB_TASK_PRIORITY (ESP_TASK_PRIO_MIN + 1)
 #define TOUCHSCREEN_TASK_PRIORITY (ESP_TASK_PRIO_MIN + 1)
-
-//#define SEQUENCER_TASK_PRIORITY (ESP_TASK_PRIO_MIN + 1) // Can be low because it sets its own timers?
 #define SEQUENCER_TASK_PRIORITY (ESP_TASK_PRIO_MAX - 1) // Can be low because it sets its own timers?
-
-//#define TULIP_MP_TASK_PRIORITY (ESP_TASK_PRIO_MAX - 2)
 #define TULIP_MP_TASK_PRIORITY (ESP_TASK_PRIO_MIN + 1)
-
-//#define MIDI_TASK_PRIORITY (ESP_TASK_PRIO_MAX - 2)
-
-//#define ALLES_TASK_PRIORITY (ESP_TASK_PRIO_MIN + 2)
+#define AMY_TASK_PRIORITY (ESP_TASK_PRIO_MAX)
 
 #define ALLES_PARSE_TASK_PRIORITY (ESP_TASK_PRIO_MIN +2)
 #define ALLES_RECEIVE_TASK_PRIORITY (ESP_TASK_PRIO_MIN + 3)
@@ -32,24 +23,14 @@
 #define TOUCHSCREEN_TASK_COREID  (0)
 #define TULIP_MP_TASK_COREID (1)
 #define SEQUENCER_TASK_COREID (0)
-//#define MIDI_TASK_COREID (0)
-#define ALLES_TASK_COREID (1)
-#define ALLES_PARSE_TASK_COREID (0)
-#define ALLES_RECEIVE_TASK_COREID (1)
-#define ALLES_RENDER_TASK_COREID (0)
-#define ALLES_FILL_BUFFER_TASK_COREID (1)
+#define AMY_TASK_COREID (1)
 
 #define DISPLAY_TASK_STACK_SIZE    (4 * 1024) 
-#define USB_TASK_STACK_SIZE    (4 * 1024) 
+#define USB_TASK_STACK_SIZE    (8 * 1024) 
 #define TOUCHSCREEN_TASK_STACK_SIZE (4 * 1024)
 #define TULIP_MP_TASK_STACK_SIZE      (32 * 1024)
 #define SEQUENCER_TASK_STACK_SIZE (2 * 1024)
-//#define MIDI_TASK_STACK_SIZE (4 * 1024)
-#define ALLES_TASK_STACK_SIZE    (4 * 1024) 
-#define ALLES_PARSE_TASK_STACK_SIZE (8 * 1024)
-#define ALLES_RECEIVE_TASK_STACK_SIZE (4 * 1024)
-#define ALLES_RENDER_TASK_STACK_SIZE (8 * 1024)
-#define ALLES_FILL_BUFFER_TASK_STACK_SIZE (8 * 1024)
+#define AMY_TASK_STACK_SIZE    (8 * 1024) 
 
 #define MP_TASK_HEAP_SIZE (2 * 1024 * 1024)
 
@@ -58,21 +39,15 @@
 #define TOUCHSCREEN_TASK_NAME       "tscreen_task"
 #define SEQUENCER_TASK_NAME         "seq_task"
 #define TULIP_MP_TASK_NAME          "tulip_mp_task"
-//#define MIDI_TASK_NAME              "midi_task"
-#define ALLES_TASK_NAME             "alles_task"
-#define ALLES_PARSE_TASK_NAME       "alles_par_task"
-#define ALLES_RECEIVE_TASK_NAME     "alles_rec_task"
-#define ALLES_RENDER_TASK_NAME      "alles_r_task"
-#define ALLES_FILL_BUFFER_TASK_NAME "alles_fb_task"
+#define AMY_TASK_NAME                "amy_task"
 
-#define MAX_TASKS 21 // includes system tasks
+#define MAX_TASKS 18 // includes system tasks
 
 extern TaskHandle_t display_handle;
 extern TaskHandle_t usb_handle;
 extern TaskHandle_t sequencer_handle;
 extern TaskHandle_t touchscreen_handle;
 extern TaskHandle_t tulip_mp_handle;
-//extern TaskHandle_t midi_handle;
 extern TaskHandle_t alles_handle;
 extern TaskHandle_t alles_parse_handle;
 extern TaskHandle_t alles_receive_handle;

--- a/tulip/esp32s3/usb_host.h
+++ b/tulip/esp32s3/usb_host.h
@@ -15,6 +15,8 @@
 #include "display.h"
 #include "midi.h"  // from extmod/tulip/
 
+extern uint8_t tulip_ready;
+
 void usbh_setup();
 void run_usb();
 

--- a/tulip/linux/main.c
+++ b/tulip/linux/main.c
@@ -479,8 +479,6 @@ static void sys_set_excecutable(char *argv0) {
 #endif
 
 
-extern int16_t amy_playback_device_id;
-extern int16_t amy_capture_device_id;
 extern void setup_lvgl();
 
 /*
@@ -868,17 +866,18 @@ int main(int argc, char **argv) {
     // Get the resources folder loc
     // So thread out alles and then micropython tasks
 
-    // Display has to run on main thread on macos
     int opt;
+    int capture_device_id = -1;
+    int playback_device_id = -1;
     while((opt = getopt(argc, argv, ":d:c:lh")) != -1) 
     { 
         switch(opt) 
         { 
             case 'd': 
-                amy_playback_device_id = atoi(optarg);
+                playback_device_id = atoi(optarg);
                 break;
             case 'c': 
-                amy_capture_device_id = atoi(optarg);
+                capture_device_id = atoi(optarg);
                 break;
             case 'l':
                 amy_print_devices();
@@ -903,12 +902,15 @@ int main(int argc, char **argv) {
         } 
     }
     unix_display_init();
-    pthread_t alles_thread_id;
-    pthread_create(&alles_thread_id, NULL, alles_start, NULL);
-    /*
-    pthread_t midi_thread_id;
-    pthread_create(&midi_thread_id, NULL, run_midi, NULL);
-    */
+
+
+    amy_config_t amy_config = amy_default_config();
+    amy_config.capture_device_id = capture_device_id;
+    amy_config.playback_device_id = playback_device_id;
+    amy_config.has_audio_in = 1;
+    amy_start(amy_config);
+    amy_live_start();
+
     pthread_t mp_thread_id;
     pthread_create(&mp_thread_id, NULL, main_, NULL);
 

--- a/tulip/linux/main.c
+++ b/tulip/linux/main.c
@@ -861,6 +861,7 @@ extern int8_t unix_display_flag;
 
 #include "lvgl.h"
 #include "tsequencer.h"
+extern void run_amy(uint8_t capture_device_id, uint8_t playback_device_id);
 
 int main(int argc, char **argv) {
     // Get the resources folder loc
@@ -903,13 +904,7 @@ int main(int argc, char **argv) {
     }
     unix_display_init();
 
-
-    amy_config_t amy_config = amy_default_config();
-    amy_config.capture_device_id = capture_device_id;
-    amy_config.playback_device_id = playback_device_id;
-    amy_config.has_audio_in = 1;
-    amy_start(amy_config);
-    amy_live_start();
+    run_amy(capture_device_id, playback_device_id);
 
     pthread_t mp_thread_id;
     pthread_create(&mp_thread_id, NULL, main_, NULL);

--- a/tulip/macos/Makefile
+++ b/tulip/macos/Makefile
@@ -100,7 +100,7 @@ INC += -I$(BUILD)
 
 # compiler settings
 CWARN = -Wall -Werror
-CWARN += -Wextra -Wno-unused-parameter -Wno-unused-but-set-parameter -Wpointer-arith -Wdouble-promotion -Wfloat-conversion -Wno-missing-declarations  -Wno-unused-but-set-variable -Wno-sign-compare -Wno-gnu-variable-sized-type-not-at-end -Wno-undefined-internal
+CWARN += -Wextra -Wno-c2x-extensions -Wno-unused-parameter -Wno-unused-but-set-parameter -Wpointer-arith -Wdouble-promotion -Wfloat-conversion -Wno-missing-declarations  -Wno-unused-but-set-variable -Wno-sign-compare -Wno-gnu-variable-sized-type-not-at-end -Wno-undefined-internal
 CFLAGS += $(INC) $(CWARN) -std=gnu99 -DUNIX $(CFLAGS_MOD) $(COPT) -I$(VARIANT_DIR) $(CFLAGS_EXTRA) 
 CFLAGS += -DTULIP_DESKTOP -DMACOS -DAMY_HAS_AUDIO_IN
 CFLAGS += $(ARCHFLAGS) 
@@ -260,12 +260,12 @@ endif
 
 
 
+#	../shared/desktop/multicast.c \
 
 # source files
 SRC_C += \
 	main.c \
 	../shared/desktop/unix_display.c \
-	../shared/desktop/multicast.c \
 	../shared/desktop/unix_mphal.c \
 	../../amy/src/libminiaudio-audio.c \
 	$(MICROPY_PORT_DIR)/mpthreadport.c \
@@ -297,7 +297,7 @@ SHARED_SRC_C += $(addprefix ../../micropython/shared/,\
 SRC_CXX += \
 	$(SRC_MOD_CXX)
 
-SRC_M = virtualmidi.m
+SRC_M = ../../amy/src/macos_midi.m
 
 OBJ = $(PY_O)
 OBJ += $(addprefix $(BUILD)/, $(SRC_C:.c=.o))

--- a/tulip/macos/main.c
+++ b/tulip/macos/main.c
@@ -904,15 +904,18 @@ int main(int argc, char **argv) {
 
     // Display has to run on main thread on macos
     int opt;
+    int capture_device_id = -1;
+    int playback_device_id = -1;
+
     while((opt = getopt(argc, argv, ":d:c:lh")) != -1) 
     { 
         switch(opt) 
         { 
             case 'd': 
-                amy_playback_device_id = atoi(optarg);
+                playback_device_id = atoi(optarg);
                 break;
             case 'c': 
-                amy_capture_device_id = atoi(optarg);
+                capture_device_id = atoi(optarg);
                 break;
             case 'l':
                 amy_print_devices();
@@ -937,18 +940,20 @@ int main(int argc, char **argv) {
         } 
     }
     unix_display_init();
-    pthread_t alles_thread_id;
-    pthread_create(&alles_thread_id, NULL, alles_start, NULL);
 
-    pthread_t midi_thread_id;
-    pthread_create(&midi_thread_id, NULL, run_midi, NULL);
+    amy_config_t amy_config = amy_default_config();
+    amy_config.has_midi_mac = 1;
+    amy_config.capture_device_id = capture_device_id;
+    amy_config.playback_device_id = playback_device_id;
+    amy_config.has_audio_in = 1;
+    amy_start(amy_config);
+    amy_live_start();
 
     pthread_t mp_thread_id;
     pthread_create(&mp_thread_id, NULL, main_, NULL);
 
     tsequencer_init();
     delay_ms(100);
-    // Schedule a "turning on" sound
 
 
 display_jump:

--- a/tulip/macos/main.c
+++ b/tulip/macos/main.c
@@ -898,6 +898,8 @@ soft_reset_exit:
 
 #include "lvgl.h"
 
+extern void run_amy(uint8_t capture_device_id, uint8_t playback_device_id);
+
 int main(int argc, char **argv) {
     // Get the resources folder loc
     // So thread out alles and then micropython tasks
@@ -941,13 +943,7 @@ int main(int argc, char **argv) {
     }
     unix_display_init();
 
-    amy_config_t amy_config = amy_default_config();
-    amy_config.has_midi_mac = 1;
-    amy_config.capture_device_id = capture_device_id;
-    amy_config.playback_device_id = playback_device_id;
-    amy_config.has_audio_in = 1;
-    amy_start(amy_config);
-    amy_live_start();
+    run_amy(capture_device_id, playback_device_id);
 
     pthread_t mp_thread_id;
     pthread_create(&mp_thread_id, NULL, main_, NULL);

--- a/tulip/shared/alles.c
+++ b/tulip/shared/alles.c
@@ -1,7 +1,7 @@
 // Alles multicast synthesizer
 // Brian Whitman
 // brian@variogr.am
-
+#if 0
 #include "alles.h"
 
 uint8_t board_level;
@@ -213,11 +213,13 @@ void run_alles() {
     amy_config_t config = amy_default_config();
     config.cores = 2;
     config.has_audio_in = 0;
-    config.lrc = CONFIG_I2S_LRCLK;
-    config.bclk = CONFIG_I2S_BCLK;
-    config.dout = CONFIG_I2S_DIN; // badly named
+    config.i2s_lrc = CONFIG_I2S_LRCLK;
+    config.i2s_bclk = CONFIG_I2S_BCLK;
+    config.i2s_dout = CONFIG_I2S_DIN; // badly named
     amy_start(config);
+    #ifndef ESP_PLATFORM
     amy_live_start();
+    #endif
 
 }
 
@@ -312,4 +314,4 @@ void handle_sync(int32_t time, int8_t index) {
 }
 
 
-
+#endif

--- a/tulip/shared/amy_connector.c
+++ b/tulip/shared/amy_connector.c
@@ -1,0 +1,110 @@
+// amy_connector.c
+// all the stuff that connects Tulip to AMY
+// like MIDI queue -> python
+// like external CV
+// like t-sequencer?
+// like alles / wifi stuff?
+
+
+#include "polyfills.h"
+#include "py/mphal.h"
+#include "py/runtime.h"
+
+uint8_t * external_map;
+
+
+// A queue to store the AMY midi messages coming IN
+uint8_t last_midi[MIDI_QUEUE_DEPTH][MAX_MIDI_BYTES_PER_MESSAGE];
+uint8_t last_midi_len[MIDI_QUEUE_DEPTH];
+extern mp_obj_t midi_callback;
+
+int16_t midi_queue_head = 0;
+int16_t midi_queue_tail = 0;
+
+
+void midi_local(uint8_t * bytes, uint16_t len) {
+    // send these bytes to AMY
+}
+
+
+void amy_midi_message_received(uint8_t *data, size_t len) {
+    //fprintf(stderr, "adding midi message of %d bytes to queue: ", len);
+    for(uint32_t i = 0; i < (uint32_t)len; i++) {
+        if(i < MAX_MIDI_BYTES_PER_MESSAGE) {
+            //fprintf(stderr, "%02x ", data[i]);
+            last_midi[midi_queue_tail][i] = data[i];
+        }
+    }
+    //fprintf(stderr, "\n");
+    last_midi_len[midi_queue_tail] = (uint16_t)len;
+    midi_queue_tail = (midi_queue_tail + 1) % MIDI_QUEUE_DEPTH;
+    if (midi_queue_tail == midi_queue_head) {
+        // Queue wrap, drop oldest item.
+        midi_queue_head = (midi_queue_head + 1) % MIDI_QUEUE_DEPTH;
+        //fprintf(stderr, "dropped midi message\n");
+    }
+
+    // We tell Python that a MIDI message has been received
+    if(midi_callback!=NULL) mp_sched_schedule(midi_callback, mp_const_false);
+}
+
+
+
+
+// Parse extra stuff out of an AMY message. Used for alles
+
+void tulip_parse_amy_message(char *message, uint16_t length) {
+    uint8_t mode = 0;
+    int16_t client = -1;
+    int32_t sync = -1;
+    int8_t sync_index = -1;
+    uint8_t ipv4 = 0;
+    uint16_t start = 0;
+    uint16_t c = 0;
+    uint8_t sync_response = 0;
+
+    // Parse the AMY stuff out of the message first
+    struct event e = amy_parse_message(message);
+    if(e.status == EVENT_TRANSFER_DATA) {
+        // transfer data already dealt with. we skip this followon check.
+        length = 0;
+    } else {
+        //fprintf(stderr, "message is %s len is %d\n", message, length);
+        // Then pull out any alles-specific modes in this message 
+        while(c < length+1) {
+            uint8_t b = message[c];
+            if(b == '_' && c==0) sync_response = 1;
+            if( ((b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')) || b == 0) {  // new mode or end
+                if(mode=='g') client = atoi(message + start); 
+                if(mode=='U') sync = atol(message + start); 
+                if(mode=='W') external_map[e.osc] = atoi(message+start);
+                if(sync_response) if(mode=='r') ipv4=atoi(message + start);
+                if(mode=='i') sync_index = atoi(message + start);
+                mode = b;
+                start = c + 1;
+            } 
+            c++;
+        }
+    }
+    if(sync_response) {
+        // If this is a sync response, let's update our local map of who is booted
+        //fprintf(stderr, "sync response message was %s\n", message);
+        //update_map(client, ipv4, sync);
+        length = 0; // don't need to do the rest
+    } else {
+        // Note, we DO NOT do anything with computed_delta in Tulip. Tulip cannot receive alles mesh messages for playback.
+    }
+    // Only do this if we got some data
+    if(length >0) {
+        // TODO -- not that it matters, but the below could probably be one or two lines long instead
+        // Don't add sync messages to the event queue
+        if(sync >= 0 && sync_index >= 0) {
+            //handle_sync(sync, sync_index);
+        } else {
+            // Don't parse events other than sync messages if i'm in mesh mode. 
+            //if(!mesh_flag) {
+                amy_add_event(e);
+            //}
+        }
+    }
+}

--- a/tulip/shared/amy_connector.c
+++ b/tulip/shared/amy_connector.c
@@ -64,7 +64,8 @@ void tulip_parse_amy_message(char *message, uint16_t length) {
     uint8_t sync_response = 0;
 
     // Parse the AMY stuff out of the message first
-    struct event e = amy_parse_message(message);
+    struct event e = amy_default_event();
+    amy_parse_message(message, &e);
     if(e.status == EVENT_TRANSFER_DATA) {
         // transfer data already dealt with. we skip this followon check.
         length = 0;
@@ -103,7 +104,7 @@ void tulip_parse_amy_message(char *message, uint16_t length) {
         } else {
             // Don't parse events other than sync messages if i'm in mesh mode. 
             //if(!mesh_flag) {
-                amy_add_event(e);
+                amy_add_event(&e);
             //}
         }
     }

--- a/tulip/shared/amy_connector.c
+++ b/tulip/shared/amy_connector.c
@@ -22,12 +22,9 @@ int16_t midi_queue_head = 0;
 int16_t midi_queue_tail = 0;
 
 
-void midi_local(uint8_t * bytes, uint16_t len) {
-    // send these bytes to AMY
-}
-
-
-void amy_midi_message_received(uint8_t *data, size_t len) {
+// I am called when AMY receives MIDI in, whether it has been processed (played in a instrument) or not 
+// In tulip i just fill up the last_midi queue so that MIDI input is accessible to Python
+void tulip_midi_input_hook(uint8_t * data, uint16_t len, uint8_t is_sysex) {
     //fprintf(stderr, "adding midi message of %d bytes to queue: ", len);
     for(uint32_t i = 0; i < (uint32_t)len; i++) {
         if(i < MAX_MIDI_BYTES_PER_MESSAGE) {
@@ -48,6 +45,56 @@ void amy_midi_message_received(uint8_t *data, size_t len) {
     if(midi_callback!=NULL) mp_sched_schedule(midi_callback, mp_const_false);
 }
 
+void midi_local(uint8_t * bytes, uint16_t len) {
+    convert_midi_bytes_to_messages(bytes, len, 0);
+}
+
+extern bool midi_has_out;
+extern void send_usb_midi_out(uint8_t * data, uint16_t len);
+
+void tulip_send_midi_out(uint8_t* buf, uint16_t len) {
+    // check if we have USB HOST midi, which is handled by Tulip
+    if(midi_has_out) {
+        send_usb_midi_out(buf, len);
+    }
+    // Also send out via AMY
+    amy_external_midi_output(buf, len);
+}
+
+#ifdef ESP_PLATFORM
+void run_amy() {
+    amy_external_midi_input_hook = tulip_midi_input_hook;
+    amy_config_t amy_config = amy_default_config();
+    amy_config.has_audio_in = 0;
+    amy_config.has_midi_uart = 1;
+    amy_config.set_default_synth = 1;
+    amy_config.cores = 2;
+    amy_config.i2s_lrc = CONFIG_I2S_LRCLK;
+    amy_config.i2s_bclk = CONFIG_I2S_BCLK;
+    amy_config.i2s_dout = CONFIG_I2S_DIN; // badly named
+    amy_config.midi_out = MIDI_OUT_PIN;
+    amy_config.midi_in = MIDI_IN_PIN;
+    amy_start(amy_config);
+    amy_live_start();
+    while(1) {
+        vTaskDelay(10);
+    }
+}
+
+#elif defined TULIP_DESKTOP
+
+void run_amy(uint8_t capture_device_id, uint8_t playback_device_id) {
+    amy_external_midi_input_hook = tulip_midi_input_hook;
+    amy_config_t amy_config = amy_default_config();
+    amy_config.has_midi_mac = 1;
+    amy_config.capture_device_id = capture_device_id;
+    amy_config.playback_device_id = playback_device_id;
+    amy_config.has_audio_in = 1;
+    amy_start(amy_config);
+    amy_live_start();
+}
+
+#endif
 
 
 

--- a/tulip/shared/amy_connector.c
+++ b/tulip/shared/amy_connector.c
@@ -54,9 +54,11 @@ extern void send_usb_midi_out(uint8_t * data, uint16_t len);
 
 void tulip_send_midi_out(uint8_t* buf, uint16_t len) {
     // check if we have USB HOST midi, which is handled by Tulip
+#ifdef ESP_PLATFORM
     if(midi_has_out) {
         send_usb_midi_out(buf, len);
     }
+#endif
     // Also send out via AMY
     amy_external_midi_output(buf, len);
 }

--- a/tulip/shared/midi.c
+++ b/tulip/shared/midi.c
@@ -1,4 +1,5 @@
 // midi.c
+#if 0
 #include "midi.h"
 #include "polyfills.h"
 uint8_t last_midi[MIDI_QUEUE_DEPTH][MAX_MIDI_BYTES_PER_MESSAGE];
@@ -285,6 +286,8 @@ void midi_out(uint8_t * bytes, uint16_t len) {
     // nothing yet for linux
     #endif
 }
+#endif
+
 #endif
 
 #endif

--- a/tulip/shared/midi.h
+++ b/tulip/shared/midi.h
@@ -1,3 +1,4 @@
+#if 0
 // midi.h
 #ifdef ESP_PLATFORM 
 #include "alles.h"
@@ -34,4 +35,6 @@ void midi_local(uint8_t * bytes, uint16_t len);
 void run_midi();
 #else
 void *run_midi(void*vargp);
+#endif
+
 #endif

--- a/tulip/shared/modtulip.c
+++ b/tulip/shared/modtulip.c
@@ -211,12 +211,13 @@ STATIC mp_obj_t tulip_sysex_in(size_t n_args, const mp_obj_t *args) {
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(tulip_sysex_in_obj, 0, 0, tulip_sysex_in);
 
+extern void tulip_send_midi_out(uint8_t *, uint16_t);
 
 STATIC mp_obj_t tulip_midi_out(size_t n_args, const mp_obj_t *args) {
     if(mp_obj_get_type(args[0]) == &mp_type_bytes) {
         mp_buffer_info_t bufinfo;
         mp_get_buffer(args[0], &bufinfo, MP_BUFFER_READ);
-        midi_out((uint8_t*)bufinfo.buf, bufinfo.len);
+        tulip_send_midi_out((uint8_t*)bufinfo.buf, bufinfo.len);
     } else {
         mp_obj_t *items;
         size_t len;

--- a/tulip/shared/modtulip.c
+++ b/tulip/shared/modtulip.c
@@ -181,7 +181,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(tulip_seq_remove_callbacks_obj, 0, 0,
 
 
 STATIC mp_obj_t tulip_seq_ticks(size_t n_args, const mp_obj_t *args) {
-    return mp_obj_new_int(sequencer_tick_count);
+    return mp_obj_new_int(amy_global.sequencer_tick_count);
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(tulip_seq_ticks_obj, 0, 0, tulip_seq_ticks);
@@ -256,18 +256,19 @@ STATIC mp_obj_t tulip_midi_local(size_t n_args, const mp_obj_t *args) {
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(tulip_midi_local_obj, 1, 1, tulip_midi_local);
 
+extern void tulip_parse_amy_message(char *message, uint16_t length);
 
 
 #ifndef __EMSCRIPTEN__
-extern void mcast_send(char*, uint16_t len);
+//extern void mcast_send(char*, uint16_t len);
 STATIC mp_obj_t tulip_alles_send(size_t n_args, const mp_obj_t *args) {
-    if(n_args > 1) {
-        if(mp_obj_get_int(args[1])) { // mesh
-            mcast_send( (char*)mp_obj_str_get_str(args[0]), strlen(mp_obj_str_get_str(args[0])));
-            return mp_const_none;
-        }
-    }
-    alles_send_message((char*)mp_obj_str_get_str(args[0]), strlen(mp_obj_str_get_str(args[0])));
+//    if(n_args > 1) {
+//        if(mp_obj_get_int(args[1])) { // mesh
+//            mcast_send( (char*)mp_obj_str_get_str(args[0]), strlen(mp_obj_str_get_str(args[0])));
+//            return mp_const_none;
+//        }
+//    }
+    tulip_parse_amy_message((char*)mp_obj_str_get_str(args[0]), strlen(mp_obj_str_get_str(args[0])));
     return mp_const_none;
 }
 
@@ -275,9 +276,9 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(tulip_alles_send_obj, 1, 2, tulip_all
 #endif
 
 
+/*
 
 #if !defined(AMYBOARD) && !defined(__EMSCRIPTEN__)
-
 extern char * alles_local_ip;
 STATIC mp_obj_t tulip_multicast_start(size_t n_args, const mp_obj_t *args) {
     const char * local_ip = mp_obj_str_get_str(args[0]);
@@ -324,7 +325,7 @@ STATIC mp_obj_t tulip_set_quartet(size_t n_args, const mp_obj_t *args) {
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(tulip_set_quartet_obj, 1, 1, tulip_set_quartet);
 #endif
-
+*/
 extern float compute_cpu_usage(uint8_t debug);
 STATIC mp_obj_t tulip_cpu(size_t n_args, const mp_obj_t *args) {
     // for now just printf to uart
@@ -1470,13 +1471,13 @@ STATIC const mp_rom_map_elem_t tulip_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_board), MP_ROM_PTR(&tulip_board_obj) }, 
     { MP_ROM_QSTR(MP_QSTR_build_strings), MP_ROM_PTR(&tulip_build_strings_obj) },
 #if !defined(__EMSCRIPTEN__) && !defined(AMYBOARD)
-    { MP_ROM_QSTR(MP_QSTR_multicast_start), MP_ROM_PTR(&tulip_multicast_start_obj) },
-    { MP_ROM_QSTR(MP_QSTR_alles_map), MP_ROM_PTR(&tulip_alles_map_obj) },
+    //{ MP_ROM_QSTR(MP_QSTR_multicast_start), MP_ROM_PTR(&tulip_multicast_start_obj) },
+    //{ MP_ROM_QSTR(MP_QSTR_alles_map), MP_ROM_PTR(&tulip_alles_map_obj) },
 #endif
 
 #ifndef __EMSCRIPTEN__
     { MP_ROM_QSTR(MP_QSTR_alles_send), MP_ROM_PTR(&tulip_alles_send_obj) },
-    { MP_ROM_QSTR(MP_QSTR_set_quartet), MP_ROM_PTR(&tulip_set_quartet_obj) },
+    //{ MP_ROM_QSTR(MP_QSTR_set_quartet), MP_ROM_PTR(&tulip_set_quartet_obj) },
     { MP_ROM_QSTR(MP_QSTR_amy_ticks_ms), MP_ROM_PTR(&tulip_amy_ticks_ms_obj) },
 #endif
 

--- a/tulip/shared/py/_boot.py
+++ b/tulip/shared/py/_boot.py
@@ -104,6 +104,7 @@ else:
     amy.override_send = lambda x: tulip.alles_send(x, alles.mesh_flag)
     #midi.setup() # Now handled by AMY.
 
+tulip.startup_bleep()
 
 if(board() == "AMYBOARD" or board()=="AMYBOARD_WEB"):
     import amyboard

--- a/tulip/shared/py/_boot.py
+++ b/tulip/shared/py/_boot.py
@@ -102,7 +102,7 @@ else:
     amy.AMY_SAMPLE_RATE=44100
     # Override amy's send to work with tulip
     amy.override_send = lambda x: tulip.alles_send(x, alles.mesh_flag)
-    midi.setup()
+    #midi.setup() # Now handled by AMY.
 
 
 if(board() == "AMYBOARD" or board()=="AMYBOARD_WEB"):

--- a/tulip/shared/py/tulip.py
+++ b/tulip/shared/py/tulip.py
@@ -15,6 +15,12 @@ def sys():
 
 import midi
 
+def startup_bleep():
+    amy.send(synth=16, note=57, vel=1, time=tulip.amy_ticks_ms()+0)
+    amy.send(synth=16, note=57, vel=0, time=tulip.amy_ticks_ms()+140)
+    amy.send(synth=16, note=69, vel=1, time=tulip.amy_ticks_ms()+150)
+    amy.send(synth=16, note=69, vel=0, time=tulip.amy_ticks_ms()+300)
+
 # prompt for y/n and return true if Y
 def prompt(prompt):
     if(board()=="WEB"):

--- a/tulip/shared/py/tulip.py
+++ b/tulip/shared/py/tulip.py
@@ -340,8 +340,6 @@ def ip():
         return "127.0.0.1" # we are on local and it's ok
     sta_if = network.WLAN(network.STA_IF)
     if(sta_if.isconnected()):
-        ipv4 = sta_if.ifconfig()[0]
-        set_quartet(int(ipv4.split('.')[3]))
         return sta_if.ifconfig()[0]
     else:
         return None

--- a/tulip/shared/sounds.c
+++ b/tulip/shared/sounds.c
@@ -7,7 +7,7 @@ void note_on(int8_t osc, int64_t time) {
     e.osc = osc;
     e.time = time;
     e.velocity = 1;
-    amy_add_event(e);
+    amy_add_event(&e);
 }
 
 
@@ -21,10 +21,10 @@ void upgrade_tone() {
     e.wave = SINE;
     e.freq_coefs[COEF_CONST] = 220;
     strcpy(e.bp0, "0,0,10,1,500,0,0,0");
-    amy_add_event(e);
+    amy_add_event(&e);
     e.osc = 1;
     e.freq_coefs[COEF_CONST] = 420;
-    amy_add_event(e);
+    amy_add_event(&e);
 
     note_on(0, e.time+1);
     note_on(1, e.time+1);
@@ -39,10 +39,10 @@ void wifi_tone() {
     e.wave = SINE;
     e.freq_coefs[COEF_CONST] = 440;
     strcpy(e.bp0 ,"0,0,10,1,500,0,0,0");
-    amy_add_event(e);
+    amy_add_event(&e);
     e.osc = 1;
     e.freq_coefs[COEF_CONST] = 840;
-    amy_add_event(e);
+    amy_add_event(&e);
 
     note_on(0, e.time+1);
     note_on(1, e.time+1);
@@ -56,18 +56,18 @@ void bleep() {
     e.time = sysclock;
     e.wave = SINE;
     e.freq_coefs[COEF_CONST] = 220;
-    //amy_add_event(e);
+    //amy_add_event(&e);
     e.velocity = 1;
     e.pan_coefs[COEF_CONST] = 0.9;
-    amy_add_event(e);
+    amy_add_event(&e);
     e.time = sysclock + 150;
     e.freq_coefs[COEF_CONST] = 440;
     e.pan_coefs[COEF_CONST] = 0.1;
-    amy_add_event(e);
+    amy_add_event(&e);
     e.time = sysclock + 300;
     e.velocity = 0;
     e.pan_coefs[COEF_CONST] = 0.5;  // Restore default pan to osc 0.
-    amy_add_event(e);
+    amy_add_event(&e);
 }
 
 void debleep() {
@@ -78,13 +78,13 @@ void debleep() {
     e.wave = SINE;
     e.freq_coefs[COEF_CONST] = 440;
     e.velocity = 1;
-    amy_add_event(e);
+    amy_add_event(&e);
     e.time = sysclock + 150;
     e.freq_coefs[COEF_CONST] = 220;
-    amy_add_event(e);
+    amy_add_event(&e);
     e.time = sysclock + 300;
     e.velocity = 0;
-    amy_add_event(e);
+    amy_add_event(&e);
 }
 
 
@@ -97,6 +97,6 @@ void scale(uint8_t wave) {
         e.wave = wave;
         e.midi_note = 48+i;
         e.velocity = 1;
-        amy_add_event(e);
+        amy_add_event(&e);
     }
 }

--- a/tulip/shared/tulip.mk
+++ b/tulip/shared/tulip.mk
@@ -18,6 +18,9 @@ EXTMOD_SRC_C += $(addprefix $(TOP)/../amy/src/, \
 	pcm.c \
 	log2_exp2.c \
 	interp_partials.c \
+	parse.c \
+	midi.c \
+	instrument.c \
 )
 
 EXTMOD_SRC_C += $(addprefix $(TULIP_EXTMOD_DIR)/, \
@@ -33,8 +36,7 @@ EXTMOD_SRC_C += $(addprefix $(TULIP_EXTMOD_DIR)/, \
 	tulip_helpers.c \
 	editor.c \
 	keyscan.c \
-	midi.c \
-	alles.c \
+	amy_connector.c \
 	sounds.c \
 	lodepng.c \
 	tsequencer.c \

--- a/tulip/shared/tulip_helpers.c
+++ b/tulip/shared/tulip_helpers.c
@@ -25,6 +25,13 @@ int check_rx_char() {
 }
 #endif
 
+uint64_t get_stack_pointer() {
+    char dummy[64];
+    uint64_t val = (uint64_t)dummy;
+    return val;
+}
+
+
 // Returns 0 if file doesn't exist, 2 if it's a file, XXX if it's a directory
 uint8_t file_exists(const char *filename) {
     uint8_t response = mp_vfs_import_stat(filename);

--- a/tulip/shared/tulip_helpers.h
+++ b/tulip/shared/tulip_helpers.h
@@ -24,4 +24,5 @@ uint32_t tulip_fwrite(mp_obj_t file, uint8_t * buf, uint32_t len);
 void tulip_fclose(mp_obj_t file);
 uint32_t tulip_fseek(mp_obj_t file, uint32_t seekpoint, int32_t whence);
 int32_t tulip_getline(char * line, uint32_t * len, mp_obj_t file );
+uint64_t get_stack_pointer();
 #endif


### PR DESCRIPTION
Tulip Desktop and Tulip CC now using AMY instruments branch
To test, boot up Tulip in Desktop mac or CC, and play MIDI into it. The MIDI is now processed by AMY and via AMY instruments

Still todo
- midi.py and voices.py understanding AMY instruments
- stack overflows in setting up AMY, maybe struct event passing as reference? 
- midi in and out surfaced in Tulip (tulip.midi_in() etc)
- sequencer
- probably others


