### PR TITLE
docs: note AMYboard front-panel cutout for the 1.5" OLED

### DIFF
--- a/docs/amyboard/accessories.md
+++ b/docs/amyboard/accessories.md
@@ -34,6 +34,8 @@ You can add more DACs, ADCs, displays, or sensors to expand AMYboard's capabilit
 
  - ![Adafruit 1.5" 128x128 OLED](img/accessory_adafruit_oled.jpg)  
    [**Adafruit Grayscale 1.5" 128x128 OLED Display (STEMMA QT)**](https://www.adafruit.com/product/4741) -- A high-contrast 128x128 grayscale OLED with 16 shades of gray. AMYboard has built-in support for this display, including waveform visualization. Connects directly via the STEMMA QT cable.
+
+   The AMYboard front panel has a sized cutout for this display, with 4 M2 sized nut/bolt holes that will easily attach through the bolt holes on the display as well.
  - [**Generic SH1107 128x128 OLED displays (I2C)**](https://www.amazon.com/HiLetgo-SH1107-128x128-Display-Module/dp/B0CFF17DGH/) -- Many available generic displays based on the SH1107 or SSD1327 will work out of the box on AMYboard.
    
 ```python


### PR DESCRIPTION
## Summary
Adds a paragraph under the Adafruit 1.5\" OLED entry in [accessories.md](docs/amyboard/accessories.md) noting that the AMYboard front panel has a sized cutout for the display and 4 M2 nut/bolt holes that line up with its mounting holes.

## Test plan
- [ ] Render the page and confirm the new paragraph appears indented within the OLED bullet (and the bullet list structure is intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)