### PR TITLE
spss.js: fix deep-link sketch doubling + Reset not silencing

### DIFF
--- a/tulip/amyboardweb/static/spss.js
+++ b/tulip/amyboardweb/static/spss.js
@@ -7,6 +7,10 @@ var amy_process_single_midi_byte = null;
 var audio_started = false;
 var amy_sysclock = null;
 var amyboard_started = false;
+// Deep-link guard: set in start_amyboard() when the initial URL has ?env=... ,
+// read later in start_audio() after check_url_env_params() has mutated the URL.
+// Keeps the default run_sketch() path from racing the deferred world-load.
+var _url_env_pending = false;
 var amy_yield_patch_events = null;
 var amy_yield_synth_commands = null;
 var amy_dump_state_to_string_c = null;
@@ -4437,8 +4441,11 @@ async function start_amyboard() {
 
   // Load sketch.py into the editor so the user can see/edit it before clicking to start audio.
   // The actual run_sketch() (applying knobs + starting loop) is deferred to start_audio().
-  var urlEnvPending = !!(new URLSearchParams(window.location.search).get("env"));
-  if (!urlEnvPending) {
+  // Use a persistent module-level flag (set before check_url_env_params mutates
+  // window.location.search) so start_audio() later still knows the deep-link
+  // sketch is pending and doesn't race a default run_sketch() against it.
+  _url_env_pending = !!(new URLSearchParams(window.location.search).get("env"));
+  if (!_url_env_pending) {
     var _pendingSketch = "";
     try { _pendingSketch = mp.FS.readFile(CURRENT_ENV_DIR + '/sketch.py', { encoding: 'utf8' }); } catch (e) {}
     if (!_pendingSketch) _pendingSketch = _get_default_sketch();
@@ -4498,8 +4505,11 @@ async function start_audio() {
 
   // Audio is now running and AMY can process messages — run sketch.py the same
   // way hardware does: apply _auto_generated_knobs, import sketch.py, start loop().
-  var urlEnvPending = !!(new URLSearchParams(window.location.search).get("env"));
-  if (mp && !urlEnvPending) {
+  // Read the persistent flag (set in start_amyboard before check_url_env_params
+  // cleared the URL query string) — do NOT re-parse window.location.search here,
+  // it's been mutated by that point and would falsely return false, causing us
+  // to race a default run_sketch() against check_url_env_params's deferred load.
+  if (mp && !_url_env_pending) {
     // Init synth 1 with default Juno patch before run_sketch applies knobs.
     // On main, restore_patch_state_from_files did this. Without it, synth 1
     // doesn't exist and _apply_knobs_text fails with "synth not defined".


### PR DESCRIPTION
## Summary

Loading a deep-link URL like \`/editor/?mode=simulate&env=acid_generator&user=shorepine&tab=patch\` from the marketing homepage caused the sketch to play **twice** (slightly offset), and Reset wouldn't fully silence it — partial sound kept going no matter how many times you hit it.

Navigating to \`?mode=simulate\` without the deep-link and loading the same sketch from AMYboard World manually worked fine, which isolated the bug to the URL-param auto-load path.

## Root cause

Race between two code paths reading the same \`?env\` query string at different times:

1. \`start_amyboard()\` reads \`?env=...\` → \`urlEnvPending = true\` → correctly skips writing the default sketch into the editor.
2. \`check_url_env_params()\` sees \`?env=...\` and schedules \`load_world_environment_by_name\` in 1500 ms, **then calls \`history.replaceState({}, title, pathname)\`** — which wipes the query string from the URL.
3. User clicks the Welcome modal, \`start_audio()\` runs: re-parses \`window.location.search.get('env')\`, gets \`null\`, sets local \`urlEnvPending = false\`, and runs the default \`amyboard.run_sketch()\` path → **sketch #1 starts** (from whatever sketch.py happened to be on disk at boot).
4. ~500 ms later, the \`setTimeout\` from step 2 fires: writes the downloaded sketch.py, calls \`amyboard.restart_sketch()\` → **sketch #2 starts**.

Two concurrent MicroPython background tasks → doubled playback offset by the delta. Reset only kills the one \`restart_sketch()\` tracks internally, so the other survives.

## Fix

Promote the local \`urlEnvPending\` in \`start_amyboard()\` to a module-level \`_url_env_pending\` captured **before** \`check_url_env_params()\` mutates the URL. \`start_audio()\` reads that flag instead of re-parsing \`window.location.search\`, so it correctly skips the default \`run_sketch()\` path when a deep-link load is in flight.

## Test plan

- [x] Hard-reload \`localhost:8000/editor/?mode=simulate&env=acid_generator&user=shorepine&tab=patch\` → only one sketch instance runs
- [x] Click Reset → sketch fully stops
- [x] Navigate to \`?mode=simulate\` without env param → load acid_generator from AMYboard World tab → still works the same as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)