### PR TITLE
Firmware update: tell users to hit BOOT then RST after flash

### DIFF
--- a/docs/amyboard/firmware.md
+++ b/docs/amyboard/firmware.md
@@ -19,7 +19,7 @@ The [AMYboard Online editor](https://amyboard.com/editor) includes a built-in fi
 <img src="img/serial_ports.png" width=400>
 
 5. Choose to either **Upgrade AMYboard firmware** (keeps your files) or **Fully erase and re-flash AMYboard** (fresh start).
-6. Wait for the process to complete. You then need to hit the RST button to restart your AMYboard into the upgraded firmware!
+6. Wait for the process to complete. You then need to hit BOOT, then RST to restart your AMYboard into the upgraded firmware!
 
 ---
 

--- a/tulip/amyboardweb/static/esptool/index.html
+++ b/tulip/amyboardweb/static/esptool/index.html
@@ -62,7 +62,7 @@
             <li><B>Upgrade AMYboard firmware.</B> Your stored data should be safe. </li>
             <li><B>Fully erase and re-flash AMYboard</b>. This will remove any stored patches or environments. (Your SD card is safe.) Use this only if you're having issues.
           </ul>
-          <li>Wait a minute until the progress bar disappears. Hit RST. Your AMYboard should be updated!</li>
+          <li>Wait a minute until the progress bar disappears. Hit BOOT, then let go, then hit RST. Your AMYboard should be updated!</li>
         </UL>
         <button id="butConnect" type="button">Search for AMYboard</button>
       </div>
@@ -93,7 +93,7 @@
             <div class="progress-bar hidden"><div></div></div>
           </div>
           <div id="upgradeComplete" class="upgrade-complete hidden">
-            Upgrade complete. Make sure to hit RST to reboot your AMYboard and then <a href="#" onclick="window.location.reload(); return false;">reload this page</a>.
+            Upgrade complete. Make sure to hit BOOT, then RST to reboot your AMYboard and then <a href="#" onclick="window.location.reload(); return false;">reload this page</a>.
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Updates the AMYboard firmware-flasher page (in-flow instruction list and the post-upgrade success message) to tell the user to hit **BOOT, then RST** after flashing, instead of just **RST**. Some boards don't reboot reliably from RST alone post-flash.
- Updates `docs/amyboard/firmware.md` Option 1 step 6 to match.

## Test plan
- [x] Verified all three strings render correctly on the deployed amyboardweb
- [x] amyboardweb deployed to Vercel preview prior to merge
- [ ] Confirm the new instruction works on a real AMYboard after the next flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)