### PR TITLE
amyboard: spawn i2c_check_for_data task so I2C follower input works

### DIFF
--- a/tulip/amyboard/main.c
+++ b/tulip/amyboard/main.c
@@ -324,6 +324,8 @@ void boardctrl_startup(void) {
 
 
 extern esp_err_t i2c_follower_init();
+extern void i2c_check_for_data();
+extern TaskHandle_t i2c_check_for_data_handle;
 
 uint8_t * xStack;
 StaticTask_t static_mp_handle;
@@ -341,6 +343,7 @@ void app_main(void) {
     idle_1_handle = xTaskGetIdleTaskHandleForCPU(1);
 
     i2c_follower_init();
+    xTaskCreatePinnedToCore(i2c_check_for_data, "i2c_check_for_data", 8192, NULL, 20, &i2c_check_for_data_handle, 0);
     fflush(stderr);
     delay_ms(500);
 


### PR DESCRIPTION
## Summary
- `i2c_follower_init()` sets up the amyboard's I2C slave hardware on address `0x3F`, and `i2c_check_for_data()` is the polling loop that reads incoming I2C packets and feeds them to `amy_add_message()`. But the FreeRTOS task to run `i2c_check_for_data()` was never created — so bytes sent to the amyboard over I2C piled up in the driver buffer and never reached AMY. This explains user reports that the docs example (Tulip CC → amyboard I2C follower port → AMY playback) stopped working.
- Adds the missing `xTaskCreatePinnedToCore()` call right after `i2c_follower_init()` in `app_main()`, using the existing `i2c_check_for_data_handle` already declared in `amyboard_support.c`.
- Minimal one-file change: 3 lines added in `tulip/amyboard/main.c`.

## Test plan
- [x] `idf.py -DMICROPY_BOARD=AMYBOARD build` succeeds cleanly.
- [ ] Flash an amyboard and connect a Tulip CC (or other I2C master) to the follower port; send AMY messages and confirm playback per the example in `docs/amyboard/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)