### PR TITLE
Normalize sketch headers; one-shot sampler

### DIFF
--- a/tulip/amyboardweb/sketches/arp.py
+++ b/tulip/amyboardweb/sketches/arp.py
@@ -1,6 +1,8 @@
 # AMYboard Sketch
-# Top-level code runs once at boot. loop() runs repeatedly (~60ms).
+# Top-level code runs once at boot. loop() is called every 32nd note.
 # DESCRIPTION: Hold MIDI keys; plays them in order as 8th-note arpeggios.
+# In simulate mode, you have to use MIDI input, not the onscreen keyboard.
+
 import amy, midi, tulip
 
 # Tell synth 1 to not grab midi notes - we'll play them from this sketch.

--- a/tulip/amyboardweb/sketches/audiopassthru.py
+++ b/tulip/amyboardweb/sketches/audiopassthru.py
@@ -1,5 +1,5 @@
 # AMYboard Sketch
-# Top-level code runs once at boot. loop() runs repeatedly (~60ms).
+# Top-level code runs once at boot. loop() is called every 32nd note.
 import amy
 
 # DESCRIPTION: Pass audio in through to audio out

--- a/tulip/amyboardweb/sketches/chords.py
+++ b/tulip/amyboardweb/sketches/chords.py
@@ -1,6 +1,8 @@
 # AMYboard Sketch
-# Top-level code runs once at boot. loop() runs repeatedly (~60ms).
+# Top-level code runs once at boot. loop() is called every 32nd note.
 # DESCRIPTION: Each MIDI key triggers a major chord rooted at that key.
+# In simulate mode, you have to use MIDI input, not the onscreen keyboard.
+
 import amy, midi
 from music import Chord
 

--- a/tulip/amyboardweb/sketches/cvfilter.py
+++ b/tulip/amyboardweb/sketches/cvfilter.py
@@ -1,5 +1,5 @@
 # AMYboard Sketch
-# Top-level code runs once at boot. loop() runs repeatedly (~60ms).
+# Top-level code runs once at boot. loop() is called every 32nd note.
 
 import amy, amyboard
 

--- a/tulip/amyboardweb/sketches/dx7filt.py
+++ b/tulip/amyboardweb/sketches/dx7filt.py
@@ -1,5 +1,5 @@
 # AMYboard Sketch
-# Top-level code runs once at boot. loop() runs repeatedly (~60ms).
+# Top-level code runs once at boot. loop() is called every 32nd note.
 # DESCRIPTION: A DX7 like patch with controllable filter
 def loop():
     pass

--- a/tulip/amyboardweb/sketches/methodical_mid.py
+++ b/tulip/amyboardweb/sketches/methodical_mid.py
@@ -1,5 +1,5 @@
 # AMYboard Sketch
-# Top-level code runs once at boot. loop() runs repeatedly (~60ms).
+# Top-level code runs once at boot. loop() is called every 32nd note.
 # DESCRIPTION: Play a MIDI file
 
 print('methodical')

--- a/tulip/amyboardweb/sketches/midi2cv.py
+++ b/tulip/amyboardweb/sketches/midi2cv.py
@@ -1,5 +1,5 @@
 # AMYboard Sketch
-# Top-level code runs once at boot. loop() runs repeatedly (~60ms).
+# Top-level code runs once at boot. loop() is called every 32nd note.
 # DESCRIPTION: MIDI to CV: notes -> 1V/oct on CV2, CC23 -> -10..10V on CV1.
 import amy, amyboard, midi
 

--- a/tulip/amyboardweb/sketches/piano.py
+++ b/tulip/amyboardweb/sketches/piano.py
@@ -1,5 +1,5 @@
 # AMYboard Sketch
-# Top-level code runs once at boot. loop() runs repeatedly (~60ms).
+# Top-level code runs once at boot. loop() is called every 32nd note.
 # DESCRIPTION: Play an additive voiced piano
 
 import amy

--- a/tulip/amyboardweb/sketches/preset_selector.py
+++ b/tulip/amyboardweb/sketches/preset_selector.py
@@ -1,4 +1,5 @@
 # AMYboard Sketch
+# Top-level code runs once at boot. loop() is called every 32nd note.
 # DESCRIPTION: scroll and choose all 257 AMY presets with the rotary encoder.
 import amyboard, amy
 from patches import patches as PRESETS

--- a/tulip/amyboardweb/sketches/sampler.py
+++ b/tulip/amyboardweb/sketches/sampler.py
@@ -1,20 +1,22 @@
 # AMYboard Sketch
-# Top-level code runs once at boot. loop() runs repeatedly (~60ms).
+# Top-level code runs once at boot. loop() is called every 32nd note.
 # DESCRIPTION: Live sampler. Hold a MIDI key to record audio in; play it on synth 1.
 
 # How this works:
 #  1. synth 1 is configured as a 4-voice PCM player reading from preset 50.
-#  2. Every MIDI note-on calls amy.start_sample, which begins recording up to
+#  2. The first MIDI note-on calls amy.start_sample, which begins recording up to
 #     5 seconds (44100 * 5 frames) from the audio input bus into preset 50.
 #     The midi note is passed as the sample's natural pitch -- so when you
 #     play the same note back you hear it at the original speed; higher notes
 #     play faster, lower notes slower.
-#  3. The matching MIDI note-off calls amy.stop_sample to end the recording.
+#  3. The matching MIDI note-off calls amy.stop_sample to end the recording
+#     and removes the MIDI callback -- recording is one-shot.
 #  4. Once a sample has been captured, hold any key on MIDI ch 1 to hear the
-#     audio you recorded, pitch-shifted to that note. Hit a new key to record
-#     a fresh sample over preset 50.
+#     audio you recorded, pitch-shifted to that note. Subsequent note-ons go
+#     straight to synth 1 and never re-trigger start_sample.
 #
-# Tip: turn on "allow audio input" in the web editor to record from your mic.
+# In simulate mode, turn on "allow audio input" in the web editor to record from your mic.
+# In simulate mode, you have to use MIDI input, not the onscreen keyboard.
 
 import amy, midi
 
@@ -23,7 +25,7 @@ SR = 44100
 
 amy.send(synth=1, wave=amy.PCM, preset=PRESET, num_voices=4)
 
-# Track which note is currently driving a recording so we know when to stop.
+# Track which note is driving the one-shot recording. None once we've stopped.
 recording_note = None
 
 
@@ -34,12 +36,18 @@ def midi_cb(m):
     status = m[0] & 0xF0
     note = m[1]
     vel = m[2]
-    if status == 0x90 and vel > 0:
+    if recording_note is None and status == 0x90 and vel > 0:
+        # First note-on: start the one-shot recording into preset PRESET.
         recording_note = note
         amy.start_sample(preset=PRESET, max_frames=SR * 5, midinote=note)
-    elif (status == 0x80 or (status == 0x90 and vel == 0)) and note == recording_note:
+    elif recording_note is not None and note == recording_note and (
+        status == 0x80 or (status == 0x90 and vel == 0)
+    ):
+        # Matching note-off ends the recording. Detach the callback so all
+        # subsequent MIDI notes go straight to synth 1 and play the captured
+        # sample without re-triggering start_sample.
         amy.stop_sample()
-        recording_note = None
+        midi.remove_callback(midi_cb)
 
 
 midi.add_callback(midi_cb)

--- a/tulip/amyboardweb/sketches/spacey.py
+++ b/tulip/amyboardweb/sketches/spacey.py
@@ -1,5 +1,5 @@
 # AMYboard Sketch
-# Top-level code runs once at boot. loop() runs repeatedly (~60ms).
+# Code put here runs first, then loop() is called every 32nd note.
 # DESCRIPTION: A spacey-like patch with reverb and echo
 def loop():
     pass

--- a/tulip/amyboardweb/sketches/wavfile.py
+++ b/tulip/amyboardweb/sketches/wavfile.py
@@ -1,5 +1,5 @@
 # AMYboard Sketch
-# Top-level code runs once at boot. loop() runs repeatedly (~60ms).
+# Code put here runs first, then loop() is called every 32nd note.
 # DESCRIPTION: Load a .wav file as a PCM instrument on synth 1.
 import amy, tulip
 

--- a/tulip/amyboardweb/sketches/woodpiano.py
+++ b/tulip/amyboardweb/sketches/woodpiano.py
@@ -1,5 +1,5 @@
 # AMYboard Sketch
-# Top-level code runs once at boot. loop() runs repeatedly (~60ms).
+# Code put here runs first, then loop() is called every 32nd note.
 # DESCRIPTION: Load a custom DX7 synth (WOOD PIANO) on synth channel 1
 import amyboard, amy
 

--- a/tulip/amyboardweb/sketches/xanadu.py
+++ b/tulip/amyboardweb/sketches/xanadu.py
@@ -1,5 +1,5 @@
 # AMYboard Sketch
-# Top-level code runs once at boot. loop() runs repeatedly (~60ms).
+# Code put here runs first, then loop() is called every 32nd note.
 # DESCRIPTION: Xanadu for AMYboard
 
 """Joseph T. Kung's XANADU, implemented for tulipcc.


### PR DESCRIPTION
## Summary
- Update the boilerplate `# loop() runs repeatedly (~60ms)` line on most sketches to `# loop() is called every 32nd note.` so it matches the actual amyboardweb runtime cadence.
- sampler.py converts to a one-shot recorder: the first MIDI note-on starts a 5s recording, the matching note-off stops it and removes the MIDI callback so subsequent note-ons play the captured sample on synth 1 without re-triggering `start_sample`.
- All 19 sketches re-uploaded to ABW under `shorepine`; `python3 deploy_sketches.py --verify` is clean.

## Test plan
- [x] `python3 deploy_sketches.py --verify` → 19 OK, 0 mismatched
- [ ] Open `/editor/?env=sampler&user=shorepine&mode=simulate` and confirm one-shot behavior