### PR TITLE
Fix preset_selector encoder direction (clockwise now increments)

### DIFF
--- a/tulip/amyboardweb/sketches/preset_selector.py
+++ b/tulip/amyboardweb/sketches/preset_selector.py
@@ -9,7 +9,9 @@ SEESAW = 0x36
 BTN_PIN = 24
 
 # --- State ---
-enc_offset = -amyboard.read_encoder(seesaw_dev=SEESAW)
+# Seesaw encoder counts down when turned clockwise, so we subtract the live
+# reading from the boot reading below to make clockwise increment the preset.
+enc_offset = amyboard.read_encoder(seesaw_dev=SEESAW)
 current_index = 0
 prev_btn = False
 loaded_patch = -1
@@ -42,7 +44,7 @@ draw()
 
 def loop():
     global current_index, prev_btn
-    raw = amyboard.read_encoder(seesaw_dev=SEESAW) + enc_offset
+    raw = enc_offset - amyboard.read_encoder(seesaw_dev=SEESAW)
     idx = raw % NUM_PRESETS
     btn = amyboard.read_buttons(pins=(BTN_PIN,), seesaw_dev=SEESAW)[0]
 


### PR DESCRIPTION
## Problem

In the AMYboard World `preset_selector` sketch, turning the rotary encoder **clockwise decremented** the preset instead of incrementing it.

## Cause

The Adafruit Seesaw rotary encoder counts *down* when turned clockwise (a known quirk — Adafruit's own examples negate `encoder.position`). The sketch computed `idx` so that it tracked the raw encoder count directly:

```python
enc_offset = -amyboard.read_encoder(seesaw_dev=SEESAW)   # boot calibration
...
raw = amyboard.read_encoder(seesaw_dev=SEESAW) + enc_offset   # == current - boot
idx = raw % NUM_PRESETS
```

So `idx` moved in the same direction as the encoder's raw count — i.e. down on clockwise.

## Fix

Invert how the live reading maps to the index, keeping the "start at index 0" calibration and the counterclockwise wraparound intact:

```python
enc_offset = amyboard.read_encoder(seesaw_dev=SEESAW)        # boot reading
...
raw = enc_offset - amyboard.read_encoder(seesaw_dev=SEESAW)  # == boot - current
idx = raw % NUM_PRESETS
```

- **At boot:** `enc_offset - reading == 0` → starts at preset 0. ✓
- **Clockwise** (reading decreases): value increases → preset increments. ✓
- **Counterclockwise** (reading increases): value goes negative, Python's `%` wraps `-1 → 256` → counts down with wraparound. ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)