### PR TITLE
grab_submodules: patch mpy-cross for macOS Tahoe / clang 19+

### DIFF
--- a/tulip/shared/grab_submodules.sh
+++ b/tulip/shared/grab_submodules.sh
@@ -12,17 +12,37 @@ else
     git submodule update --init amy
     git submodule update --init micropython
     cd micropython
-    # Patch mpy-cross warnings for newer clang versions on macOS.
-    if ! grep -q -- "-Wno-gnu-folding-constant" mpy-cross/Makefile; then
-        sed -i.bak 's/^CWARN += /CWARN += -Wno-gnu-folding-constant /' mpy-cross/Makefile
-    fi
-    git submodule update --init lib/axtls 
-    git submodule update --init lib/libffi 
+    git submodule update --init lib/axtls
+    git submodule update --init lib/libffi
     git submodule update --init lib/mbedtls
     git submodule update --init lib/berkeley-db-1.xx
-    git submodule update --init lib/micropython-lib 
-    git submodule update --init lib/tinyusb 
+    git submodule update --init lib/micropython-lib
+    git submodule update --init lib/tinyusb
     cd ..
     touch .submodules_ok
+fi
+
+# Patch micropython/mpy-cross/Makefile for newer Apple clang tightenings.
+# Run every invocation (even when .submodules_ok exists) and gate each
+# individual sed on a grep so it stays idempotent. This way users whose
+# submodules are already set up pick up fresh patches when they update
+# macOS to a clang version that added new default warnings, without
+# having to rm .submodules_ok.
+#
+# -Wno-gnu-folding-constant               — Apple clang tightening, earlier round
+# -Wno-unknown-warning-option             — stop older clangs from erroring on
+#                                           flag names they don't recognize yet
+# -Wno-unterminated-string-initialization — macOS Tahoe / clang >= 19 turned the
+#                                           {10,"r10"} style init into an error;
+#                                           py/emitinlinethumb.c uses this
+#                                           pattern intentionally (3-char array,
+#                                           null byte deliberately dropped).
+if [ -f micropython/mpy-cross/Makefile ]; then
+    if ! grep -q -- "-Wno-gnu-folding-constant" micropython/mpy-cross/Makefile; then
+        sed -i.bak 's/^CWARN += /CWARN += -Wno-gnu-folding-constant /' micropython/mpy-cross/Makefile
+    fi
+    if ! grep -q -- "-Wno-unterminated-string-initialization" micropython/mpy-cross/Makefile; then
+        sed -i.bak 's/^CWARN += /CWARN += -Wno-unknown-warning-option -Wno-unterminated-string-initialization /' micropython/mpy-cross/Makefile
+    fi
 fi
 popd > /dev/null


### PR DESCRIPTION
## Summary

macOS Tahoe 26 ships Apple clang (LLVM 19+) which adds \`-Wunterminated-string-initialization\` as a default \`-Wall\` diagnostic. \`micropython/mpy-cross/Makefile\` compiles with \`-Werror\`, so fresh clones on Tahoe fail at \`py/emitinlinethumb.c:163\` — the \`{10, "r10"}\` pattern is a 3-char array intentionally dropping the null terminator.

## Fix

Extend the existing \`grab_submodules.sh\` patch (which already adds \`-Wno-gnu-folding-constant\`) with two more flags:

- \`-Wno-unterminated-string-initialization\` — silences the Tahoe-era warning
- \`-Wno-unknown-warning-option\` (prepended) — so older clangs that don't recognize the new flag name don't fail \`-Werror\` on an "unknown warning option" warning

gcc silently ignores unknown \`-Wno-*\` flags so Linux builds stay fine.

Also moved the Makefile patch *out* of the \`.submodules_ok\` gate. Previously, a colleague who'd already set up submodules and then upgraded their macOS would have to \`rm .submodules_ok\` and rerun to pick up the new patch. Now it always runs, kept idempotent by each \`sed\` being gated behind its own \`grep\`.

## Test plan

- [x] Ran \`./grab_submodules.sh\` twice — second run is a no-op (idempotent)
- [x] \`make\` in \`mpy-cross\` builds clean on macOS (after patch)
- [ ] Colleague on macOS Tahoe 26.4.1 can \`git pull\` + \`./tulip/shared/grab_submodules.sh\` (no \`rm .submodules_ok\` needed) → fresh tulipcc build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)