### PR TITLE
Detect out-of-date AMYboard firmware on editor sync

### DIFF
--- a/tulip/amyboard/esp32_common.cmake
+++ b/tulip/amyboard/esp32_common.cmake
@@ -314,6 +314,15 @@ set(MICROPY_CROSS_FLAGS -march=xtensawin)
 # Suppress -Wgnu-folding-constant when building mpy-cross on macOS clang.
 set(ENV{CFLAGS_EXTRA} "$ENV{CFLAGS_EXTRA} -Wno-gnu-folding-constant")
 
+# Stamp the firmware with its build time (UTC unix epoch, seconds precision)
+# so the AMYboard editor can tell when a connected board is running firmware
+# older than the latest release. Recomputed on every CMake configure; both
+# release.sh and dev.sh clean-build (rm -rf build), so each published firmware
+# gets a fresh epoch. Also written to a file so fs_create.py can emit the
+# matching amyboard-version.json release asset with the same value.
+string(TIMESTAMP AMYBOARD_BUILD_EPOCH "%s" UTC)
+file(WRITE ${CMAKE_BINARY_DIR}/amyboard_build_epoch.txt "${AMYBOARD_BUILD_EPOCH}")
+
 # Set compile options for this port.
 target_compile_definitions(${MICROPY_TARGET} PUBLIC
     ${MICROPY_DEF_CORE}
@@ -327,6 +336,7 @@ target_compile_definitions(${MICROPY_TARGET} PUBLIC
     LFS2_NO_MALLOC LFS2_NO_ASSERT
     ESP_PLATFORM
     AMYBOARD
+    AMYBOARD_BUILD_EPOCH=${AMYBOARD_BUILD_EPOCH}
     AMY_WAVETABLE
     #AMY_DEBUG
     ${MICROPY_DEF_TINYUSB}

--- a/tulip/amyboardweb/static/editor/index.html
+++ b/tulip/amyboardweb/static/editor/index.html
@@ -1284,6 +1284,30 @@
         </div>
       </div>
 
+      <!-- Firmware out-of-date modal. Shown after a successful pull/sync when the
+           connected AMYboard's firmware build epoch (queried over sysex via zY)
+           is older than the latest GitHub release. The user can ignore it or
+           jump to the firmware upgrade tab. See _check_firmware_up_to_date() and
+           show_firmware_outdated_modal() in spss.js. -->
+      <div class="modal fade" id="firmwareOutdatedModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered" style="max-width:460px;">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title">Firmware update available</h5>
+              <button type="button" class="btn-close" aria-label="Close" onclick="dismiss_firmware_outdated_modal();"></button>
+            </div>
+            <div class="modal-body px-4 py-3">
+              <p id="firmware-outdated-info" class="mb-2">Your AMYboard firmware is out of date.</p>
+              <p class="text-muted small mb-0">You can keep using the editor with your current firmware, or upgrade to the latest release for the newest features and fixes.</p>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-outline-secondary btn-sm" onclick="dismiss_firmware_outdated_modal();">Ignore</button>
+              <button type="button" class="btn btn-warning btn-sm" onclick="firmware_outdated_upgrade();">Upgrade Firmware</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <div class="card border-0 bg-light shadow-sm mb-3">
         <div class="card-body">
           <form name="amyboard_settings">

--- a/tulip/amyboardweb/static/spss.js
+++ b/tulip/amyboardweb/static/spss.js
@@ -1244,6 +1244,20 @@ function _process_complete_sysex(d) {
         if (_sysex_ack_resolve) { var r = _sysex_ack_resolve; _sysex_ack_resolve = null; r(); }
         return;
     }
+    // zY firmware-version reply: F0 00 03 45 'Y' <ascii decimal epoch> F7.
+    // Must be handled before the chunk/base64 branch below or the digits would
+    // be misread as a base64 chunk payload.
+    if (d[4] === 0x59 /* Y */) {
+        var vs = '';
+        for (var vi = 5; vi < d.length - 1; vi++) vs += String.fromCharCode(d[vi]);
+        var vepoch = parseInt(vs, 10);
+        if (!isNaN(vepoch)) {
+            _board_firmware_epoch = vepoch;
+            console.log('zY: board firmware epoch =', vepoch, '(' + _fmt_epoch(vepoch) + ')');
+        }
+        if (_version_resolve) { var vr = _version_resolve; _version_resolve = null; vr(_board_firmware_epoch); }
+        return;
+    }
     // Chunk marker at position 4.
     var marker = d[4];
     var payloadStart, isChunked, isEnd;
@@ -2706,6 +2720,192 @@ function _send_zi_ping() {
     }
 }
 
+// ─── Firmware version check (zY) ──────────────────────────────────────────
+// The board's firmware is stamped at build time with a UTC unix epoch (seconds
+// precision; see AMYBOARD_BUILD_EPOCH in amyboard/esp32_common.cmake). We query
+// it over sysex with 'zY'; the board replies
+//   F0 00 03 45 'Y' <ascii decimal epoch> F7
+// (parsed in _process_complete_sysex above). We compare that against the epoch
+// baked into the LATEST RELEASE firmware — published as amyboard-version.json
+// alongside the release .bin — and, if the board is older, nudge the user to
+// upgrade. Firmware that predates this feature never answers 'zY'; we treat a
+// missing reply as "out of date" (it is, by definition).
+var _board_firmware_epoch = null;        // epoch reported by the connected board, or null
+var _version_resolve = null;             // one-shot resolver for an in-flight zY query
+var _latest_release_epoch = undefined;   // cached: undefined=unfetched, null=fetch failed, number=epoch
+var _firmware_outdated_notified = false; // only show the modal once per session
+// Always compare against the LATEST RELEASE, regardless of dev/release channel.
+var LATEST_VERSION_JSON_URL = 'https://github.com/shorepine/tulipcc/releases/latest/download/amyboard-version.json';
+
+// Format a unix epoch (seconds) as a short local date+time for log/UI display.
+function _fmt_epoch(epoch) {
+    if (epoch === null || epoch === undefined || isNaN(epoch)) return 'unknown';
+    try {
+        return new Date(epoch * 1000).toLocaleString();
+    } catch (e) {
+        return String(epoch);
+    }
+}
+
+// Send a single 'zY' firmware-version query. Mirrors _send_zi_ping: zY is
+// answered in C (modtulip.c, guarded by AMYBOARD_BUILD_EPOCH) and replies with
+// 'Y'<epoch>, never the 'AK' ACK, so we send it directly rather than through
+// sysex_write_amy_message's ack path. Returns true if the send was dispatched.
+function _send_zv_query() {
+    var outputDevice = get_selected_midi_output_device();
+    if (!outputDevice) return false;
+    try {
+        var rawOut = outputDevice._midiOutput || outputDevice.output || null;
+        if (rawOut && typeof rawOut.open === 'function') {
+            try { rawOut.open().catch(function() {}); } catch (e) {}
+        }
+        var payload = Array.from(new TextEncoder().encode('zYZ'));
+        if (typeof outputDevice.sendSysex === 'function') {
+            outputDevice.sendSysex(AMYBOARD_SYSEX_MFR_ID, payload);
+        } else if (typeof outputDevice.send === 'function') {
+            outputDevice.send([0xF0].concat(AMYBOARD_SYSEX_MFR_ID, payload, [0xF7]));
+        } else {
+            return false;
+        }
+        return true;
+    } catch (e) {
+        console.warn('_send_zv_query: send failed:', e);
+        return false;
+    }
+}
+
+// Send 'zY' and wait up to timeout_ms for the board's epoch reply. Resolves to
+// the epoch number, or null if no parseable reply arrived in time. If we
+// already have _board_firmware_epoch (from a pre-warm during wait_for_board_ready
+// or an earlier query), returns it immediately.
+function _query_firmware_epoch(timeout_ms) {
+    if (_board_firmware_epoch !== null) return Promise.resolve(_board_firmware_epoch);
+    if (!timeout_ms) timeout_ms = 2000;
+    return new Promise(function(resolve) {
+        var done = false;
+        _version_resolve = function(epoch) {
+            if (done) return;
+            done = true;
+            resolve(epoch === undefined ? null : epoch);
+        };
+        if (!_send_zv_query()) {
+            if (!done) { done = true; _version_resolve = null; resolve(null); }
+            return;
+        }
+        setTimeout(function() {
+            if (done) return;
+            done = true;
+            _version_resolve = null;
+            resolve(_board_firmware_epoch); // may still be null (no reply)
+        }, timeout_ms);
+    });
+}
+
+// Fetch the epoch baked into the latest RELEASE firmware from its
+// amyboard-version.json release asset, through the same /api/firmware proxy the
+// flasher uses for cross-origin GitHub fetches. Cached for the session.
+// Resolves to the epoch number, or null on any failure (in which case we stay
+// quiet — we never warn about being out of date if we can't establish a baseline).
+async function _fetch_latest_release_epoch() {
+    if (_latest_release_epoch !== undefined) return _latest_release_epoch;
+    try {
+        var proxied = '/api/firmware?url=' + encodeURIComponent(LATEST_VERSION_JSON_URL);
+        var resp = await fetch(proxied, { cache: 'no-store' });
+        if (!resp.ok) { _latest_release_epoch = null; return null; }
+        var obj = JSON.parse(await resp.text());
+        var ep = parseInt(obj.epoch, 10);
+        _latest_release_epoch = isNaN(ep) ? null : ep;
+    } catch (e) {
+        console.warn('firmware version check: could not fetch latest release epoch:', e);
+        _latest_release_epoch = null;
+    }
+    return _latest_release_epoch;
+}
+
+// Called at the end of a successful sync/pull. Compares the connected board's
+// firmware epoch against the latest release; if the board is older (or never
+// answered the zY query — firmware predating this feature), shows the
+// "firmware out of date" modal once per session. No-op outside control mode.
+async function _check_firmware_up_to_date() {
+    if (amyboard_mode !== 'control') return;
+    if (_firmware_outdated_notified) return;
+
+    var latest;
+    try {
+        latest = await _fetch_latest_release_epoch();
+    } catch (e) {
+        return;
+    }
+    // Can't establish a baseline → don't nag.
+    if (latest === null || latest === undefined) return;
+
+    var boardEpoch = _board_firmware_epoch;
+    if (boardEpoch === null) {
+        try { boardEpoch = await _query_firmware_epoch(2000); } catch (e) { boardEpoch = null; }
+    }
+    // boardEpoch===null means old firmware that doesn't answer zY → out of date.
+    var outdated = (boardEpoch === null) || (boardEpoch < latest);
+    console.log('firmware version check: board=' + _fmt_epoch(boardEpoch) +
+                ' latest_release=' + _fmt_epoch(latest) + ' outdated=' + outdated);
+    if (outdated) {
+        _firmware_outdated_notified = true;
+        show_firmware_outdated_modal(boardEpoch, latest);
+    }
+}
+
+// Show the "your AMYboard firmware is out of date" modal. The user can ignore
+// it (dismiss_firmware_outdated_modal) or jump to the firmware upgrade tab
+// (firmware_outdated_upgrade).
+function show_firmware_outdated_modal(boardEpoch, latestEpoch) {
+    var info = document.getElementById('firmware-outdated-info');
+    if (info) {
+        var boardStr = (boardEpoch === null || boardEpoch === undefined)
+            ? 'an unknown version (it predates firmware version reporting)'
+            : _fmt_epoch(boardEpoch);
+        info.textContent = 'Your AMYboard is running firmware from ' + boardStr +
+            '. The latest release is from ' + _fmt_epoch(latestEpoch) +
+            '. Upgrading is recommended.';
+    }
+    var el = document.getElementById('firmwareOutdatedModal');
+    if (!el) return;
+    try {
+        if (window.bootstrap) {
+            bootstrap.Modal.getOrCreateInstance(el).show();
+            return;
+        }
+    } catch (e) {}
+    // Fallback if bootstrap JS isn't available.
+    el.classList.add('show');
+    el.style.display = 'block';
+    el.removeAttribute('aria-hidden');
+}
+
+function dismiss_firmware_outdated_modal() {
+    var el = document.getElementById('firmwareOutdatedModal');
+    if (!el) return;
+    try {
+        var m = window.bootstrap && bootstrap.Modal.getOrCreateInstance(el);
+        if (m) m.hide();
+    } catch (e) {}
+    el.classList.remove('show');
+    el.style.display = 'none';
+    el.setAttribute('aria-hidden', 'true');
+    document.querySelectorAll('.modal-backdrop').forEach(function(b) { b.remove(); });
+    document.body.classList.remove('modal-open');
+    document.body.style.removeProperty('overflow');
+    document.body.style.removeProperty('padding-right');
+}
+
+// "Upgrade Firmware" button in the outdated modal: dismiss, then switch to the
+// firmware upgrade tab (same navigation dismiss_sync_modal_and_upgrade uses).
+function firmware_outdated_upgrade() {
+    dismiss_firmware_outdated_modal();
+    var upgradeTab = document.getElementById('upgrade-tab');
+    if (upgradeTab && window.bootstrap) {
+        try { new bootstrap.Tab(upgradeTab).show(); } catch (e) {}
+    }
+}
+
 // Install a raw MIDIAccess.statechange listener ONCE per page lifetime.
 // This bypasses WebMidi.js and logs the raw platform events. On Windows,
 // the WebMidi.js 'connected'/'disconnected' wrapper events have been
@@ -2777,6 +2977,11 @@ async function wait_for_board_ready(timeout_ms) {
         _ping_resolve = function() {
             if (reply_received) return;
             reply_received = true;
+            // Board just answered the readiness ping — opportunistically ask
+            // for its firmware epoch (zY) so a later sync can compare versions
+            // without an extra round-trip. Fire-and-forget; the reply lands in
+            // _process_complete_sysex and populates _board_firmware_epoch.
+            try { _send_zv_query(); } catch (e) {}
             resolve(true);
         };
     });
@@ -4921,6 +5126,15 @@ function _handle_sync_sysex_payload(payload) {
         // Remember the MIDI ports that worked so next page load can preselect.
         try { _save_successful_midi_ports(); } catch (e) {}
         if (_sync_resolve) { var r = _sync_resolve; _sync_resolve = null; _sync_reject = null; r(); }
+        // After a successful pull, check whether the board's firmware is older
+        // than the latest release and, if so, nudge the user to upgrade. Slight
+        // delay so the editor/knob UI settles and the syncing modal is fully
+        // gone before we (maybe) pop the outdated-firmware modal.
+        setTimeout(function() {
+            _check_firmware_up_to_date().catch(function(e) {
+                console.warn('firmware version check failed:', e);
+            });
+        }, 400);
         return;
     }
 }

--- a/tulip/dev.sh
+++ b/tulip/dev.sh
@@ -58,7 +58,8 @@ do_firmware() {
     gh release upload --clobber --repo "$GH_REPO" "$DEV_TAG" \
         amyboard/dist/amyboard-firmware-AMYBOARD.bin \
         amyboard/dist/amyboard-full-AMYBOARD.bin \
-        amyboard/dist/amyboard-sys.bin
+        amyboard/dist/amyboard-sys.bin \
+        amyboard/dist/amyboard-version.json
     echo "[dev] Firmware uploaded to '$DEV_TAG' prerelease."
 }
 

--- a/tulip/fs_create.py
+++ b/tulip/fs_create.py
@@ -3,6 +3,7 @@
 from littlefs import lfs
 import os
 import sys
+import json
 
 if(len(sys.argv)<2):
     print("Usage: python fs_create.py (amyboard,tulip) [flash]")
@@ -101,6 +102,34 @@ os.system("mkdir -p dist")
 os.system("cp build/%s.bin dist/%s-full-%s.bin" % (distro, distro, MICROPY_BOARD))
 os.system("cp build/micropython.bin dist/%s-firmware-%s.bin" % (distro, MICROPY_BOARD))
 os.system("cp build/%s-sys.bin dist/%s-sys.bin" %(distro, distro))
+
+# Emit a small version manifest for AMYboard so the web editor can tell when a
+# connected board is running firmware older than the latest release. The epoch
+# is the same UTC unix-seconds value compiled into the firmware — esp32_common.cmake
+# writes build/amyboard_build_epoch.txt at configure time and also defines
+# AMYBOARD_BUILD_EPOCH for the C code, so the JSON and the running firmware agree.
+# release.sh uploads this to the version tag (-> releases/latest/download/) and
+# dev.sh uploads it to the rolling 'dev' prerelease.
+if distro == 'amyboard':
+    version = {"board": MICROPY_BOARD}
+    try:
+        with open('build/amyboard_build_epoch.txt') as f:
+            version["epoch"] = int(f.read().strip())
+    except (OSError, ValueError) as e:
+        print("warning: could not read build/amyboard_build_epoch.txt:", e)
+        version["epoch"] = 0
+    try:
+        with open('build/genhdr/mpversion.h') as f:
+            for line in f:
+                if 'MICROPY_GIT_HASH' in line:
+                    version["git_hash"] = line.split('"')[1]
+                elif 'MICROPY_BUILD_DATE' in line:
+                    version["build_date"] = line.split('"')[1]
+    except OSError:
+        pass
+    with open('dist/amyboard-version.json', 'w') as f:
+        json.dump(version, f)
+    print("wrote dist/amyboard-version.json:", version)
 
 # Optionally do the flash of the whole image
 if(len(sys.argv)>2):

--- a/tulip/release.sh
+++ b/tulip/release.sh
@@ -70,6 +70,9 @@ if [ "$TYPE" == "upload" ]; then
     gh release upload --clobber $RELEASE amyboard/dist/amyboard-full-AMYBOARD.bin
     gh release upload --clobber $RELEASE amyboard/dist/amyboard-firmware-AMYBOARD.bin
     gh release upload --clobber $RELEASE amyboard/dist/amyboard-sys.bin
+    # Firmware build epoch manifest — the web editor fetches
+    # releases/latest/download/amyboard-version.json to detect out-of-date boards.
+    gh release upload --clobber $RELEASE amyboard/dist/amyboard-version.json
 fi
 
 

--- a/tulip/shared/modtulip.c
+++ b/tulip/shared/modtulip.c
@@ -375,6 +375,33 @@ STATIC mp_obj_t tulip_amy_send_sysex(size_t n_args, const mp_obj_t *args) {
     // mp_sched callback is delayed).
     char *slot = sysex_message_copies[sysex_copy_read_idx];
     sysex_copy_read_idx = (sysex_copy_read_idx + 1) % SYSEX_COPY_SLOTS;
+#ifdef AMYBOARD_BUILD_EPOCH
+    // zY: firmware-version query. The AMYboard editor sends this (framed as
+    // F0 00 03 45 'z' 'Y' 'Z' F7) right after detecting the board so it can
+    // warn when the connected firmware is older than the latest release.
+    // Reply with the compile-time build epoch (UTC unix seconds) as ASCII
+    // decimal digits:  F0 00 03 45 'Y' <digits> F7.
+    //
+    // Handled here in the tulip layer (not in the amy submodule) so amy stays
+    // untouched, and the build epoch — a tulip/board build concept — lives
+    // where it's defined. We intercept BEFORE amy_add_message_from_sysex so
+    // AMY never parses 'zY', and we send NO 'AK' ACK (the editor waits for the
+    // 'Y' reply, not an ACK). 'Y'/'y' are unused AMY wire opcodes, so older
+    // firmware lacking this handler simply logs and ignores the request.
+    if (slot && slot[0] == 'z' && slot[1] == 'Y') {
+        extern void midi_out(uint8_t *bytes, uint16_t len);
+        char digits[16];
+        int nd = snprintf(digits, sizeof(digits), "%lu", (unsigned long)AMYBOARD_BUILD_EPOCH);
+        uint8_t frame[24];
+        int fi = 0;
+        frame[fi++] = 0xF0; frame[fi++] = 0x00; frame[fi++] = 0x03; frame[fi++] = 0x45;
+        frame[fi++] = 'Y';
+        for (int i = 0; i < nd && fi < (int)sizeof(frame) - 1; i++) frame[fi++] = (uint8_t)digits[i];
+        frame[fi++] = 0xF7;
+        midi_out(frame, (uint16_t)fi);
+        return mp_const_none;
+    }
+#endif
     if (slot) {
         // Use _from_sysex variant so that during a file transfer,
         // this data is routed to parse_transfer_message. Internal


### PR DESCRIPTION
## Summary

Makes the editor's **pull/sync** warn when a connected hardware AMYboard is running firmware older than the latest release. Related to #936 but a separate change.

- **Firmware build epoch** — `esp32_common.cmake` stamps the AMYboard firmware with `AMYBOARD_BUILD_EPOCH` (UTC unix seconds, seconds precision via CMake `TIMESTAMP "%s"`) and writes `build/amyboard_build_epoch.txt`.
- **SysEx query** — `modtulip.c` answers a new `zY` query with `F0 00 03 45 'Y' <ascii epoch> F7`. Handled in the tulip layer (guarded by `#ifdef AMYBOARD_BUILD_EPOCH`), so the **`amy` submodule is untouched** and older firmware just ignores the unknown opcode (no reply).
- **Version manifest** — `fs_create.py` emits `dist/amyboard-version.json` `{board, epoch, git_hash, build_date}`; `release.sh`/`dev.sh` upload it so `releases/latest/download/amyboard-version.json` is the comparison baseline.
- **Editor** — `spss.js` pre-warms the board epoch on the readiness ping, re-queries on sync, fetches the latest-release epoch through the existing `/api/firmware` proxy (always against `releases/latest`), and after a successful pull shows a dismissible `#firmwareOutdatedModal` that can jump to the Upgrade Firmware tab. A missing `zY` reply (pre-feature firmware) counts as out of date.

## Stacking note

This is **stacked on #936** (base branch `amyboard-dev-channel`), because the `dev.sh` edit here depends on `dev.sh`, which #936 creates. GitHub will auto-retarget this PR to `main` once #936 merges. Everything else (cmake, modtulip.c, fs_create.py, release.sh, spss.js, editor) is independent of #936.

## Test plan

- [x] AMYboard firmware builds with `-DAMYBOARD_BUILD_EPOCH` compiled in; `amyboard_build_epoch.txt` written.
- [x] `fs_create.py` writes `amyboard-version.json` with the matching epoch.
- [x] `spss.js` passes `node --check`; edits sync into `stage/`.
- [ ] **Hardware round-trip** (requires flashing a dev build): old release firmware on the board triggers the modal after a pull; a freshly flashed board does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)