### PR TITLE
Firmware upgrade page: only RST needed to reboot after upgrade

### DIFF
--- a/docs/amyboard/firmware.md
+++ b/docs/amyboard/firmware.md
@@ -19,7 +19,7 @@ The [AMYboard Online editor](https://amyboard.com/editor) includes a built-in fi
 <img src="img/serial_ports.png" width=400>
 
 5. Choose to either **Upgrade AMYboard firmware** (keeps your files) or **Fully erase and re-flash AMYboard** (fresh start).
-6. Wait for the process to complete. You then need to hit BOOT, then RST to restart your AMYboard into the upgraded firmware!
+6. Wait for the process to complete. You then need to hit RST to restart your AMYboard into the upgraded firmware!
 
 ---
 

--- a/tulip/amyboardweb/static/esptool/index.html
+++ b/tulip/amyboardweb/static/esptool/index.html
@@ -62,7 +62,7 @@
             <li><B>Upgrade AMYboard firmware.</B> Your stored data should be safe. </li>
             <li><B>Fully erase and re-flash AMYboard</b>. This will remove any stored patches or environments. (Your SD card is safe.) Use this only if you're having issues.
           </ul>
-          <li>Wait a minute until the progress bar disappears. Hit BOOT, then let go, then hit RST. Your AMYboard should be updated!</li>
+          <li>Wait a minute until the progress bar disappears. Hit RST. Your AMYboard should be updated!</li>
         </UL>
         <button id="butConnect" type="button">Search for AMYboard</button>
       </div>
@@ -94,7 +94,7 @@
             <div class="progress-bar hidden"><div></div></div>
           </div>
           <div id="upgradeComplete" class="upgrade-complete hidden">
-            Upgrade complete. Make sure to hit BOOT, then RST to reboot your AMYboard and then <a href="#" onclick="window.location.reload(); return false;">reload this page</a>.
+            Upgrade complete. Make sure to hit RST to reboot your AMYboard and then <a href="#" onclick="window.location.reload(); return false;">reload this page</a>.
           </div>
         </div>
       </div>


### PR DESCRIPTION
## What

On the AMYboard web firmware flasher page, the post-upgrade instructions told users to press **BOOT, then RST** to reboot into the new firmware. After a successful upgrade you only need to press **RST** — BOOT is not required (and pressing BOOT would put the board back into bootloader/download mode).

## Changes

- `tulip/amyboardweb/static/esptool/index.html`
  - Upgrade step: "Hit BOOT, then let go, then hit RST" → "Hit RST"
  - "Upgrade complete" banner: "hit BOOT, then RST to reboot" → "hit RST to reboot"
- `docs/amyboard/firmware.md`
  - Option 1 (web upgrader) final step: "hit BOOT, then RST to restart" → "hit RST to restart" (same instruction, kept consistent)

## Not changed

The **bootloader-entry** instructions are left as-is, because entering download mode genuinely requires BOOT:
- "Hold down both buttons … release RST, then release BOOT" (flasher page + docs)
- The wrong-port warning in `script.js` ("Hold down BOOT … Release BOOT")
- The `esptool` full-flash instructions

This matches `docs/amyboard/firmware.md`'s manual-flash step, which already says only "Press RST … to reboot it."

🤖 Generated with [Claude Code](https://claude.com/claude-code)