### PR TITLE
amyboardweb: default MIDI CC assignments for editor knobs

### DIFF
--- a/tulip/amyboardweb/static/amy_parameters.js
+++ b/tulip/amyboardweb/static/amy_parameters.js
@@ -346,7 +346,7 @@ window.addEventListener("DOMContentLoaded", function() {
     },
     {
       section: "ADSR",
-      cc: "",
+      cc: 79,
       display_name: "sustain",
       change_code: "i%iv" + CTL_OSC + "A,1,,%v,,0",
       min_value: 0,

--- a/tulip/amyboardweb/static/amy_parameters.js
+++ b/tulip/amyboardweb/static/amy_parameters.js
@@ -72,7 +72,7 @@ window.addEventListener("DOMContentLoaded", function() {
     },
     {
       section: "VCF",
-      cc: "",
+      cc: 74,
       display_name: "freq",
       change_code: "i%iv" + CTL_OSC + "F%v",
       knob_type: "log",
@@ -83,7 +83,7 @@ window.addEventListener("DOMContentLoaded", function() {
     },
     {
       section: "VCF",
-      cc: "",
+      cc: 71,
       display_name: "resonance",
       change_code: "i%iv" + CTL_OSC + "R%v",
       knob_type: "log",
@@ -235,7 +235,7 @@ window.addEventListener("DOMContentLoaded", function() {
     },
     {
       section: "Chorus",
-      cc: "",
+      cc: 93,
       knob_type: "log",
       display_name: "level",
       change_code: "k%v",
@@ -268,7 +268,7 @@ window.addEventListener("DOMContentLoaded", function() {
     },
     {
       section: "LFO",
-      cc: "",
+      cc: 76,
       display_name: "freq",
       change_code: "i%iv" + LFO_OSC + "f%v",
       knob_type: "log",
@@ -290,7 +290,7 @@ window.addEventListener("DOMContentLoaded", function() {
     },
     {
       section: "LFO",
-      cc: "",
+      cc: 77,
       display_name: "osc",
       change_code: "i%iv" + OSCA_OSC + "f,,,,,%vZi%iv" + OSCB_OSC + "f,,,,,%v",
       knob_type: "log",
@@ -324,7 +324,7 @@ window.addEventListener("DOMContentLoaded", function() {
 
     {
       section: "ADSR",
-      cc: "",
+      cc: 73,
       display_name: "attack",
       change_code: "i%iv" + CTL_OSC + "A%v,1,,,,0",
       min_value: 0,
@@ -334,7 +334,7 @@ window.addEventListener("DOMContentLoaded", function() {
     },
     {
       section: "ADSR",
-      cc: "",
+      cc: 75,
       knob_type: "log",
       display_name: "decay",
       change_code: "i%iv" + CTL_OSC + "A,1,%v,,,0",
@@ -356,7 +356,7 @@ window.addEventListener("DOMContentLoaded", function() {
     },
     {
       section: "ADSR",
-      cc: "",
+      cc: 72,
       knob_type: "log",
       display_name: "release",
       change_code: "i%iv" + CTL_OSC + "A,1,,,%v,0",
@@ -371,7 +371,7 @@ window.addEventListener("DOMContentLoaded", function() {
 
     {
       section: "Reverb",
-      cc: "",
+      cc: 91,
       knob_type: "log",
       display_name: "level",
       change_code: "h%v",
@@ -403,7 +403,7 @@ window.addEventListener("DOMContentLoaded", function() {
     },
     {
       section: "Echo",
-      cc: "",
+      cc: 94,
       display_name: "level",
       change_code: "M%v",
       min_value: 0,


### PR DESCRIPTION
## Summary
- Maps editor knobs in `amy_parameters.js` to the standard MIDI CC list (https://anotherproducer.com/online-tools-for-musicians/midi-cc-list/).
- ADSR `sustain` has no standard CC (CC 64 is the sustain *pedal*, a switch — not a level), so it uses CC 79 — Sound Controller 10, the spare voice-parameter slot in the Sound Controller bank (70–79) with no default function.
- Knobs without a clear standard CC remain unmapped.

## Default CC assignments
| Section | Knob | CC |
|---|---|---|
| VCF | freq | 74 (Brightness/Cutoff) |
| VCF | resonance | 71 (Harmonic Content) |
| ADSR | attack | 73 (Attack Time) |
| ADSR | decay | 75 (Decay Time) |
| ADSR | sustain | 79 (Sound Controller 10, no default function) |
| ADSR | release | 72 (Release Time) |
| LFO | freq | 76 (Vibrato Rate) |
| LFO | osc | 77 (Vibrato Depth) |
| Reverb | level | 91 (Effects 1 Depth) |
| Chorus | level | 93 (Effects 3 Depth) |
| Echo | level | 94 (Effects 4 Depth) |
| volume | total | 7 |

## Test plan
- [ ] Open the amyboardweb editor locally and confirm the listed knobs show the default CC numbers above.
- [ ] Confirm unmapped knobs still show an empty CC.
- [ ] Send the matching CCs from an external MIDI controller and verify each one moves the expected knob.
- [ ] Confirm `Reset Defaults` / channel switching restores the CC defaults.

Not for merge/deploy until tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
