### PR TITLE
shared/py/drums.py: Make default Kick be the one available in AMY 

### DIFF
--- a/tulip/shared/py/drums.py
+++ b/tulip/shared/py/drums.py
@@ -286,7 +286,7 @@ def run(screen):
     app.add(app.leds, direction=lv.ALIGN.OUT_BOTTOM_LEFT, pad_y=0)
     drum_items = [x[1] for x in drumkit]
     _NOTE_OF_ROW = [0] * _NUM_ROWS
-    initial_voices = ['Std Kick', 'Snare', 'Maraca', 'Closed Hat', 'Open Hat', 'Cowbell', 'Congo Low']
+    initial_voices = ['Kick', 'Snare', 'Maraca', 'Closed Hat', 'Open Hat', 'Cowbell', 'Low Tom']
     app.rows = []
     for i in range(_NUM_ROWS):
         row = DrumRow(drum_items, row=i)


### PR DESCRIPTION
AMY is currently built with pcm_tiny.h, which means the PCM presets are only available up to preset=10.  Previously, the drums.py app was trying to use preset=25 for the kick drum, which resulted in a heavily down pitched maraca, which sounded bad.  Here, we change the default voices for the drums.py app to be ones that are available even in "tiny" AMY.

We still have the problem that many of the alternate voices offered by the pulldown in drums.py are not going to work as expected with tiny AMY.  We built drums.py expecting AMY to be compiled with pcm_small.h, but then we ran into AMY size issues for, e.g., RP2040 targets under Arduino, so we cut it back.  Ideally, we'd build AMY with pcm_small when building for a Tulip target.