### PR TITLE
Fix Railway deploy: add anthropic to root requirements.txt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,8 +174,12 @@ deploy of `tulip/amyboardweb/` does NOT touch it.
   — the root one takes precedence and uses `--app-dir tulip/server`)
 - Start command: `uvicorn amyboardworld_db_api:app --host 0.0.0.0 --port $PORT --app-dir tulip/server`
 - Production URL: `https://tulipcc-production.up.railway.app`
-- Dependencies: `tulip/server/requirements.txt` (fastapi, uvicorn[standard],
-  python-multipart, requests)
+- Dependencies: the **root** `/requirements.txt` is the file Railway/Nixpacks
+  actually installs (auto-detected at the repo root). Keep it in sync with
+  `tulip/server/requirements.txt` (the local-dev copy). Currently: fastapi,
+  uvicorn[standard], python-multipart, requests, anthropic. **Adding a dep to
+  only `tulip/server/requirements.txt` will NOT install it on Railway** — it
+  must also go in the root `/requirements.txt`.
 
 ### Auto-deploy on push to main
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn[standard]
 python-multipart
 requests
+anthropic


### PR DESCRIPTION
Follow-up to #944. Railway/Nixpacks installs deps from the **root** `/requirements.txt`, not `tulip/server/requirements.txt` — so the deployed `/generate` endpoint failed at runtime with `No module named 'anthropic'`. Adds `anthropic` to the root file and documents that the root file is the authoritative install source (keep in sync with the `tulip/server` copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)