### PR TITLE
Address audio-in sketch review: per-osc gain, note-on, and filter

### DIFF
--- a/tulip/amyboardweb/sketches/audiopassthru.py
+++ b/tulip/amyboardweb/sketches/audiopassthru.py
@@ -9,13 +9,16 @@ import amy
 # This will just pass through any audio in to audio out, including SPDIF to analog & vice versa
 # This also lets you set global effects on audio input
 
-# AMY's default volume is 1, which is -20dB. This is good for synths for headroom but not good 
-# for direct input to output effects. So let's set volume to 10, which is unity
-amy.send(volume=10)
+# The two oscs aren't chained, so every per-osc setting has to be sent to each osc.
+# AMY's default volume (1) attenuates the output by -20dB for synth headroom. Rather than turn up
+# the global volume (which would affect everything), give each AUDIO_IN osc a fixed 10x gain (amp=10)
+# to reach unity, leaving vel for note dynamics.
 amy.send(synth=18, num_voices=1, oscs_per_voice=2)
-amy.send(synth=18, osc=0, wave=amy.AUDIO_IN0, pan=0)
-amy.send(synth=18, osc=1, wave=amy.AUDIO_IN1, pan=1)
-amy.send(synth=18, vel=1,note=60) # turn on a note. The note number is required but ignored
+amy.send(synth=18, osc=0, wave=amy.AUDIO_IN0, pan=0, amp=10)
+amy.send(synth=18, osc=1, wave=amy.AUDIO_IN1, pan=1, amp=10)
+# Turn on a note on each osc so both channels sound. The note number is required but ignored.
+amy.send(synth=18, osc=0, vel=1, note=60)
+amy.send(synth=18, osc=1, vel=1, note=60)
 
 def loop():
     pass

--- a/tulip/amyboardweb/sketches/filter_audio_in.py
+++ b/tulip/amyboardweb/sketches/filter_audio_in.py
@@ -4,15 +4,19 @@ import amy
 
 # DESCRIPTION: Apply a low pass filter to audio in controlled by CV1
 
-# AMY's default volume is 1, which is -20dB. This is good for synths for headroom but not good 
-# for direct input to output effects. So let's set volume to 10, which is unity
-amy.send(volume=10)
+# The two oscs aren't chained, so every per-osc setting has to be sent to each osc.
+# AMY's default volume (1) attenuates the output by -20dB for synth headroom. Give each AUDIO_IN osc
+# a fixed 10x gain (amp=10) to reach unity, leaving vel for note dynamics. The LPF24 is a linear
+# biquad cascade, so the hot pre-filter signal just scales through it.
 amy.send(synth=18, num_voices=1, oscs_per_voice=2)
-amy.send(synth=18, osc=0, wave=amy.AUDIO_IN0, pan=0)
-amy.send(synth=18, osc=1, wave=amy.AUDIO_IN1, pan=1)
-amy.send(synth=18, vel=1,note=60) # turn on a note. The note number is required but ignored
-# Set filter-freq to be set by ext0 (CV1)
-amy.send(synth=18, filter_freq={'const': 300, 'ext0': 0.25}, filter_type=amy.FILTER_LPF24)
+amy.send(synth=18, osc=0, wave=amy.AUDIO_IN0, pan=0, amp=10)
+amy.send(synth=18, osc=1, wave=amy.AUDIO_IN1, pan=1, amp=10)
+# Turn on a note on each osc so both channels sound. The note number is required but ignored.
+amy.send(synth=18, osc=0, vel=1, note=60)
+amy.send(synth=18, osc=1, vel=1, note=60)
+# Set filter-freq to be controlled by ext0 (CV1), on each osc so both channels are filtered.
+amy.send(synth=18, osc=0, filter_freq={'const': 300, 'ext0': 0.25}, filter_type=amy.FILTER_LPF24)
+amy.send(synth=18, osc=1, filter_freq={'const': 300, 'ext0': 0.25}, filter_type=amy.FILTER_LPF24)
 
 def loop():
     pass


### PR DESCRIPTION
Follow-up to #942 addressing @dpwe's review (https://github.com/shorepine/tulipcc/pull/942#pullrequestreview-4402302992).

The synth's two oscs (left/right `AUDIO_IN`) aren't chained, so every per-osc setting is now sent to each osc explicitly:

- **Unity gain via `amp=10` per osc** (with `vel=1`) instead of raising the global `volume`. `amp` sets the oscillator's constant gain coefficient (multiplied with vel and the envelope), so the makeup gain is local to the synth and the two sketches stay consistent. `vel` is left at 1 for note dynamics.
- **Note-on sent to both osc 0 and osc 1**, so both channels actually sound. The single note-on only reached the base osc (left channel) — the oscs aren't chained, so note/velocity don't propagate to osc 1.

### `filter_audio_in.py`
`filter_freq`/`filter_type` are also set on **both oscs** — the right channel (`AUDIO_IN1`) was previously unfiltered. The LPF24 is a linear biquad cascade, so the hot pre-filter signal just scales through it and the master volume scale brings it back to unity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
