### PR TITLE
Fix amy.load_sample regression; new ABW sketches; marketing tile cleanup

### DIFF
--- a/tulip/amyboardweb/sketches/arp.py
+++ b/tulip/amyboardweb/sketches/arp.py
@@ -1,0 +1,59 @@
+# AMYboard Sketch
+# Top-level code runs once at boot. loop() runs repeatedly (~60ms).
+# DESCRIPTION: Hold MIDI keys; plays them in order as 8th-note arpeggios.
+import amy, midi, tulip
+
+# Free up channel 1 (default synth) and put our voice on synth 17.
+amy.send(synth=1, num_voices=0)
+amy.send(synth=17, patch=257, num_voices=6)
+
+# 8th note at 120 BPM = 250 ms per step.
+STEP_MS = 250
+
+held = set()           # midi note numbers currently held down
+arp_idx = 0            # next index into the sorted held list to play
+last_played = None     # most recently triggered note (so we can release it)
+last_step_ms = 0       # last time we advanced the arp
+
+
+def midi_cb(m):
+    if not m or len(m) < 3:
+        return
+    status = m[0] & 0xF0
+    note = m[1]
+    vel = m[2]
+    if status == 0x90 and vel > 0:
+        held.add(note)
+    elif status == 0x80 or (status == 0x90 and vel == 0):
+        held.discard(note)
+
+
+midi.add_callback(midi_cb)
+
+
+def loop():
+    global arp_idx, last_played, last_step_ms
+    now = tulip.amy_ticks_ms()
+    if now - last_step_ms < STEP_MS:
+        return
+    last_step_ms = now
+
+    # Release the previous step's note before triggering the next one.
+    if last_played is not None:
+        amy.send(synth=17, note=last_played, vel=0)
+        last_played = None
+
+    if not held:
+        arp_idx = 0
+        return
+
+    notes = sorted(held)
+    arp_idx %= len(notes)
+    n = notes[arp_idx]
+    amy.send(synth=17, note=n, vel=0.8)
+    last_played = n
+    arp_idx += 1
+
+# Do not edit. Set automatically by the knobs on AMYboard Online.
+_auto_generated_knobs = """
+"""

--- a/tulip/amyboardweb/sketches/chords.py
+++ b/tulip/amyboardweb/sketches/chords.py
@@ -1,0 +1,49 @@
+# AMYboard Sketch
+# Top-level code runs once at boot. loop() runs repeatedly (~60ms).
+# DESCRIPTION: Each MIDI key triggers a major chord rooted at that key.
+import amy, midi
+from music import Chord
+
+# Free up channel 1 (default synth) and put our voice on synth 17.
+amy.send(synth=1, num_voices=0)
+amy.send(synth=17, patch=257, num_voices=6)
+
+ROOT_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']
+
+# Per-root midi notes currently sounding so we can release them on note off.
+active = {}
+
+
+def chord_for_root(root_midi):
+    """Return midi notes for a major chord rooted at root_midi."""
+    name = ROOT_NAMES[root_midi % 12]
+    c = Chord(name + ":maj")
+    return [root_midi + offset for offset in c.annotations]
+
+
+def midi_cb(m):
+    if not m or len(m) < 3:
+        return
+    status = m[0] & 0xF0
+    note = m[1]
+    vel = m[2]
+    if status == 0x90 and vel > 0:
+        notes = chord_for_root(note)
+        active[note] = notes
+        v = vel / 127.0
+        for n in notes:
+            amy.send(synth=17, note=n, vel=v)
+    elif status == 0x80 or (status == 0x90 and vel == 0):
+        for n in active.pop(note, ()):
+            amy.send(synth=17, note=n, vel=0)
+
+
+midi.add_callback(midi_cb)
+
+
+def loop():
+    pass
+
+# Do not edit. Set automatically by the knobs on AMYboard Online.
+_auto_generated_knobs = """
+"""

--- a/tulip/amyboardweb/sketches/deploy_sketches.py
+++ b/tulip/amyboardweb/sketches/deploy_sketches.py
@@ -1,18 +1,24 @@
 #!/usr/bin/env python3
-"""Upload all official sketches to AMYboard World.
+"""Upload or verify official sketches against AMYboard World.
 
 Usage:
     WORLD_ADMIN_TOKEN=xxx python3 deploy_sketches.py
     WORLD_ADMIN_TOKEN=xxx WORLD_API_URL=https://... python3 deploy_sketches.py
+    python3 deploy_sketches.py --verify
 
 Uploads every .py file in this directory (except this script) to
 AMYboard World as username "shorepine". Parses "# DESCRIPTION: ..."
 from each file for the description field. Uses the filename stem as
 the sketch name.
 
-Requires WORLD_ADMIN_TOKEN for the reserved "shorepine" username.
+With --verify, fetches each shorepine sketch from ABW and compares
+content + description to the local copy. Reports mismatches and exits
+non-zero if any are found. No admin token is required for verify.
+
+Requires WORLD_ADMIN_TOKEN for the reserved "shorepine" username (upload only).
 """
 
+import json
 import os
 import re
 import sys
@@ -54,21 +60,124 @@ def upload(url, username, filename, description, file_data, admin_token):
     return urlopen(req, timeout=30)
 
 
+def collect_local_sketches():
+    """Return sorted list of local .py sketch filenames (excluding this script)."""
+    script_name = os.path.basename(__file__)
+    return sorted(
+        f for f in os.listdir(SCRIPT_DIR)
+        if f.endswith(".py") and f != script_name
+    )
+
+
+def fetch_remote_shorepine(api_url):
+    """Return dict mapping filename -> item metadata for shorepine ABW sketches."""
+    list_url = api_url + "/api/amyboardworld/files?limit=1000"
+    with urlopen(list_url, timeout=30) as resp:
+        data = json.loads(resp.read().decode("utf-8"))
+    items = data.get("items", [])
+    return {
+        i["filename"]: i
+        for i in items
+        if i.get("username") == USERNAME and i.get("item_type") == "environment"
+    }
+
+
+def fetch_remote_content(api_url, item):
+    """Return raw bytes of an ABW item's file content."""
+    url = api_url + item["download_url"]
+    with urlopen(url, timeout=30) as resp:
+        return resp.read()
+
+
+def verify(api_url):
+    """Compare each local sketch to its ABW shorepine counterpart.
+
+    Returns (mismatches, missing_remote, extra_remote) where each is a list.
+    """
+    local_files = collect_local_sketches()
+    remote = fetch_remote_shorepine(api_url)
+
+    print(f"Verifying {len(local_files)} local sketches against {api_url}")
+    print(f"Username: {USERNAME}")
+    print(f"Remote shorepine sketches: {len(remote)}")
+    print()
+
+    mismatches = []
+    missing_remote = []
+    ok = 0
+
+    for filename in local_files:
+        filepath = os.path.join(SCRIPT_DIR, filename)
+        with open(filepath, "rb") as f:
+            local_bytes = f.read()
+        local_desc = extract_description(local_bytes.decode("utf-8", errors="replace"))
+
+        item = remote.get(filename)
+        if item is None:
+            print(f"  {filename}: MISSING on ABW")
+            missing_remote.append(filename)
+            continue
+
+        try:
+            remote_bytes = fetch_remote_content(api_url, item)
+        except Exception as e:
+            print(f"  {filename}: FAILED to fetch remote: {e}")
+            mismatches.append((filename, f"fetch error: {e}"))
+            continue
+
+        remote_desc = item.get("description", "") or ""
+        problems = []
+        if remote_bytes != local_bytes:
+            problems.append(
+                f"content differs (local {len(local_bytes)}b, remote {len(remote_bytes)}b)"
+            )
+        if remote_desc != local_desc:
+            problems.append(
+                f"description differs (local={local_desc!r}, remote={remote_desc!r})"
+            )
+
+        if problems:
+            print(f"  {filename}: MISMATCH")
+            for p in problems:
+                print(f"    - {p}")
+            mismatches.append((filename, "; ".join(problems)))
+        else:
+            print(f"  {filename}: OK")
+            ok += 1
+
+    extra_remote = sorted(set(remote) - set(local_files))
+    if extra_remote:
+        print()
+        print("Remote shorepine sketches with no local file:")
+        for f in extra_remote:
+            print(f"  + {f}")
+
+    print()
+    print(
+        f"Summary: {ok} OK, {len(mismatches)} mismatched, "
+        f"{len(missing_remote)} missing on ABW, {len(extra_remote)} extra on ABW"
+    )
+    return mismatches, missing_remote, extra_remote
+
+
 def main():
+    args = sys.argv[1:]
+    api_url = os.environ.get("WORLD_API_URL", DEFAULT_URL)
+
+    if "--verify" in args:
+        mismatches, missing_remote, extra_remote = verify(api_url)
+        if mismatches or missing_remote or extra_remote:
+            sys.exit(1)
+        sys.exit(0)
+
     token = os.environ.get("WORLD_ADMIN_TOKEN", "")
     if not token:
         print("Error: WORLD_ADMIN_TOKEN environment variable must be set.")
         sys.exit(1)
 
-    api_url = os.environ.get("WORLD_API_URL", DEFAULT_URL)
     upload_url = api_url + "/api/amyboardworld/upload"
 
-    # Collect all .py files except this script
-    script_name = os.path.basename(__file__)
-    sketch_files = sorted(
-        f for f in os.listdir(SCRIPT_DIR)
-        if f.endswith(".py") and f != script_name
-    )
+    sketch_files = collect_local_sketches()
 
     if not sketch_files:
         print("No sketch files found.")

--- a/tulip/amyboardweb/sketches/midi2cv.py
+++ b/tulip/amyboardweb/sketches/midi2cv.py
@@ -1,0 +1,35 @@
+# AMYboard Sketch
+# Top-level code runs once at boot. loop() runs repeatedly (~60ms).
+# DESCRIPTION: MIDI to CV: notes -> 1V/oct on CV2, CC23 -> -10..10V on CV1.
+import amy, amyboard, midi
+
+# We're emitting CV, not playing audio. Disable the default synth on ch 1.
+amy.send(synth=1, num_voices=0)
+
+# CC# we treat as the modulation source for CV1.
+MOD_CC = 23
+
+
+def midi_cb(m):
+    if not m or len(m) < 3:
+        return
+    status = m[0] & 0xF0
+    a = m[1]
+    b = m[2]
+    if status == 0x90 and b > 0:
+        # 1 volt per octave on CV2 (channel=1). MIDI 0 = 0V, MIDI 12 = 1V, ...
+        amyboard.cv_out(a / 12.0, channel=1)
+    elif status == 0xB0 and a == MOD_CC:
+        # Scale CC value 0..127 to -10..+10V on CV1 (channel=0).
+        amyboard.cv_out((b / 127.0) * 20.0 - 10.0, channel=0)
+
+
+midi.add_callback(midi_cb)
+
+
+def loop():
+    pass
+
+# Do not edit. Set automatically by the knobs on AMYboard Online.
+_auto_generated_knobs = """
+"""

--- a/tulip/amyboardweb/sketches/sampler.py
+++ b/tulip/amyboardweb/sketches/sampler.py
@@ -1,0 +1,53 @@
+# AMYboard Sketch
+# Top-level code runs once at boot. loop() runs repeatedly (~60ms).
+# DESCRIPTION: Live sampler. Hold a MIDI key to record audio in; play it on synth 1.
+
+# How this works:
+#  1. synth 1 is configured as a 4-voice PCM player reading from preset 50.
+#  2. Every MIDI note-on calls amy.start_sample, which begins recording up to
+#     5 seconds (44100 * 5 frames) from the audio input bus into preset 50.
+#     The midi note is passed as the sample's natural pitch -- so when you
+#     play the same note back you hear it at the original speed; higher notes
+#     play faster, lower notes slower.
+#  3. The matching MIDI note-off calls amy.stop_sample to end the recording.
+#  4. Once a sample has been captured, hold any key on MIDI ch 1 to hear the
+#     audio you recorded, pitch-shifted to that note. Hit a new key to record
+#     a fresh sample over preset 50.
+#
+# Tip: turn on "allow audio input" in the web editor to record from your mic.
+
+import amy, midi
+
+PRESET = 50
+SR = 44100
+
+amy.send(synth=1, wave=amy.PCM, preset=PRESET, num_voices=4)
+
+# Track which note is currently driving a recording so we know when to stop.
+recording_note = None
+
+
+def midi_cb(m):
+    global recording_note
+    if not m or len(m) < 3:
+        return
+    status = m[0] & 0xF0
+    note = m[1]
+    vel = m[2]
+    if status == 0x90 and vel > 0:
+        recording_note = note
+        amy.start_sample(preset=PRESET, max_frames=SR * 5, midinote=note)
+    elif (status == 0x80 or (status == 0x90 and vel == 0)) and note == recording_note:
+        amy.stop_sample()
+        recording_note = None
+
+
+midi.add_callback(midi_cb)
+
+
+def loop():
+    pass
+
+# Do not edit. Set automatically by the knobs on AMYboard Online.
+_auto_generated_knobs = """
+"""

--- a/tulip/amyboardweb/sketches/universal_hair.py
+++ b/tulip/amyboardweb/sketches/universal_hair.py
@@ -1,4 +1,4 @@
-# DESCRIPTION: UNIVERSAL HAIR soundtrack  universalhair.net
+# DESCRIPTION: UNIVERSAL HAIR soundtrack universalhair.net
 # By Douglas Repetto
 # adapted by Dan Ellis
 

--- a/tulip/amyboardweb/sketches/wavfile.py
+++ b/tulip/amyboardweb/sketches/wavfile.py
@@ -1,0 +1,25 @@
+# AMYboard Sketch
+# Top-level code runs once at boot. loop() runs repeatedly (~60ms).
+# DESCRIPTION: Load a .wav file as a PCM instrument on synth 1.
+import amy, tulip
+
+# Built-in tulipcc samples live under tulip.root_dir() + 'sys/ex/'.
+# wav files can also be loaded from an SD card with a path like '/sd/file.wav'.
+WAV_PATH = tulip.root_dir() + 'sys/ex/bcla3.wav'
+PRESET = 50
+
+amy.reset()
+
+# Load the wav into AMY's in-memory PCM table at PRESET.
+amy.load_sample(WAV_PATH, preset=PRESET)
+
+# Make synth 1 a 4-voice PCM player using that preset. Play it with MIDI ch 1.
+amy.send(synth=1, wave=amy.PCM, preset=PRESET, num_voices=4)
+
+
+def loop():
+    pass
+
+# Do not edit. Set automatically by the knobs on AMYboard Online.
+_auto_generated_knobs = """
+"""

--- a/tulip/amyboardweb/static/index.html
+++ b/tulip/amyboardweb/static/index.html
@@ -713,10 +713,6 @@
         <span class="can-do-title">Wavetable patch</span>
         <span class="can-do-desc">Uses our WAVETABLE oscillator type to play wavetable synthesis.</span>
       </a>
-      <a href="/editor/?mode=simulate&env=patchselector&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
-        <span class="can-do-title">Patch Selector on OLED</span>
-        <span class="can-do-desc">Our built in patch selector, use the rotary encoder to select different saved patches, press to select.</span>
-      </a>
       <a href="/editor/?mode=simulate&env=preset_selector&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
         <span class="can-do-title">Preset Selector</span>
         <span class="can-do-desc">Sets up the rotary encoder to cycle through all 257 AMYboard presets.</span>


### PR DESCRIPTION
## Summary
- Bump amy submodule to 0e83c80 ([shorepine/amy#688](https://github.com/shorepine/amy/pull/688)) — fixes `amy.load_sample()` regression where every base64 chunk failed as `"Unrecognized transfer-level command"`. Added `TestLoadSample` to amy so this can't drift again.
- Add 5 new sketches under `tulip/amyboardweb/sketches/` (arp, chords, midi2cv, wavfile, sampler) and upload them to ABW under `shorepine`. Remove the `patchselector` tile from the amyboardweb marketing page.
- `deploy_sketches.py` gains a `--verify` mode that diffs each local sketch (content + description) against its `shorepine` ABW counterpart and exits non-zero on drift.
- Fix `universal_hair.py` description double-space so `--verify` reports clean (the server normalizes whitespace on upload).

## Test plan
- [x] `make test` in amy: 86/86 (incl. new `TestLoadSample`)
- [x] `tulip/amyboardweb` builds clean (dev.py session timestamp 20260426083721)
- [x] `python3 deploy_sketches.py --verify` → 19 OK, 0 mismatched
- [ ] Open `/editor/?env=wavfile&user=shorepine&mode=simulate` in browser, run, confirm no console errors and sample plays