### PR TITLE
fs_create: include .mid in whitelist (case-insensitive)

### DIFF
--- a/tulip/amyboard/amyboard_fs_create.py
+++ b/tulip/amyboard/amyboard_fs_create.py
@@ -22,8 +22,9 @@ if(not os.path.exists('build/flash_args')):
 
 SYSTEM_HOME = "../fs/amyboard"
 
-# Copy over only these extensions 
-good_exts = [".txt", ".png", ".py", ".json", ".obj", ".wav"]
+# Copy over only these extensions (compared case-insensitively, so .MID
+# and .mid both match).
+good_exts = [".txt", ".png", ".py", ".json", ".obj", ".wav", ".mid"]
 # And these folders
 source_folders = ['app','ex','im']
 
@@ -71,7 +72,7 @@ for folder in folders:
     lfs.mkdir(fs,folder)
     for file in os.listdir(folder):
         file_part, ext = os.path.splitext(file)
-        if(ext in good_exts):
+        if(ext.lower() in good_exts):
             copy_to_lfs(folder+'/'+file, folder+'/'+file)
 
 os.chdir(cur_dir)

--- a/tulip/fs_create.py
+++ b/tulip/fs_create.py
@@ -26,8 +26,9 @@ if(not os.path.exists('build/flash_args')):
 
 SYSTEM_HOME = "../fs/%s" % (distro)
 
-# Copy over only these extensions 
-good_exts = [".txt", ".png", ".py", ".json", ".obj", ".wav"]
+# Copy over only these extensions (compared case-insensitively, so .MID
+# and .mid both match).
+good_exts = [".txt", ".png", ".py", ".json", ".obj", ".wav", ".mid"]
 # And these folders
 source_folders = ['app','ex','im']
 
@@ -70,7 +71,7 @@ for folder in folders:
     lfs.mkdir(fs,folder)
     for file in os.listdir(folder):
         file_part, ext = os.path.splitext(file)
-        if(ext in good_exts):
+        if(ext.lower() in good_exts):
             copy_to_lfs(folder+'/'+file, folder+'/'+file)
 
 os.chdir(cur_dir)


### PR DESCRIPTION
## Summary

\`tulip/fs_create.py\` and \`tulip/amyboard/amyboard_fs_create.py\` hardcoded a whitelist of shipped extensions (\`.txt .png .py .json .obj .wav\`) with a case-sensitive check, so \`tulip/fs/amyboard/ex/Methodical.MID\` was silently skipped when packaging the AMYboard sys partition — present on AMYboard World (web) but missing from flashed hardware.

## Fix

- Add \`.mid\` to \`good_exts\`
- Lowercase \`ext\` before membership check so \`.MID\`/\`.mid\`/\`.Mid\` all match

Applied to both \`tulip/fs_create.py\` (the one \`release.sh\` actually calls) and the legacy \`tulip/amyboard/amyboard_fs_create.py\` standalone copy.

## Test plan

- [x] Rerun \`python fs_create.py amyboard\` against existing build, grep resulting \`amyboard-sys.bin\` for \`Methodical\` → found
- [x] Flashed v-apr-2026 \`amyboard-full-AMYBOARD.bin\` (already replaced on release) and confirmed hardware filesystem now contains \`/sys/ex/Methodical.MID\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)