### PR TITLE
docs: warn to use front-panel I2C jack for AMYboard accessories

### DIFF
--- a/docs/amyboard/accessories.md
+++ b/docs/amyboard/accessories.md
@@ -1,5 +1,7 @@
 # AMYboard Accessories
 
+**Important: plug accessories into the FRONT-panel I2C jack, not the back "tulip" I2C jack.** The back jack is a separate I2C bus reserved for connecting AMYboard to a Tulip CC; accessories plugged in there will not be reachable from your code.
+
 AMYboard has a front panel I2C port for plugging in accessories. These connect with a simple cable (GROVE connector) -- no soldering required.
 
 The I2C bus (SCL=18, SDA=17, 400kHz) is available for connecting additional hardware:

--- a/docs/amyboard/accessories.md
+++ b/docs/amyboard/accessories.md
@@ -1,6 +1,6 @@
 # AMYboard Accessories
 
-**Important: plug accessories into the FRONT-panel I2C jack, not the back "tulip" I2C jack.** The back jack is a separate I2C bus reserved for connecting AMYboard to a Tulip CC; accessories plugged in there will not be reachable from your code.
+Important: plug accessories into the FRONT-panel I2C jack, the side with the 3.5mm jacks, **not** the back "Tulip" I2C jack. The back jack is a separate I2C bus reserved for connecting AMYboard to a Tulip CC; accessories plugged in there will not be reachable from your code.
 
 AMYboard has a front panel I2C port for plugging in accessories. These connect with a simple cable (GROVE connector) -- no soldering required.
 


### PR DESCRIPTION
## Summary
Adds a bold note at the top of [accessories.md](docs/amyboard/accessories.md) reminding users that accessories go on the FRONT-panel I2C jack. The back \"tulip\" jack is a separate bus (the I2C follower link to a Tulip CC), so accessories plugged there will not be reachable.

## Test plan
- [ ] Render the page and confirm the warning sits between the title and the existing intro paragraph and renders in bold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)