### PR TITLE
Sketch tweaks (arp/chords/wavfile) + marketing cards for sampler/sineclock

### DIFF
--- a/tulip/amyboardweb/sketches/arp.py
+++ b/tulip/amyboardweb/sketches/arp.py
@@ -3,9 +3,8 @@
 # DESCRIPTION: Hold MIDI keys; plays them in order as 8th-note arpeggios.
 import amy, midi, tulip
 
-# Free up channel 1 (default synth) and put our voice on synth 17.
-amy.send(synth=1, num_voices=0)
-amy.send(synth=17, patch=257, num_voices=6)
+# Tell synth 1 to not grab midi notes - we'll play them from this sketch.
+amy.send(synth=1, grab_midi_notes=0)
 
 # 8th note at 120 BPM = 250 ms per step.
 STEP_MS = 250
@@ -40,7 +39,7 @@ def loop():
 
     # Release the previous step's note before triggering the next one.
     if last_played is not None:
-        amy.send(synth=17, note=last_played, vel=0)
+        amy.send(synth=1, note=last_played, vel=0)
         last_played = None
 
     if not held:
@@ -50,7 +49,7 @@ def loop():
     notes = sorted(held)
     arp_idx %= len(notes)
     n = notes[arp_idx]
-    amy.send(synth=17, note=n, vel=0.8)
+    amy.send(synth=1, note=n, vel=0.8)
     last_played = n
     arp_idx += 1
 

--- a/tulip/amyboardweb/sketches/chords.py
+++ b/tulip/amyboardweb/sketches/chords.py
@@ -4,9 +4,9 @@
 import amy, midi
 from music import Chord
 
-# Free up channel 1 (default synth) and put our voice on synth 17.
-amy.send(synth=1, num_voices=0)
-amy.send(synth=17, patch=257, num_voices=6)
+# Tell synth 1 to not grab midi notes - we'll play them from this sketch.
+amy.send(synth=1, grab_midi_notes=0)
+
 
 ROOT_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']
 
@@ -32,10 +32,10 @@ def midi_cb(m):
         active[note] = notes
         v = vel / 127.0
         for n in notes:
-            amy.send(synth=17, note=n, vel=v)
+            amy.send(synth=1, note=n, vel=v)
     elif status == 0x80 or (status == 0x90 and vel == 0):
         for n in active.pop(note, ()):
-            amy.send(synth=17, note=n, vel=0)
+            amy.send(synth=1, note=n, vel=0)
 
 
 midi.add_callback(midi_cb)

--- a/tulip/amyboardweb/sketches/wavfile.py
+++ b/tulip/amyboardweb/sketches/wavfile.py
@@ -8,13 +8,9 @@ import amy, tulip
 WAV_PATH = tulip.root_dir() + 'sys/ex/bcla3.wav'
 PRESET = 50
 
-amy.reset()
-
 # Load the wav into AMY's in-memory PCM table at PRESET.
 amy.load_sample(WAV_PATH, preset=PRESET)
-
-# Make synth 1 a 4-voice PCM player using that preset. Play it with MIDI ch 1.
-amy.send(synth=1, wave=amy.PCM, preset=PRESET, num_voices=4)
+amy.send(synth=1, oscs_per_voice=1, num_voices=4, wave=amy.PCM, preset=PRESET)
 
 
 def loop():
@@ -22,4 +18,11 @@ def loop():
 
 # Do not edit. Set automatically by the knobs on AMYboard Online.
 _auto_generated_knobs = """
+i1ic255Z
+i1iv4in4Z
+i1v0w7p50Z
+i1v1Z
+i1v2Z
+i1v3Z
+i1V1.000x0.000,0.000,0.000M0.000,500.000,,0.000,0.000k0.000,320.000,0.500,0.500h0.000,0.850,0.500,3000.000Z
 """

--- a/tulip/amyboardweb/static/index.html
+++ b/tulip/amyboardweb/static/index.html
@@ -729,6 +729,14 @@
         <span class="can-do-title">Evolving Chords</span>
         <span class="can-do-desc">Lush evolving chord progressions with layered synths and generative voice leading.</span>
       </a>
+      <a href="/editor/?mode=simulate&env=sampler&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
+        <span class="can-do-title">Live MIDI sampler</span>
+        <span class="can-do-desc">Hold a MIDI key to record up to 5s of audio in, then play it back pitched to the keyboard on synth 1.</span>
+      </a>
+      <a href="/editor/?mode=simulate&env=sineclock&user=shorepine&tab=code" class="can-do-item" style="text-decoration:none; color:#fff;">
+        <span class="can-do-title">Sineclock</span>
+        <span class="can-do-desc">Douglas Repetto's sineclock — chimes the time of day with stacked sine waves.</span>
+      </a>
     </div>
     <a href="https://github.com/shorepine/tulipcc/blob/main/docs/amyboard/README.md" class="btn-loud btn-loud-primary" style="margin-top:2.5rem; display:inline-block;">Get started with your new AMYboard</a>
   </div>


### PR DESCRIPTION
## Summary
- arp/chords switch to playing on synth=1 with `grab_midi_notes=0` instead of proxying to synth=17, so the editor's auto-generated knobs panel controls the patch the user actually hears.
- wavfile pins `oscs_per_voice=1` and ships with a default knobs block tuned for the bcla3 PCM voice.
- Add "Live MIDI sampler" and "Sineclock" cards to the "What it can do" grid on amyboard.com so every official ABW sketch has a tile.

## Test plan
- [x] `python3 deploy_sketches.py --verify` clean against ABW
- [ ] Visual check on amyboard.com after deploy