### PR TITLE
amyboardweb: upgrade-complete reload link + mode=simulate example links

### DIFF
--- a/tulip/amyboardweb/static/esptool/index.html
+++ b/tulip/amyboardweb/static/esptool/index.html
@@ -93,7 +93,7 @@
             <div class="progress-bar hidden"><div></div></div>
           </div>
           <div id="upgradeComplete" class="upgrade-complete hidden">
-            Upgrade complete. Make sure to hit RST to reboot your AMYboard.
+            Upgrade complete. Make sure to hit RST to reboot your AMYboard and then <a href="#" onclick="window.location.reload(); return false;">reload this page</a>.
           </div>
         </div>
       </div>

--- a/tulip/amyboardweb/static/index.html
+++ b/tulip/amyboardweb/static/index.html
@@ -643,79 +643,79 @@
     <h2 class="section-title">What it can do</h2>
     <p style="font-size:1.2rem; font-weight:500; margin-bottom:2rem; opacity:0.85;">Try out some examples on <a href="/editor/" style="color:#FFDD00; text-decoration:underline; text-underline-offset:3px;">AMYboard online</a>, and send them to your AMYboard in seconds!</p>
     <div class="can-do-grid">
-      <a href="/editor/?env=acid_generator&user=shorepine&tab=patch" class="can-do-item" style="text-decoration:none; color:#fff;">
+      <a href="/editor/?mode=simulate&env=acid_generator&user=shorepine&tab=patch" class="can-do-item" style="text-decoration:none; color:#fff;">
         <span class="can-do-title">Generative Acid patch (303 + 808)</span>
         <span class="can-do-desc">We set up a TB303 and 808 and play a generative pattern. Twiddle the knobs!!</span>
       </a>
-      <a href="/editor/?env=woodpiano&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
+      <a href="/editor/?mode=simulate&env=woodpiano&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
         <span class="can-do-title">A custom 4-op FM synth</span>
         <span class="can-do-desc">We set up a custom ALGO patch in Python modeled after the infamous WOOD PIANO preset.</span>
       </a>
-      <a href="/editor/?env=methodical_mid&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
+      <a href="/editor/?mode=simulate&env=methodical_mid&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
         <span class="can-do-title">Play a MIDI file</span>
         <span class="can-do-desc">We load a MIDI file from disk and play it with a synth patch.</span>
       </a>
-      <a href="/editor/?env=spacey&user=shorepine&tab=patch" class="can-do-item" style="text-decoration:none; color:#fff;">
+      <a href="/editor/?mode=simulate&env=spacey&user=shorepine&tab=patch" class="can-do-item" style="text-decoration:none; color:#fff;">
         <span class="can-do-title">A spacey synth patch</span>
         <span class="can-do-desc">Global effects (echo, reverb) on top of a slow envelope over PWM.</span>
       </a>
-      <a href="/editor/?env=cvfilter&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
+      <a href="/editor/?mode=simulate&env=cvfilter&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
         <span class="can-do-title">Control your filters with CV input</span>
         <span class="can-do-desc">We use the AMY CtrlCoef EXT0 to have CV input modulate the filter frequency.</span>
       </a>
-      <a href="/editor/?env=audiopassthru&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
+      <a href="/editor/?mode=simulate&env=audiopassthru&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
         <span class="can-do-title">Convert between SPDIF and analog audio</span>
         <span class="can-do-desc">Set up AMY to pass AUDIO_IN to AUDIO_OUT so that S/PDIF outputs over analog line-out, and vice versa.</span>
       </a>
-      <a href="/editor/?env=midi2cv&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
+      <a href="/editor/?mode=simulate&env=midi2cv&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
         <span class="can-do-title">MIDI controller to CV</span>
         <span class="can-do-desc">We set up a callback to get MIDI controller data and output scaled CV values.</span>
       </a>
-      <a href="/editor/?env=dx7filt&user=shorepine&tab=patch" class="can-do-item" style="text-decoration:none; color:#fff;">
+      <a href="/editor/?mode=simulate&env=dx7filt&user=shorepine&tab=patch" class="can-do-item" style="text-decoration:none; color:#fff;">
         <span class="can-do-title">DX7 setup with filter and reverb</span>
         <span class="can-do-desc">Try setting the MIDI CC for VCF freq!</span>
       </a>
-      <a href="/editor/?env=arp&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
+      <a href="/editor/?mode=simulate&env=arp&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
         <span class="can-do-title">Arpeggiator</span>
         <span class="can-do-desc">Uses MIDI input callbacks and the AMY sequencer to set up an arpeggiator</span>
       </a>
-      <a href="/editor/?env=audiopassthru&user=shorepine&tab=patch" class="can-do-item" style="text-decoration:none; color:#fff;">
+      <a href="/editor/?mode=simulate&env=audiopassthru&user=shorepine&tab=patch" class="can-do-item" style="text-decoration:none; color:#fff;">
         <span class="can-do-title">Echo / reverb on live audio</span>
         <span class="can-do-desc">Shows how to use AUDIO_IN to add effects on live audio. Turn on "allow audio input" on the web and move the effects!</span>
       </a>
-      <a href="/editor/?env=chords&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
+      <a href="/editor/?mode=simulate&env=chords&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
         <span class="can-do-title">Chord computer</span>
         <span class="can-do-desc">Plays chords based on a root note.</span>
       </a>
-      <a href="/editor/?env=wavfile&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
+      <a href="/editor/?mode=simulate&env=wavfile&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
         <span class="can-do-title">Load a wav file into a sampler</span>
         <span class="can-do-desc">Loads a WAVE file from disk (can also be SD card) and plays it back as a sampler.</span>
       </a>
-      <a href="/editor/?env=xanadu&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
+      <a href="/editor/?mode=simulate&env=xanadu&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
         <span class="can-do-title">Xanadu</span>
         <span class="can-do-desc">Joseph Kung's "Xanadu" for Csound, ported to AMY commands in code.</span>
       </a>
-      <a href="/editor/?env=wavetable&user=shorepine&tab=patch" class="can-do-item" style="text-decoration:none; color:#fff;">
+      <a href="/editor/?mode=simulate&env=wavetable&user=shorepine&tab=patch" class="can-do-item" style="text-decoration:none; color:#fff;">
         <span class="can-do-title">Wavetable patch</span>
         <span class="can-do-desc">Uses our WAVETABLE oscillator type to play wavetable synthesis.</span>
       </a>
-      <a href="/editor/?env=patchselector&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
+      <a href="/editor/?mode=simulate&env=patchselector&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
         <span class="can-do-title">Patch Selector on OLED</span>
         <span class="can-do-desc">Our built in patch selector, use the rotary encoder to select different saved patches, press to select.</span>
       </a>
-      <a href="/editor/?env=preset_selector&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
+      <a href="/editor/?mode=simulate&env=preset_selector&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
         <span class="can-do-title">Preset Selector</span>
         <span class="can-do-desc">Sets up the rotary encoder to cycle through all 257 AMYboard presets.</span>
       </a>
-      <a href="/editor/?env=piano&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
+      <a href="/editor/?mode=simulate&env=piano&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
         <span class="can-do-title">Additive-synthesis piano</span>
         <span class="can-do-desc">Uses the AMY dpwe piano patch, fully synthesized from partial analysis.</span>
       </a>
-      <a href="/editor/?env=house_generator&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
+      <a href="/editor/?mode=simulate&env=house_generator&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
         <span class="can-do-title">Generative House</span>
         <span class="can-do-desc">A generative house track with 808 drums, Wood Piano bassline, and piano chords over evolving progressions.</span>
       </a>
-      <a href="/editor/?env=universal_hair&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
+      <a href="/editor/?mode=simulate&env=universal_hair&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
         <span class="can-do-title">Evolving Chords</span>
         <span class="can-do-desc">Lush evolving chord progressions with layered synths and generative voice leading.</span>
       </a>


### PR DESCRIPTION
## Summary

Two small marketing-site polish items:

1. **Firmware upgrade page**: the yellow "Upgrade complete" banner now reads "Make sure to hit RST to reboot your AMYboard **and then reload this page**." with "reload this page" as an inline anchor that triggers \`window.location.reload()\`. A page reload is what re-enumerates the freshly-flashed board's USB device, so prompting for it is less confusing than leaving users wondering why the flasher can't reconnect.

2. **Homepage examples grid**: all 19 "Try out some examples" cards on \`static/index.html\` now link to \`/editor/?mode=simulate&env=...\` so clicking any of them lands the user directly in Simulate mode and skips the mode-picker modal on first visit.

## Test plan

- [x] \`grep -c 'href="/editor/?mode=simulate&env='\` → 19 (all updated)
- [x] \`grep -c 'href="/editor/?env='\` → 0 (no stragglers)
- [ ] Smoke test: click an example card and verify it loads straight into simulate mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)