### PR TITLE
homepage: Arduino link → arduino.md

### DIFF
--- a/tulip/amyboardweb/static/index.html
+++ b/tulip/amyboardweb/static/index.html
@@ -628,7 +628,7 @@
       <div class="feature-item">Two CV in and out jacks</div>
       <div class="feature-item">MIDI in and out (Type A or B switchable)</div>
       <div class="feature-item">I2C port for <a href="https://github.com/shorepine/tulipcc/blob/main/docs/amyboard/accessories.md">DIY accessories</a></div>
-      <div class="feature-item">Ships with Micropython firmware, compatible with our <a href="/editor/">online editor</a>, or use <a href="https://github.com/shorepine/tulipcc/blob/main/docs/amyboard/accessories.md">Arduino</a> or your own firmware</div>
+      <div class="feature-item">Ships with Micropython firmware, compatible with our <a href="/editor/">online editor</a>, or use <a href="https://github.com/shorepine/tulipcc/blob/main/docs/amyboard/arduino.md">Arduino</a> or your own firmware</div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
One-line href fix. Was pointing at accessories.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)