### PR TITLE
amyboardweb: reduce sysex delay and fix tar_extract truncation

### DIFF
--- a/tulip/amyboardweb/static/spss.js
+++ b/tulip/amyboardweb/static/spss.js
@@ -2177,7 +2177,7 @@ async function sysex_write_amy_message(message) {
         throw new Error("Selected MIDI output does not support sysex send.");
     }
     // Matches amy.sysex_write pacing to avoid overrunning USB-MIDI consumers.
-    await sleep_ms(100);
+    await sleep_ms(25);
 }
 
 async function open_send_to_amyboard_modal() {

--- a/tulip/shared/py/tulip.py
+++ b/tulip/shared/py/tulip.py
@@ -383,10 +383,12 @@ def tar_extract(file_name, show_progress=True):
             else:
                 if(show_progress): print("extracting:", i.name)
                 sub_file = tar.extractfile(i)
-                data = sub_file.read()
                 try:
                     with open(i.name, "wb") as dest:
-                        dest.write(data)
-                        dest.close()
+                        while True:
+                            data = sub_file.read(4096)
+                            if not data:
+                                break
+                            dest.write(data)
                 except OSError as error:
                     if(show_progress): print("borked on:", i.name)


### PR DESCRIPTION
## Summary
- reduce amyboardweb sysex inter-transfer pacing from 100ms to 25ms
- fix `tulip.tar_extract` to stream file data instead of single-read

## Why
- sysex transfer pacing was intentionally tuned and is now lowered
- large files extracted from tar were truncated at 65536 bytes because `utarfile.FileSection.read()` defaults to 64KiB when called once without size

## Validation
- verified source locations and logic:
  - `tulip/amyboardweb/static/spss.js` sysex pacing now uses `sleep_ms(25)`
  - `tulip/shared/py/tulip.py` extraction now loops until EOF via `sub_file.read(4096)`
