### PR TITLE
amyboardweb: restore DX7 patch levels; skip disabled panes on DX7

### DIFF
--- a/tulip/amyboardweb/static/amy_parameters.js
+++ b/tulip/amyboardweb/static/amy_parameters.js
@@ -62,7 +62,7 @@ window.addEventListener("DOMContentLoaded", function() {
       section: "Osc A",
       cc: "",
       display_name: "level",
-      change_code: "i%iv" + OSCA_OSC + "a%v,,0,0",
+      change_code: "i%iv" + OSCA_OSC + "a%v",
       knob_type: "log",
       default_value: 1.0,
       amy_default: 1.0,       // amp_coefs[EG0] = 1.0
@@ -180,7 +180,7 @@ window.addEventListener("DOMContentLoaded", function() {
       section: "Osc B",
       cc: "",
       display_name: "level",
-      change_code: "i%iv" + OSCB_OSC + "a%v,,0,0",
+      change_code: "i%iv" + OSCB_OSC + "a%v",
       knob_type: "log",
       default_value: 1.0,
       amy_default: 1.0,       // amp_coefs[EG0] = 1.0
@@ -679,7 +679,9 @@ window.addEventListener("DOMContentLoaded", function() {
       init_knobs(globalKnobs, "knob-grid-global");
     }
     if (typeof window.onKnobCcChange === "function") {
+      const disabledSections = window._disabled_sections || {};
       for (const knob of knobs) {
+        if (disabledSections[knob.section]) continue;
         if (knob.knob_type !== "spacer" && knob.knob_type !== "spacer-half"
           && knob.knob_type !== "pushbutton") {
           window.onKnobCcChange(knob);

--- a/tulip/amyboardweb/static/editor/index.html
+++ b/tulip/amyboardweb/static/editor/index.html
@@ -2142,6 +2142,13 @@
                     // Apply VCF coda so analog filter controls work with DX7
                     amy_send({synth: presetSynth, osc: 0, eg1_type: AMY.ENVELOPE_NORMAL, filter_type: AMY.FILTER_LPF24, filter_freq: "8000,1,0,0,4.0,0", bp1: "0,1,0,1,10000,0", resonance: 0.7}, true);
                   }
+                  // Mark disabled panes before sending CC mappings so disabled-section
+                  // knobs don't blast initial ic updates to AMY for DX7 presets.
+                  if (typeof window.set_section_disabled === "function") {
+                    window.set_section_disabled("Osc A", isDX7Preset);
+                    window.set_section_disabled("Osc B", isDX7Preset);
+                    window.set_section_disabled("ADSR", isDX7Preset);
+                  }
                   // In control mode, skip sending knob CC mappings — they race with the
                   // patch load over sysex and can overwrite the K command. The hardware
                   // doesn't need them; knob state is read back via sync_knobs_from_hardware.
@@ -2155,6 +2162,7 @@
                 if (typeof sync_channel_knobs_from_synth_to_ui === "function") {
                   sync_channel_knobs_from_synth_to_ui(presetSynth).then(function() {
                     if (typeof window.set_section_disabled === "function") {
+                      window.set_section_disabled("Osc A", isDX7Preset);
                       window.set_section_disabled("Osc B", isDX7Preset);
                       window.set_section_disabled("ADSR", isDX7Preset);
                     }

--- a/tulip/amyboardweb/static/spss.js
+++ b/tulip/amyboardweb/static/spss.js
@@ -1101,7 +1101,9 @@ function send_all_knob_cc_mappings(channel) {
   var ch = Number(channel);
   if (!Number.isInteger(ch) || ch < 1 || ch > 16) ch = 1;
   var knobs = get_knobs_for_channel(ch);
+  var disabledSections = window._disabled_sections || {};
   for (var i = 0; i < knobs.length; i++) {
+    if (knobs[i] && disabledSections[knobs[i].section]) continue;
     var ccVal = build_knob_cc_value(knobs[i]);
     if (ccVal) {
       amy_send({synth: ch, midi_cc: ccVal}, true);
@@ -4846,6 +4848,7 @@ function apply_zd_dump_to_knobs(dumpText) {
         if (typeof window.set_section_disabled === "function") {
             var oscsPerVoice = num_oscs_from_patch_file_content(wireLines.join('\n'));
             var isDX7 = oscsPerVoice >= 8;
+            window.set_section_disabled("Osc A", isDX7);
             window.set_section_disabled("Osc B", isDX7);
             window.set_section_disabled("ADSR", isDX7);
         }


### PR DESCRIPTION
## Summary
- Drop trailing `,,0,0` from OSCA/OSCB level `change_code` in `amy_parameters.js` so the `a` (amp) command no longer clobbers EG0/LFO coefs — mostly-restores DX7 patch sound.
- Disable the **Osc A** pane (in addition to Osc B + ADSR) for DX7 presets across all three load paths: the editor preset loader (`editor/index.html`), `spss.js` patch loader (`load_saved_patch_file_into_current_channel`), and `apply_zd_dump_to_knobs` (Pull).
- Stop blasting initial knob-CC updates for disabled panes on DX7 preset load:
  - `send_all_knob_cc_mappings` (spss.js) skips knobs whose section is in `window._disabled_sections`.
  - `refresh_knobs_for_channel` (amy_parameters.js) skips the `onKnobCcChange` loop for those knobs.
  - The editor preset loader now marks Osc A / Osc B / ADSR disabled **before** calling `send_all_knob_cc_mappings`, so the skip takes effect on first load.

Deployed to https://amyboard-wip.vercel.app for collaborator testing.

## Test plan
- [ ] Load a DX7 preset: Osc A, Osc B, ADSR panes are all visibly disabled.
- [ ] Load a DX7 preset: no `ic…` wire commands go out to AMY for Osc A / Osc B / ADSR knobs on initial load.
- [ ] DX7 patches actually make sound (the `,,0,0` removal should restore amp).
- [ ] Load a non-DX7 (AMYboard/Juno) preset: all panes remain enabled and knob CC mappings send normally.
- [ ] Pull in control mode applies the same disable + skip behavior via `apply_zd_dump_to_knobs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)