### PR TITLE
amyboard.py: add seesaw NeoPixel helpers for Quad Rotary Encoder

### DIFF
--- a/tulip/shared/amyboard-py/amyboard.py
+++ b/tulip/shared/amyboard-py/amyboard.py
@@ -710,12 +710,16 @@ def _web_encoder_press(state):
 
 # Adafruit I2C Quad Rotary Encoder Breakout
 # https://www.adafruit.com/product/5752
-# Four rotary encoders with built-in push buttons.
+# Four rotary encoders with built-in push buttons and one NeoPixel per encoder.
 #  read_encoder(encoder=0)  # reads the current value of the encoder
 #  init_buttons()  # must be called to configure pullup of encoder buttons
 #  read_buttons()  # returns a boolean list of the state of the 4 buttons.
+#  init_neopixels()  # must be called once before driving the on-board NeoPixels.
+#  set_neopixel(index, r, g, b)  # stage a pixel color; call show_neopixels() to latch.
+#  show_neopixels()  # latch pending pixel writes to the LEDs.
 # Code based on abstracting
-# https://github.com/adafruit/Adafruit_CircuitPython_seesaw/blob/main/adafruit_seesaw/seesaw.py.
+# https://github.com/adafruit/Adafruit_CircuitPython_seesaw/blob/main/adafruit_seesaw/seesaw.py
+# and https://github.com/adafruit/Adafruit_CircuitPython_seesaw/blob/main/adafruit_seesaw/neopixel.py.
 #
 # Missing-hardware behaviour: if the Seesaw encoder breakout isn't on the
 # I2C bus (user built an AMYboard with no rotary encoder attached), the
@@ -802,6 +806,66 @@ def read_buttons(pins=(12, 14, 17, 9), seesaw_dev=0x49, delay=0.008):
     except OSError:
         _seesaw_missing.add(seesaw_dev)
         return [False] * len(pins)
+
+def init_neopixels(num=4, pin=18, seesaw_dev=0x49):
+    """Configure the seesaw NeoPixels.
+
+    Defaults match the Adafruit Quad Rotary Encoder Breakout: 4 pixels on
+    seesaw pin 18 at 800 kHz. Call once before set_neopixel()/show_neopixels().
+    Silently no-ops if the seesaw device isn't on the I2C bus."""
+    if web():
+        return
+    if seesaw_dev in _seesaw_missing:
+        return
+    try:
+        i2c = get_i2c()
+        NEOPIXEL_BASE = 0x0E
+        NEOPIXEL_PIN = 0x01
+        NEOPIXEL_SPEED = 0x02
+        NEOPIXEL_BUF_LENGTH = 0x03
+        i2c.writeto(seesaw_dev, bytes([NEOPIXEL_BASE, NEOPIXEL_PIN, pin]))
+        i2c.writeto(seesaw_dev, bytes([NEOPIXEL_BASE, NEOPIXEL_SPEED, 1]))  # 1 = 800 kHz
+        i2c.writeto(seesaw_dev, bytes([NEOPIXEL_BASE, NEOPIXEL_BUF_LENGTH]) + struct.pack('>H', num * 3))
+    except OSError:
+        _seesaw_missing.add(seesaw_dev)
+
+def set_neopixel(index, r, g, b, seesaw_dev=0x49):
+    """Stage seesaw NeoPixel `index` to color (r, g, b) (0..255 each).
+
+    Call show_neopixels() afterwards to latch the staged buffer to the LEDs.
+    Assumes init_neopixels() has already been called. Color order on the
+    wire is GRB (the standard for these Adafruit NeoPixels). Silently
+    no-ops if the seesaw device isn't on the I2C bus."""
+    if web():
+        return
+    if seesaw_dev in _seesaw_missing:
+        return
+    try:
+        i2c = get_i2c()
+        NEOPIXEL_BASE = 0x0E
+        NEOPIXEL_BUF = 0x04
+        i2c.writeto(
+            seesaw_dev,
+            bytes([NEOPIXEL_BASE, NEOPIXEL_BUF]) + struct.pack('>H', index * 3) + bytes([g, r, b]),
+        )
+    except OSError:
+        _seesaw_missing.add(seesaw_dev)
+
+def show_neopixels(seesaw_dev=0x49):
+    """Latch any pending set_neopixel() writes to the LEDs.
+
+    Silently no-ops if the seesaw device isn't on the I2C bus."""
+    if web():
+        return
+    if seesaw_dev in _seesaw_missing:
+        return
+    try:
+        i2c = get_i2c()
+        NEOPIXEL_BASE = 0x0E
+        NEOPIXEL_SHOW = 0x05
+        i2c.writeto(seesaw_dev, bytes([NEOPIXEL_BASE, NEOPIXEL_SHOW]))
+    except OSError:
+        _seesaw_missing.add(seesaw_dev)
 
 def monitor_encoders():
     """Show status of encoders on display."""


### PR DESCRIPTION
## Summary
- The existing seesaw clone in [`amyboard.py`](tulip/shared/amyboard-py/amyboard.py) covers encoders and buttons but **not** the NeoPixel-per-encoder LEDs on the [Adafruit Quad Rotary Encoder Breakout (5752)](https://www.adafruit.com/product/5752).
- Adds three helpers that drive the seesaw `NEOPIXEL_BASE (0x0E)` registers — `NEOPIXEL_PIN`, `NEOPIXEL_SPEED`, `NEOPIXEL_BUF_LENGTH`, `NEOPIXEL_BUF`, `NEOPIXEL_SHOW`:
  - `init_neopixels(num=4, pin=18, seesaw_dev=0x49)` — set pin, speed (800 kHz), and buffer length.
  - `set_neopixel(index, r, g, b, seesaw_dev=0x49)` — stage a pixel color (wire order GRB).
  - `show_neopixels(seesaw_dev=0x49)` — latch the staged buffer to the LEDs.
- Defaults are tuned for the 5752 breakout (4 pixels on seesaw pin 18) but every helper takes overrides so other seesaw boards work too.
- Follows the existing missing-hardware pattern (`web()` no-op, `_seesaw_missing` short-circuit, `OSError` caches the absent address) so sketches still import/run cleanly on AMYboards without the encoder breakout attached.

## Usage
```python
import amyboard
amyboard.init_neopixels()              # configure once
amyboard.set_neopixel(0, 64, 0, 0)     # encoder 0 → dim red
amyboard.set_neopixel(1, 0, 64, 0)     # encoder 1 → dim green
amyboard.show_neopixels()              # latch
```

## Test plan
- [ ] Flash AMYboard firmware containing this commit (frozen module — needs a rebuild) and verify with the 5752 breakout daisy-chained on the I2C HOST port:
  - [ ] `init_neopixels()` runs without error.
  - [ ] `set_neopixel(i, r, g, b) + show_neopixels()` lights the expected LED in the expected color (GRB order).
  - [ ] Encoders/buttons still work in the same session (shared bus, no regressions).
- [ ] On an AMYboard with no encoder breakout attached: importing `amyboard` and calling the new helpers does not raise — `_seesaw_missing` cache absorbs the first `OSError`.
- [ ] Web build (`tulip/amyboardweb`) still builds; new helpers are no-ops under `web()`.

Notes:
- Pure-Python addition to a frozen module — no C / build-config changes.
- CPython `ast.parse` accepts the file; no ESP-IDF firmware build attempted as part of this PR.