### PR TITLE
Add audio-in sketches: unity-gain passthrough + CV-controlled LPF

### DIFF
--- a/tulip/amyboardweb/sketches/filter_audio_in.py
+++ b/tulip/amyboardweb/sketches/filter_audio_in.py
@@ -2,12 +2,7 @@
 # Top-level code runs once at boot. loop() is called every 32nd note.
 import amy
 
-# DESCRIPTION: Pass audio in through to audio out
-# We just set up AMY to have a synth with two oscs
-# one for left channel and one for right channel. 
-
-# This will just pass through any audio in to audio out, including SPDIF to analog & vice versa
-# This also lets you set global effects on audio input
+# DESCRIPTION: Apply a low pass filter to audio in controlled by CV1
 
 # AMY's default volume is 1, which is -20dB. This is good for synths for headroom but not good 
 # for direct input to output effects. So let's set volume to 10, which is unity
@@ -16,6 +11,8 @@ amy.send(synth=18, num_voices=1, oscs_per_voice=2)
 amy.send(synth=18, osc=0, wave=amy.AUDIO_IN0, pan=0)
 amy.send(synth=18, osc=1, wave=amy.AUDIO_IN1, pan=1)
 amy.send(synth=18, vel=1,note=60) # turn on a note. The note number is required but ignored
+# Set filter-freq to be set by ext0 (CV1)
+amy.send(synth=18, filter_freq={'const': 300, 'ext0': 0.25}, filter_type=amy.FILTER_LPF24)
 
 def loop():
     pass


### PR DESCRIPTION
Adds/updates two AMYboard World example sketches for audio input.

## Changes
- **audiopassthru.py**: set `amy.send(volume=10)` (unity). AMY's default volume of 1.0 applies a ×0.1 (−20 dB) scaling at the output stage — good headroom for synths, but it makes direct audio-in→out passthrough quiet. Volume 10 is unity gain.
- **filter_audio_in.py** (new): applies a 24 dB/oct low-pass filter to the audio-in passthrough, with cutoff controlled by CV1 (`ext0`). Filter is set on the passthrough synth (`synth=18`) so it actually affects the AUDIO_IN oscillators.

## Notes
Both sketches will be published to AMYboard World (`shorepine`) via `deploy_sketches.py` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)