### PR TITLE
Add flake for Nix development shell environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,7 @@ _autosave-*
 *-save.kicad_pcb
 fp-info-cache
 *.lck
+
+# Nix files
+/.direnv
+result

--- a/docs/tulip_flashing.md
+++ b/docs/tulip_flashing.md
@@ -18,7 +18,7 @@ It will ask you if you want to upgrade your firmware and/or your `/sys` folder (
 
 ## Flash Tulip from a compiled release
 
-If you've got an unflashed Tulip, just finished a DIY, or somehow messed up the flash / firmware, you can flash the entire Tulip and filesystem with one file from our releases. We aim to release versions of Tulip regularly. You can find the latest in our [releases section](https://github.com/shorepine/tulipcc/releases/latest). 
+If you've got an unflashed Tulip, just finished a DIY, or somehow messed up the flash / firmware, you can flash the entire Tulip and filesystem with one file from our releases. We aim to release versions of Tulip regularly. You can find the latest in our [releases section](https://github.com/shorepine/tulipcc/releases/latest).
 
 **If you have the [Tulip from Makerfabs](https://tulip.computer/)**, you can directly download the latest full firmware binary here: [TULIP4_R11](https://github.com/shorepine/tulipcc/releases/latest/download/tulip-full-TULIP4_R11.bin).
 
@@ -60,7 +60,10 @@ Linux:
 sudo apt install cmake ninja-build dfu-util virtualenv
 ```
 
-For both macOS & Linux, next, download the supported version of ESP-IDF. That is release 5.4.1. You need to get this with `git`, so install that if you don't already have it. Once Espressif updates the release, we can provide a direct download link that's a bit easier. 
+Nix:
+A devshell is provided through `direnv` or through `nix develop`.
+
+For both macOS & Linux, next, download the supported version of ESP-IDF. That is release 5.4.1. You need to get this with `git`, so install that if you don't already have it. Once Espressif updates the release, we can provide a direct download link that's a bit easier.
 
 I like to keep them in `~/esp/`, as you'll likely want to use different versions eventually. So we'll assume it's in `~/esp/esp-idf`.
 
@@ -76,7 +79,7 @@ cd esp-idf-v5.4.1
 source export.sh
 
 cd ~
-git clone https://github.com/shorepine/tulipcc.git 
+git clone https://github.com/shorepine/tulipcc.git
 pip3 install Cython
 pip3 install littlefs-python # needed to flash the filesystem
 cd ~/tulipcc/tulip/esp32s3
@@ -84,9 +87,9 @@ cd ~/tulipcc/tulip/esp32s3
 
 ### Flash Tulip after compiling
 
-Now connect your Tulip to your computer over USB. See the notes about which USB port to use above. 
+Now connect your Tulip to your computer over USB. See the notes about which USB port to use above.
 
-Choose the right `MICROPY_BOARD` value for your board. 
+Choose the right `MICROPY_BOARD` value for your board.
 
  * [Tulip CC](https://tulip.computer/) (our integrated board with display): `TULIP4_R11`
  * Any DIY Tulip board based on the N16R8 (16MB flash): `N16R8`
@@ -101,23 +104,23 @@ For example, for a Tulip4 DIY board based on a N32R8:
 
 ```bash
 idf.py -DMICROPY_BOARD=N32R8 build
-# With a brand new chip or devboard, the first time, you'll want to flash Tulip's filesystem 
+# With a brand new chip or devboard, the first time, you'll want to flash Tulip's filesystem
 # to the flash memory. Run this only once, or each time you modify `fs` if you're developing Tulip itself.
 cd ..
 python fs_create.py tulip flash
 ```
 
-You may need to restart Tulip after the flash, but Tulip should now just turn on whenever you connect USB or power it on. 
+You may need to restart Tulip after the flash, but Tulip should now just turn on whenever you connect USB or power it on.
 
 To build and flash going forward, without modifying the filesystem:
 
 ```bash
 cd tulip/esp32s3
 source ~/esp/esp-idf/export.sh # do this once per terminal window
-idf.py -DMICROPY_BOARD=[X] flash 
+idf.py -DMICROPY_BOARD=[X] flash
 idf.py monitor # shows stderr and stdin for controlling Tulip, use control-] to quit
 
-# If you (or we!) make changes to the underlying libraries on AMY or micropython, you want to fully clean the build 
+# If you (or we!) make changes to the underlying libraries on AMY or micropython, you want to fully clean the build
 rm ../../.submodules_ok # this forces the submodules to re-init
 idf.py fullclean
 idf.py -DMICROPY_BOARD=[X] flash

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1769092226,
+        "narHash": "sha256-6h5sROT/3CTHvzPy9koKBmoCa2eJKh4fzQK8eYFEgl8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b579d443b37c9c5373044201ea77604e37e748c8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,72 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs =
+    {
+      nixpkgs,
+      flake-utils,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        # Import nixpkgs for the specific system
+        pkgs = import nixpkgs { inherit system; };
+
+        littlefs-python =
+          {
+            buildPythonPackage,
+            cython,
+            setuptools,
+            setuptools-scm,
+            ...
+          }:
+          buildPythonPackage rec {
+            pname = "littlefs-python";
+            version = "0.17.0";
+
+            src = pkgs.fetchFromGitHub {
+              owner = "jrast";
+              repo = pname;
+              tag = "v${version}";
+              fetchSubmodules = true;
+              hash = "sha256-GRMYnnt8E1QNWoynDJyXOIzE1AtzeXOwBv/ZrIDWSGs=";
+            };
+
+            buildInputs = [
+              cython
+              setuptools-scm
+            ];
+
+            pyproject = true;
+            build-system = [ setuptools ];
+          };
+
+        python = pkgs.python3.override {
+          self = python;
+          packageOverrides = pyfinal: pyprev: {
+            littlefs-python = pyfinal.callPackage littlefs-python { };
+          };
+        };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          name = "tulipcc-devshell";
+
+          packages = with pkgs; [
+            esptool
+            cmake
+            ninja
+            dfu-util
+
+            (python.withPackages (python-pkgs: [
+              python-pkgs.littlefs-python
+              python-pkgs.cython
+            ]))
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
My editor has a markdown LSP apparently and it removed trailing spaces from several of the lines in docs/tulip_flashing.md. I can revert those changes if this is a problem.