### PR TITLE
tulip/macos: suppress clang-19 -Werror so the desktop build works

### DIFF
--- a/tulip/macos/Makefile
+++ b/tulip/macos/Makefile
@@ -4,8 +4,10 @@ WHICH_ARCH ?= $(shell arch)
 
 DEBUG=1
 
-# Ensure sub-makes (notably micropython/mpy-cross) also suppress this clang warning.
-export CFLAGS_EXTRA += -Wno-gnu-folding-constant
+# Ensure sub-makes (notably micropython/mpy-cross) also suppress these clang tightenings
+# (Apple clang / clang >= 19, e.g. macOS Tahoe). CFLAGS_EXTRA is appended after -Werror,
+# so these downgrade the otherwise-fatal warnings (e.g. moductypes.c type2char[16]).
+export CFLAGS_EXTRA += -Wno-gnu-folding-constant -Wno-unknown-warning-option -Wno-unterminated-string-initialization
 
 ifeq ($(WHICH_ARCH), arm64)
 	ARCHFLAGS = -target arm64-macos11


### PR DESCRIPTION
macOS host clang >= 19 (macOS Tahoe) defaults `-Wunterminated-string-initialization` on, and micropython's `extmod/moductypes.c` (`type2char[16] = "BbHhIiQq------fd"`) trips it. The unix port builds with `-Werror`, so the Tulip Desktop release build (`release.sh` → `macos/package.sh`) fails on a clean build.

Append `-Wno-unknown-warning-option -Wno-unterminated-string-initialization` to `CFLAGS_EXTRA` in `tulip/macos/Makefile` (the port applies `CFLAGS_EXTRA` after `-Werror`). Mirrors the existing `-Wno-gnu-folding-constant` here and `grab_submodules.sh`'s mpy-cross patch. esp32/xtensa-clang builds are unaffected.

Verified: the macOS desktop built (both arches), notarized, and shipped in the v-jun-2026 release with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)