### PR TITLE
Add AMYboard dev/release firmware + web channels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,49 @@ Notes:
 - This command cleans and compiles all Tulip targets.
 - Typical runtime is about 5 to 10 minutes.
 
+## AMYboard Dev Channel (`dev.sh`)
+
+AMYboard has two firmware/web channels:
+
+- **release** — the real GitHub release (`releases/latest`), flashed from
+  `amyboard.com`. Promoted via `release.sh` (firmware) + `amyboardweb/deploy.sh` (web).
+- **dev** — rolling test builds, flashed from `https://amyboard-dev.vercel.app`.
+  Published via `tulip/dev.sh`.
+
+### Publishing dev builds
+
+Run from `tulip/` (ESP-IDF env active, see above):
+
+- `./dev.sh` — firmware + web
+- `./dev.sh firmware` — firmware only
+- `./dev.sh web` — web only
+
+`dev.sh`:
+
+1. Builds AMYboard firmware and uploads `amyboard-{firmware,full,sys}-AMYBOARD.bin`
+   to a GitHub **prerelease tagged `dev`** (created on first run, `--clobber`ed after).
+   Because it's a prerelease, it never becomes `releases/latest`.
+2. Builds `amyboardweb/stage/` via `python3 dev.py --build-only` and deploys it to
+   the **`amyboard-dev`** Vercel project (scope `bwhitmans-projects`, `--prod`).
+
+### How the flasher chooses a channel
+
+`amyboardweb/static/esptool/js/script.js` resolves the channel at runtime:
+`amyboard.com` → release, any host containing `amyboard-dev` → dev, localhost → dev,
+anything else → release. A `?channel=dev|release` query param (on the flasher page or
+the parent editor page) overrides this for testing. So the **dev site only ever flashes
+dev firmware and amyboard.com only ever flashes the latest release** — the same web
+artifact is deployed to both; only the hostname differs.
+
+### Promotion (dev → release)
+
+Once a dev build is tested, promote with the existing scripts:
+
+1. Firmware: `./release.sh v-XXX-2026 upload` (rebuilds from `main`, uploads to the
+   version tag, which becomes `releases/latest`).
+2. Web: `cd amyboardweb && ./deploy.sh` (deploys `stage/` to the `amyboard` Vercel
+   project / amyboard.com).
+
 ## World DB API Server (Railway)
 
 The FastAPI server in `tulip/server/amyboardworld_db_api.py` backs all

--- a/tulip/amyboardweb/dev.py
+++ b/tulip/amyboardweb/dev.py
@@ -279,9 +279,23 @@ class DevHandler(SimpleHTTPRequestHandler):
 # ── Entry point ────────────────────────────────────────────────────────────────
 
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="AMYboard Web dev server / builder")
+    parser.add_argument(
+        "--build-only",
+        action="store_true",
+        help="Build stage/ once and exit (no watcher, no HTTP server). Used by dev.sh.",
+    )
+    args = parser.parse_args()
+
     os.chdir(SCRIPT_DIR)
 
     full_build()
+
+    if args.build_only:
+        print("[dev] --build-only: stage/ built, exiting.")
+        raise SystemExit(0)
 
     watcher = threading.Thread(target=watcher_loop, daemon=True)
     watcher.start()

--- a/tulip/amyboardweb/static/esptool/css/style.css
+++ b/tulip/amyboardweb/static/esptool/css/style.css
@@ -81,6 +81,15 @@ div.clear {
   display: none;
 }
 
+.channel-badge {
+  margin: 0 0 1em;
+  padding: 0.6em 0.9em;
+  border-radius: 6px;
+  font-weight: 600;
+  background: #b35900;
+  color: #fff;
+}
+
 .notSupported {
   padding: 1em;
   margin-top: 1em;

--- a/tulip/amyboardweb/static/esptool/index.html
+++ b/tulip/amyboardweb/static/esptool/index.html
@@ -67,13 +67,14 @@
         <button id="butConnect" type="button">Search for AMYboard</button>
       </div>
       <div id="app">
+        <div id="channelBadge" class="channel-badge hidden"></div>
         <div id="commands">
           <div class="upload">
             <input class="offset" type="hidden" value="10000" />
             <button
               id="butProgram"
               type="button"
-              data-url="https://github.com/shorepine/tulipcc/releases/latest/download/amyboard-firmware-AMYBOARD.bin"
+              data-bin="amyboard-firmware-AMYBOARD.bin"
               disabled="disabled"
             >
               Upgrade AMYboard firmware
@@ -85,7 +86,7 @@
             <button
               id="butErase"
               type="button"
-              data-url="https://github.com/shorepine/tulipcc/releases/latest/download/amyboard-full-AMYBOARD.bin"
+              data-bin="amyboard-full-AMYBOARD.bin"
               disabled="disabled"
             >
               Fully erase and re-flash AMYboard

--- a/tulip/amyboardweb/static/esptool/js/script.js
+++ b/tulip/amyboardweb/static/esptool/js/script.js
@@ -17,18 +17,58 @@ const offsets = document.querySelectorAll(".upload .offset");
 const appDiv = document.getElementById("app");
 const noReset = document.getElementById("noReset");
 
+// Firmware channel: the "dev" site flashes test builds from the rolling 'dev'
+// GitHub prerelease; everywhere else flashes the real (latest) release.
+const FIRMWARE_BASES = {
+    release: "https://github.com/shorepine/tulipcc/releases/latest/download",
+    dev:     "https://github.com/shorepine/tulipcc/releases/download/dev",
+};
+
+function channelFromSearch(search) {
+    try {
+        const v = new URLSearchParams(search || "").get("channel");
+        return v === "dev" || v === "release" ? v : null;
+    } catch (e) {
+        return null;
+    }
+}
+
+function resolveFirmwareChannel() {
+    // Explicit ?channel= override on this frame or the parent editor frame.
+    let override = channelFromSearch(window.location.search);
+    if (!override) {
+        try { override = channelFromSearch(window.parent.location.search); } catch (e) {}
+    }
+    if (override) return override;
+
+    const host = (window.location.hostname || "").toLowerCase();
+    if (host === "amyboard.com" || host === "www.amyboard.com") return "release";
+    if (host.includes("amyboard-dev")) return "dev";
+    if (host === "localhost" || host === "127.0.0.1") return "dev";
+    return "release";
+}
+
+const firmwareChannel = resolveFirmwareChannel();
+
+function firmwareUrl(button) {
+    const bin = button?.dataset?.bin;
+    if (!bin) return undefined;
+    const base = FIRMWARE_BASES[firmwareChannel] || FIRMWARE_BASES.release;
+    return `${base}/${bin}`;
+}
+
 const upgradeActions = [
     {
         button: butProgram,
         offsetInput: offsets[0],
-        url: butProgram?.dataset?.url,
+        url: firmwareUrl(butProgram),
         eraseAll: false,
         eraseOTA: true,
     },
     {
         button: butErase,
         offsetInput: offsets[1],
-        url: butErase?.dataset?.url,
+        url: firmwareUrl(butErase),
         eraseAll: true,
         eraseOTA: false,
     }
@@ -96,6 +136,17 @@ document.addEventListener("DOMContentLoaded", () => {
     loadAllSettings();
     updateTheme();
     writeLogLine("ESP Web Flasher loaded.");
+
+    const channelBadge = document.getElementById("channelBadge");
+    if (channelBadge) {
+        if (firmwareChannel === "dev") {
+            channelBadge.textContent =
+                "DEV channel — flashing test builds from the rolling 'dev' release, not a stable version.";
+            channelBadge.classList.remove("hidden");
+        } else {
+            channelBadge.classList.add("hidden");
+        }
+    }
 });
 
 function initBaudRate() {

--- a/tulip/dev.sh
+++ b/tulip/dev.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# dev.sh — build + publish AMYboard DEV builds (firmware + web).
+#
+# This is the DEV counterpart to the release flow:
+#   - release.sh v-XXX-2026 upload     # promotes firmware to the real release
+#   - amyboardweb/deploy.sh            # promotes web to amyboard.com
+#
+# dev.sh publishes test builds instead:
+#   - firmware -> a rolling GitHub PRERELEASE tagged 'dev'
+#                 (assets at .../releases/download/dev/...; never becomes 'latest')
+#   - web      -> the 'amyboard-dev' Vercel project (https://amyboard-dev.vercel.app)
+#
+# The flasher picks its channel from the site it's served on: amyboard-dev.*
+# only ever flashes the 'dev' firmware, amyboard.com only the latest release.
+#
+# Run from the tulip/ directory:
+#   ./dev.sh            # firmware + web
+#   ./dev.sh firmware   # firmware only
+#   ./dev.sh web        # web only
+set -e
+
+die() { echo "$*" 1>&2 ; exit 1; }
+
+WHAT="${1:-all}"
+
+DEV_TAG="dev"
+GH_REPO="shorepine/tulipcc"
+VERCEL_SCOPE="bwhitmans-projects"
+VERCEL_DEV_PROJECT="amyboard-dev"
+
+[ -d amyboard ] && [ -d amyboardweb ] || die "Run ./dev.sh from the tulip/ directory."
+
+ensure_idf() {
+    if command -v idf.py >/dev/null 2>&1; then return; fi
+    [ -f "$HOME/.espressif/python_env/idf5.4_py3.13_env/bin/activate" ] && \
+        source "$HOME/.espressif/python_env/idf5.4_py3.13_env/bin/activate"
+    [ -f "$HOME/esp/esp-idf-v5.4.1/export.sh" ] && \
+        source "$HOME/esp/esp-idf-v5.4.1/export.sh"
+    command -v idf.py >/dev/null 2>&1 || \
+        die "idf.py not found — activate the ESP-IDF env first (see CLAUDE.md)."
+}
+
+do_firmware() {
+    echo "[dev] Building AMYboard firmware …"
+    ensure_idf
+    cd amyboard
+    rm -rf build
+    idf.py -DMICROPY_BOARD=AMYBOARD build
+    cd ..
+    python fs_create.py amyboard
+
+    echo "[dev] Publishing firmware to GitHub '$DEV_TAG' prerelease …"
+    if ! gh release view "$DEV_TAG" --repo "$GH_REPO" >/dev/null 2>&1; then
+        gh release create "$DEV_TAG" --repo "$GH_REPO" --prerelease \
+            --title "AMYboard dev (rolling)" \
+            --notes "Rolling AMYboard development build. Flash from https://amyboard-dev.vercel.app — this is NOT a stable release."
+    fi
+    gh release upload --clobber --repo "$GH_REPO" "$DEV_TAG" \
+        amyboard/dist/amyboard-firmware-AMYBOARD.bin \
+        amyboard/dist/amyboard-full-AMYBOARD.bin \
+        amyboard/dist/amyboard-sys.bin
+    echo "[dev] Firmware uploaded to '$DEV_TAG' prerelease."
+}
+
+do_web() {
+    echo "[dev] Building amyboardweb stage/ …"
+    cd amyboardweb
+    python3 dev.py --build-only
+
+    # Link stage/ to the dev Vercel project (creates it on first run).
+    project_json="stage/.vercel/project.json"
+    current_project=""
+    if [ -f "$project_json" ]; then
+        current_project=$(python3 - "$project_json" <<'PY'
+import json, sys
+try:
+    print(json.load(open(sys.argv[1])).get("projectName", ""))
+except Exception:
+    print("")
+PY
+)
+    fi
+    if [ "$current_project" != "$VERCEL_DEV_PROJECT" ]; then
+        vercel link --yes --scope "$VERCEL_SCOPE" --project "$VERCEL_DEV_PROJECT" --cwd stage
+    fi
+
+    echo "[dev] Deploying web to '$VERCEL_DEV_PROJECT' …"
+    vercel deploy stage --prod --yes --scope "$VERCEL_SCOPE"
+    cd ..
+    echo "[dev] Web deployed. Test it at https://amyboard-dev.vercel.app"
+}
+
+case "$WHAT" in
+    all)      do_firmware; do_web ;;
+    firmware) do_firmware ;;
+    web)      do_web ;;
+    *)        die "usage: ./dev.sh [all|firmware|web]" ;;
+esac
+
+echo "[dev] Done. Promote to release with: ./release.sh v-XXX-2026 upload  &&  (cd amyboardweb && ./deploy.sh)"


### PR DESCRIPTION
## Summary
- Adds a `dev` firmware/web channel for AMYboard alongside the existing `release` channel.
- `tulip/dev.sh` builds AMYboard firmware → uploads to a GitHub **prerelease tagged `dev`** (flagged prerelease, so it never becomes `releases/latest`), and builds + deploys the web app to the **`amyboard-dev`** Vercel project (https://amyboard-dev.vercel.app).
- The flasher picks its channel by **hostname**: `amyboard.com` → release, any host containing `amyboard-dev` → dev, `localhost` → dev, anything else → release. A `?channel=dev|release` query param overrides for testing. Same web artifact deploys to both sites; only the hostname differs.
- Promotion to release is unchanged: `release.sh` (firmware) + `amyboardweb/deploy.sh` (web).

## Changes
- `tulip/dev.sh` *(new)* — dev publish script (`all` | `firmware` | `web`)
- `tulip/amyboardweb/static/esptool/js/script.js` — channel resolver, per-channel firmware URLs, dev badge
- `tulip/amyboardweb/static/esptool/index.html` — `data-url` → `data-bin`, badge element
- `tulip/amyboardweb/static/esptool/css/style.css` — `.channel-badge`
- `tulip/amyboardweb/dev.py` — `--build-only` (one-shot stage build for `dev.sh`)
- `AGENTS.md` / `CLAUDE.md` — new "AMYboard Dev Channel" section

## Not included / follow-up
- **Sync-time firmware-tag detection + "out of date" alert** (the third option in #932) is **not** implemented — the channel is decided by the *site*, not the *connected board's* tag.
- **Vercel auto-URL caveat:** the per-deploy hash URL comes out as `amyboard-<hash>` (Vercel drops the `-dev`), so only the stable `amyboard-dev.vercel.app` alias resolves to dev; raw per-deployment hash URLs fall back to release. Could harden with a build-time channel stamp written only by `dev.sh`.

## Test plan
- [x] `amyboard-dev.vercel.app` serves the channel-aware flasher (verified live)
- [x] `dev` prerelease has `amyboard-firmware/full/sys-AMYBOARD.bin` and is flagged prerelease; `releases/latest` still points to `v-may-2026`
- [x] dev `.bin` fetches through the dev-site proxy (HTTP 200)
- [ ] Flash a real AMYboard from `amyboard-dev.vercel.app` and confirm it pulls dev firmware
- [ ] Confirm `amyboard.com` still flashes the latest release

Relates to #932

🤖 Generated with [Claude Code](https://claude.com/claude-code)