### PR TITLE
Fix ADS1115 CV crosstalk + read both CV channels every AMY block (~5.8ms)

### DIFF
--- a/tulip/amyboard/amyboard_support.c
+++ b/tulip/amyboard/amyboard_support.c
@@ -87,6 +87,7 @@ void i2c_check_for_data() {
 #define ADS1115_DR_1600SPS (0x0080)
 #define ADS1115_MODE_SINGLE (0x0100)
 #define ADS1115_OS_SINGLE (0x8000)
+#define ADS1115_OS_NOTBUSY (0x8000) // OS bit reads 1 when no conversion is in progress
 #define ADS1115_PGA_2_048V (0x0400)
 #define ADS1115_PGA_4_096V (0x0200)
 #define ADS1115_MUX_SINGLE_0 (0x4000) 
@@ -146,6 +147,18 @@ uint16_t read_ads1115_raw(uint8_t channel) {
              ADS1115_MODE_SINGLE | ADS1115_OS_SINGLE | ADS1115_PGA_4_096V |
              channel_mux);
     ads1115_write_register(ADS1115_REGISTER_CONFIG, data);
+    // Wait for the single-shot conversion on the just-selected mux channel to
+    // finish before reading the result. The OS bit reads 0 while converting and
+    // 1 when done; at 1600 SPS a conversion takes ~625us. Without this wait the
+    // CONVERT register still holds the *previous* conversion (the other channel),
+    // which made cv_in(0) and cv_in(1) return the same input. Bound the poll so a
+    // missing/unresponsive ADC can't stall the cv_read_task forever.
+    uint8_t cfg[2];
+    for(int i = 0; i < 20; i++) {
+        if(ads1115_read_register(ADS1115_REGISTER_CONFIG, cfg, 2) != ESP_OK) break;
+        if((((uint16_t)cfg[0] << 8) | cfg[1]) & ADS1115_OS_NOTBUSY) break; // conversion done
+        vTaskDelay(pdMS_TO_TICKS(1));
+    }
     uint8_t output[2];
     ads1115_read_register(ADS1115_REGISTER_CONVERT, output, 2);
     return ((uint16_t)output[0] << 8) | (uint16_t)output[1];

--- a/tulip/amyboard/amyboard_support.c
+++ b/tulip/amyboard/amyboard_support.c
@@ -188,6 +188,15 @@ float cv_input_hook(uint16_t channel) {
 void cv_read_task(void *pvParameter) {
     uint16_t min = 1058;  // -10V
     uint16_t max = 21312; // 10V
+    // Scan both CV channels once per AMY audio block (AMY_BLOCK_SIZE / AMY_SAMPLE_RATE,
+    // ~5.8ms at 256/44100) so CV tracks the audio block cadence. Expressed in RTOS ticks,
+    // rounded to nearest, so it follows the audio rate regardless of tick rate; clamped to
+    // >=1 tick. (At configTICK_RATE_HZ=1000 this is 6 ticks; 5.8ms can't be hit exactly.)
+    TickType_t cv_period = (AMY_BLOCK_SIZE * configTICK_RATE_HZ + AMY_SAMPLE_RATE / 2) / AMY_SAMPLE_RATE;
+    if(cv_period == 0) cv_period = 1;
+    // xTaskDelayUntil holds a fixed period regardless of how long the two ADS1115
+    // conversions take, unlike vTaskDelay which would add the read time on top.
+    TickType_t last_wake = xTaskGetTickCount();
     for(;;) {
         for(uint8_t ch = 0; ch < 2; ch++) {
             if(!cv_local_override[ch]) {
@@ -195,7 +204,7 @@ void cv_read_task(void *pvParameter) {
                 cv_cached_value[ch] = ((((float)raw - (float)min)/((float)max-(float)min))*20.0)-10.0;
             }
         }
-        vTaskDelay(pdMS_TO_TICKS(50));
+        xTaskDelayUntil(&last_wake, cv_period);
     }
 }
 #endif


### PR DESCRIPTION
Two related changes to AMYboard CV input reading in `tulip/amyboard/amyboard_support.c`.

## 1. Fix CV input crosstalk (`read_ads1115_raw`)

`amyboard.cv_in(0)` and `amyboard.cv_in(1)` both returned the **channel 0** input, even though `amyboard.adc1115_raw(1)` correctly read the second jack. A user worked around it with a ~25ms delay between reads; this fixes the cause.

**Root cause:** `cv_in()` returns a value cached by the C background task `cv_read_task` → `read_ads1115_raw()`, which wrote the ADS1115 config register (selecting the mux channel **and** starting a single-shot conversion) and then **immediately read the conversion register with no wait**. At `DR_1600SPS` a conversion takes ~625µs, but the I2C read-back lands in ~100–300µs, so it returned the **previous** conversion's value. Because the task reads ch0 then ch1 back-to-back, the two cached values cross-wired onto effectively one channel. (`adc1115_raw()` uses the pure-Python `adc1115.py` driver, which polls the conversion-ready bit — hence it was correct.)

**Fix:** poll the OS conversion-ready bit (`0x8000`) after the config write and before reading the result, mirroring `adc1115.py`. Bounded to 20 iterations so a missing/unresponsive ADC can't stall the task.

## 2. Read both CV channels every AMY block (~5.8ms) instead of every 50ms

`cv_read_task` previously slept a fixed `vTaskDelay(50ms)` after each scan, so CV values could be up to ~50ms stale. It now paces to one AMY audio block period — `AMY_BLOCK_SIZE / AMY_SAMPLE_RATE` (256/44100 ≈ **5.8ms**) — derived from the `amy.h` macros so it tracks the audio rate.

- Uses **`xTaskDelayUntil`** (not `vTaskDelay`) so the period is fixed regardless of how long the two conversions take. `vTaskDelay` would have added the ~3ms read time on top.
- The board runs `CONFIG_FREERTOS_HZ=1000` (1ms tick), so 5.8ms rounds to **6ms** — the closest achievable with integer ticks. The period is computed round-to-nearest and clamped to ≥1 tick.
- The two polled reads take ~3ms, comfortably within the 6ms period. `cv_read_task` runs on its own low-priority FreeRTOS task on core 0, off the audio render thread.

## Testing

- [ ] **Not compiled or hardware-tested here.** This worktree's submodules aren't bootstrapped, so I didn't run the full ESP-IDF build. I did verify the dependencies statically: `AMY_BLOCK_SIZE`/`AMY_SAMPLE_RATE` are compile-time macros in the pinned `amy.h`, and `INCLUDE_xTaskDelayUntil=1` for xtensa in ESP-IDF 5.4.1.
- Build + flash AMYboard (`cd tulip/amyboard && idf.py -DMICROPY_BOARD=AMYBOARD build`), then with different voltages on CV1 and CV2 confirm `amyboard.cv_in(0)` and `amyboard.cv_in(1)` track their own jacks **without** any added delay, and that values update promptly (~6ms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)