### PR TITLE
amyboardweb: skip green-button gate on save's internal zA+zD pull

### DIFF
--- a/tulip/amyboardweb/static/spss.js
+++ b/tulip/amyboardweb/static/spss.js
@@ -3936,6 +3936,10 @@ async function save_amy_state() {
         if (!userSketchText || !userSketchText.trim().length) return;
         try {
             // Step 1+2: pull current live state (sketch still running).
+            // The user clicked Save, so this internal pull is implicit —
+            // skip the green-button gate on the modal and go straight to
+            // busy state. The second modal (zB reboot wait) still gates.
+            _skip_pull_gate = true;
             await sync_amy_state_async();
             await sleep_ms(500);
             // Step 3: splice fresh knobs into editor text.


### PR DESCRIPTION
## Summary
- Save in control mode runs an internal zA+zD pull (so we can splice fresh knobs into the editor text) before the zB reboot + upload
- That internal pull is implicit from clicking Save — re-prompting via the green Pull from AMYboard button was just extra clicks
- Set `_skip_pull_gate` before `sync_amy_state_async()` so the modal goes straight to busy state for the internal pull
- The subsequent zB-reboot modal still gates so the user confirms MIDI ports before the actual upload

Save flow now: 1 click on Save + 1 click on the green button (for upload), down from 3.

## Test plan
- [ ] Click "Write sketch and knobs to AMYboard" → first modal flashes busy directly (no green button), zA+zD completes silently
- [ ] Then second modal opens with green Pull from AMYboard button
- [ ] Click green → board reboots, upload completes, sketch restarts
- [ ] Fresh page load still shows the green button (not skipped)
- [ ] Try again on error still goes straight to busy (skip flag still works for retries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)