### PR TITLE
amyboardweb: restore hero video max-width to 960px

### DIFF
--- a/tulip/amyboardweb/static/index.html
+++ b/tulip/amyboardweb/static/index.html
@@ -331,7 +331,7 @@
     /* ── VIDEO ── */
     .video-wrapper {
       width: 100%;
-      max-width: 720px;       /* ~75% of the old 960px */
+      max-width: 960px;
       aspect-ratio: 16 / 9;   /* 16:9 YouTube aspect */
       margin: 0 auto;
     }


### PR DESCRIPTION
Revert the 720px shrink. Keep the 16:9 aspect ratio and updated video URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)