### PR TITLE
amyboardweb: update embedded homepage video

### DIFF
--- a/tulip/amyboardweb/static/index.html
+++ b/tulip/amyboardweb/static/index.html
@@ -632,7 +632,7 @@
   <div class="container">
     <h2 class="section-title">Hear it in action</h2>
     <div class="video-wrapper">
-      <iframe src="https://www.youtube.com/embed/1lYFjQp7Xrw?si=FaSXGabzvbs0BGeF" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      <iframe src="https://www.youtube.com/embed/00TVvMiIWes" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
     </div>
   </div>
 </section>


### PR DESCRIPTION
One-line swap of the YouTube embed on the amyboard.com homepage to https://www.youtube.com/watch?v=00TVvMiIWes