### PR TITLE
Add AMY_AGENTS.md guidance file read by the sketch generator

### DIFF
--- a/AMY_AGENTS.md
+++ b/AMY_AGENTS.md
@@ -1,0 +1,70 @@
+# AMY_AGENTS.md
+
+Guidance for the AMYboard **"Prompt to sketch"** code generator
+(`POST /api/amyboardworld/generate`). The server reads this file **at request
+time** and appends it to the generator's system prompt, so anything here directly
+steers the sketches Claude writes.
+
+**How to maintain this file:** add short, high-signal notes that correct a
+wrong-but-tempting pattern. The best entries say **"prefer X over Y, and why,"**
+with one small *verified* code example. Keep it tight — every word ships in every
+generation's prompt and counts toward token cost, so favor a crisp rule + example
+over prose.
+
+---
+
+## MIDI-controlled parameters: map the CC inside AMY (`midi_cc` / `ic`), don't poll in `loop()`
+
+When the user asks for a synth parameter (resonance, filter cutoff, amp, pan,
+pitch, …) to be controlled by a MIDI CC, **map the CC to the parameter inside
+AMY** with `amy.send(synth=N, midi_cc=...)` — the exact mechanism the on-screen
+knobs use. **Do not** write a `midi.add_callback` handler that reads the CC and
+calls `amy.send()` from `loop()`.
+
+Why: the AMY mapping lives in the audio engine, so the parameter tracks the CC at
+control rate with zero per-message Python overhead, and it keeps working even when
+`loop()` is busy. A Python polling callback is slower, jittery, and easy to get
+wrong.
+
+### Syntax
+
+`amy.send(synth=N, midi_cc="C,L,N,X,O,CMD")` — comma-separated fields:
+
+| field | meaning |
+|---|---|
+| `C` | MIDI CC number (0–127) |
+| `L` | log mapping? `0` = linear, `1` = logarithmic |
+| `N` | min value of the mapped output range |
+| `X` | max value of the mapped output range |
+| `O` | offset added after mapping |
+| `CMD` | the AMY **wire command** to run on each CC message, where `%i` → the MIDI channel and `%v` → the mapped value |
+
+`CMD` is a raw AMY wire command. Common parameter wire codes (from
+`amy/amy/__init__.py` `_KW_MAP_LIST`): resonance `R`, filter_freq `F`, amp `a`,
+pan `Q`, pitch_bend `s`. A synth-level set is `i%i<code>%v` — the wire form of
+`amy.send(synth=%i, <param>=%v)`.
+
+### Example — "make resonance controlled by MIDI CC 42"
+
+```python
+import amy
+amy.send(synth=1, patch=0, num_voices=4)          # Juno patch (has a filter/resonance)
+# Map CC 42 -> resonance on synth 1, linear, range 0..8:
+amy.send(synth=1, midi_cc="42,0,0,8,0,i%iR%v")
+
+def loop():
+    pass
+```
+
+`CMD = "i%iR%v"` runs `amy.send(synth=<channel>, resonance=<value>)` on every CC-42
+message — no `loop()` code, no callback.
+
+### Managing mappings
+
+- Remove one mapping: `amy.send(synth=N, midi_cc="42")` (CC number only, no other fields).
+- Remove all mappings for a synth: `amy.send(synth=N, midi_cc="255")`.
+
+> Source of truth: the editor builds these strings in `build_knob_cc_value()`
+> (`tulip/amyboardweb/static/spss.js`); per-knob `change_code` wire commands live in
+> `tulip/amyboardweb/static/amy_parameters.js`; the full field spec is the `ic` row
+> of `amy/docs/api.md`.

--- a/tulip/server/amyboardworld_db_api.py
+++ b/tulip/server/amyboardworld_db_api.py
@@ -1242,13 +1242,36 @@ def _log_generation(ip: str, prompt: str, result: dict[str, Any]) -> None:
         conn.commit()
 
 
+_AMY_AGENTS_PATH = Path(__file__).resolve().parents[2] / "AMY_AGENTS.md"
+
+
+def _load_amy_agents_guidance() -> str:
+    """Read the maintainer-edited AMY_AGENTS.md (repo root), if present, and return
+    it as an appended system-prompt section. Lets the team steer generated sketches
+    toward correct AMY idioms without code changes. Returns '' if absent / empty /
+    unreadable. Read per request so edits apply on the next deploy (or immediately
+    in local dev); when the file is unchanged the prompt bytes are stable, so the
+    Anthropic prompt cache stays warm."""
+    try:
+        text = _AMY_AGENTS_PATH.read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+    if not text:
+        return ""
+    return (
+        "\n\n# PROJECT GUIDANCE (from AMY_AGENTS.md) — authoritative; prefer these "
+        "patterns over naive ones:\n\n" + text
+    )
+
+
 def _generate_sketch_via_claude(description: str, current_code: str | None) -> dict[str, Any]:
     """Call the Anthropic API once (with one corrective retry) and return the
     extracted, validated sketch plus token usage. Raises on API errors."""
     import anthropic  # lazy: server still imports if the dep is absent
 
     client = anthropic.Anthropic(api_key=CLAUDE_API_KEY)
-    system = [{"type": "text", "text": _AMYBOARD_SYSTEM_PROMPT, "cache_control": {"type": "ephemeral"}}]
+    system_text = _AMYBOARD_SYSTEM_PROMPT + _load_amy_agents_guidance()
+    system = [{"type": "text", "text": system_text, "cache_control": {"type": "ephemeral"}}]
 
     frame = (
         "Write a complete AMYboard sketch.py for this request.\n\n"


### PR DESCRIPTION
Adds a maintainer-editable **`AMY_AGENTS.md`** (repo root) that the `/generate` endpoint appends to its system prompt **at request time**, so the team can steer generated sketches toward correct AMY idioms without code changes. When the file is unchanged the prompt bytes are stable, so prompt caching stays warm.

**First note:** map MIDI-CC-controlled parameters with `amy.send(synth=N, midi_cc="C,L,N,X,O,CMD")` (the `ic` wire command, exactly as the on-screen knobs do via `build_knob_cc_value`) instead of polling the CC in a `loop()`/`add_callback` handler — far more efficient (mapping lives in the audio engine).

Verified: for *"make resonance controlled by MIDI CC 42"*, the generator now emits `amy.send(synth=1, midi_cc="42,0,0,8,0,i%iR%v")` and no polling callback.

Edits to `AMY_AGENTS.md` take effect on the next deploy (push to main → Railway auto-redeploys) or immediately in local dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)