### PR TITLE
sketches/methodical_mid: import tulip

### DIFF
--- a/tulip/amyboardweb/sketches/methodical_mid.py
+++ b/tulip/amyboardweb/sketches/methodical_mid.py
@@ -1,7 +1,7 @@
 # AMYboard Sketch
 # Top-level code runs once at boot. loop() runs repeatedly (~60ms).
 # DESCRIPTION: Play a MIDI file
-import amyboard, amy
+import amyboard, amy, tulip
 import umidiparser
 
 # Render using Juno patch 9


### PR DESCRIPTION
## Summary
One-line sketch update: `methodical_mid.py` now imports `tulip` in addition to `amyboard` and `amy`.

## Test plan
- [x] Committed from user's local working tree after amyboard-py restructuring
- [ ] `deploy_sketches.py` will re-upload this to AMYboard World after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)