### PR TITLE
amyboardweb: wave preset UI + reliable wave state sync

### DIFF
--- a/tulip/amyboardweb/build.sh
+++ b/tulip/amyboardweb/build.sh
@@ -54,7 +54,7 @@ import hashlib
 import os
 
 root = "static"
-ignore = {"amy_event_layout.generated.js", "patches.generated.js"}
+ignore = {"amy_event_layout.generated.js", "patches.generated.js", "pcm_presets.generated.js"}
 h = hashlib.sha1()
 for base, dirs, files in os.walk(root):
     dirs.sort()

--- a/tulip/amyboardweb/static/editor/index.html
+++ b/tulip/amyboardweb/static/editor/index.html
@@ -47,6 +47,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/mode/python/python.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
     <script type="text/javascript" src="amy_event_layout.generated.js"></script>
+    <script type="text/javascript" src="pcm_presets.generated.js"></script>
     <script type="text/javascript" src="amy_parameters.js"></script>
     <script>
       window.AMYBOARD_WORLD_API_BASE = "https://tulipcc-production.up.railway.app";
@@ -281,6 +282,54 @@
         padding: 0 2px;
         color: #f8f8f8;
         user-select: none;
+      }
+
+      .amy-select-display-clickable {
+        text-decoration: underline;
+        text-underline-offset: 2px;
+        cursor: pointer;
+      }
+
+      .amy-wave-preset-popup {
+        position: absolute;
+        z-index: 10000;
+        width: max-content;
+        max-width: 320px;
+        max-height: 260px;
+        overflow-y: auto;
+        background: #181818;
+        border: 1px solid #444;
+        border-radius: 8px;
+        box-shadow: 0 10px 20px rgba(0, 0, 0, 0.35);
+        padding: 6px;
+      }
+
+      .amy-wave-preset-popup-title {
+        font-size: 11px;
+        font-weight: 600;
+        color: #ddd;
+        margin: 2px 4px 6px;
+      }
+
+      .amy-wave-preset-option {
+        width: 100%;
+        text-align: left;
+        border: none;
+        background: transparent;
+        color: #f0f0f0;
+        border-radius: 6px;
+        padding: 4px 6px;
+        font-size: 11px;
+        line-height: 1.2;
+      }
+
+      .amy-wave-preset-option:hover {
+        background: #2a2a2a;
+      }
+
+      .amy-wave-preset-option.is-selected {
+        background: #2f4737;
+        color: #bfe8c6;
       }
 
       .knob-spacer {

--- a/tulip/amyboardweb/static/pcm_presets.generated.js
+++ b/tulip/amyboardweb/static/pcm_presets.generated.js
@@ -1,0 +1,87 @@
+// Auto-generated from amy/src/pcm_tiny.h
+window.AMY_WAVE_PRESETS = {
+  "19": [
+    {
+      "name": "111.WAV",
+      "value": 11,
+      "wave": 19
+    },
+    {
+      "name": "BRAIDS01.WAV",
+      "value": 12,
+      "wave": 19
+    },
+    {
+      "name": "PPG_WA00.WAV",
+      "value": 13,
+      "wave": 19
+    },
+    {
+      "name": "SINE2SAW.WAV",
+      "value": 14,
+      "wave": 19
+    },
+    {
+      "name": "VIRAL.WAV",
+      "value": 15,
+      "wave": 19
+    }
+  ],
+  "7": [
+    {
+      "name": "808-MARACA-D",
+      "value": 0,
+      "wave": 7
+    },
+    {
+      "name": "808-KIK 4-D",
+      "value": 1,
+      "wave": 7
+    },
+    {
+      "name": "808-SNR 4-D",
+      "value": 2,
+      "wave": 7
+    },
+    {
+      "name": "808-SNR 7-D",
+      "value": 3,
+      "wave": 7
+    },
+    {
+      "name": "808-SNR 10D",
+      "value": 4,
+      "wave": 7
+    },
+    {
+      "name": "808-SNR 12-D",
+      "value": 5,
+      "wave": 7
+    },
+    {
+      "name": "808-C-HAT1-D",
+      "value": 6,
+      "wave": 7
+    },
+    {
+      "name": "808-O-HAT1-D",
+      "value": 7,
+      "wave": 7
+    },
+    {
+      "name": "808-LTOM M-D",
+      "value": 8,
+      "wave": 7
+    },
+    {
+      "name": "808-DRYCLP-D",
+      "value": 9,
+      "wave": 7
+    },
+    {
+      "name": "808-CWBELL-D",
+      "value": 10,
+      "wave": 7
+    }
+  ]
+};

--- a/tulip/amyboardweb/static/spss.js
+++ b/tulip/amyboardweb/static/spss.js
@@ -662,8 +662,38 @@ async function write_current_patches_file_from_knobs() {
   }
   mp.FS.writeFile(CURRENT_PATCH_FILE, allMessages.join("\n") + "\n");
   await sync_persistent_fs();
+  refresh_editor_if_viewing_patches_file();
 }
 window.write_current_patches_file_from_knobs = write_current_patches_file_from_knobs;
+
+function is_selected_file_patches_file() {
+  if (!selected_environment_file || typeof selected_environment_file !== "string") {
+    return false;
+  }
+  return selected_environment_file.toLowerCase().endsWith("patches.txt");
+}
+
+function refresh_editor_if_viewing_patches_file() {
+  if (!editor || !is_selected_file_patches_file()) {
+    return false;
+  }
+  try {
+    var latest = mp.FS.readFile(CURRENT_PATCH_FILE, { encoding: "utf8" });
+    if (editor.getValue() !== latest) {
+      editor.setValue(latest);
+    }
+    environment_editor_dirty = false;
+    editor.scrollTo(0, 0);
+    setTimeout(function () { editor.save(); }, 50);
+    setTimeout(function () {
+      editor.refresh();
+      editor.scrollTo(0, 0);
+    }, 100);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
 
 window.refresh_knobs_for_active_channel = async function(options) {
   var opts = options || {};


### PR DESCRIPTION
## Summary
- add PCM to wave options and generate PCM/WAVETABLE preset lists from `pcm_tiny.h`
- make wave labels clickable (PCM/WAVETABLE) with compact preset popup + underline styling
- persist wave preset selection in knob state and restore it via patch parsing
- refresh `patches.txt` editor view after writes and reset editor scroll to top-left
- simplify load/write flow so `set_knobs_from_patch_number` remains the source of knob state truth
- fix LFO wave restore so imported/loaded `v2w*` values are preserved instead of snapping to triangle

## Validation
- syntax checks:
  - `node --check tulip/amyboardweb/static/editor_knobs.js`
  - `node --check tulip/amyboardweb/static/amy_parameters.js`
  - `node --check tulip/amyboardweb/static/spss.js`
- manually verified behavior with env load + `patches.txt` rewrite flow
