### PR TITLE
World admin: sketch-generation audit log (prompt + output code + IP + time)

### DIFF
--- a/tulip/server/amyboardworld_admin.html
+++ b/tulip/server/amyboardworld_admin.html
@@ -19,6 +19,8 @@
     .err { color: #991b1b; }
     .tags { width: 220px; }
     .desc { max-width: 400px; }
+    pre.code { white-space: pre-wrap; max-width: 640px; max-height: 320px; overflow: auto; background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 6px; padding: 8px; margin: 4px 0 0; font-size: 12px; }
+    details summary { cursor: pointer; }
   </style>
 </head>
 <body>
@@ -87,6 +89,30 @@
         </tr>
       </thead>
       <tbody id="rows"></tbody>
+    </table>
+  </div>
+
+  <div class="panel">
+    <div class="row">
+      <h3 style="margin:0">Sketch generations</h3>
+      <input id="genQ" type="text" placeholder="filter prompt / code" />
+      <input id="genIp" type="text" placeholder="filter IP" />
+      <button id="genRefreshBtn" type="button">Refresh generations</button>
+    </div>
+    <div class="small">"Prompt to sketch" audit log (newest first). Output code is captured going forward.</div>
+    <table>
+      <thead>
+        <tr>
+          <th>When</th>
+          <th>IP</th>
+          <th>Prompt</th>
+          <th>OK</th>
+          <th>Model</th>
+          <th>Tokens (in/out)</th>
+          <th>Output code</th>
+        </tr>
+      </thead>
+      <tbody id="genRows"></tbody>
     </table>
   </div>
 
@@ -290,8 +316,50 @@
     }
   });
 
+  async function refreshGenerations() {
+    const token = getToken();
+    if (!token) { setStatus('Admin token required', true); return; }
+    const params = new URLSearchParams();
+    params.set('limit', '250');
+    const gq = (document.getElementById('genQ').value || '').trim();
+    if (gq) params.set('q', gq);
+    const gip = (document.getElementById('genIp').value || '').trim();
+    if (gip) params.set('ip', gip);
+    const genRows = document.getElementById('genRows');
+    try {
+      const data = await api('/api/admin/generations?' + params.toString(), {
+        headers: { 'x-admin-token': token },
+      });
+      const gens = Array.isArray(data.generations) ? data.generations : [];
+      genRows.innerHTML = '';
+      for (const g of gens) {
+        const tr = document.createElement('tr');
+        const okHtml = g.ok ? '<span class="ok">ok</span>' : '<span class="err">fail</span>';
+        const code = g.code || '';
+        const codeCell = code
+          ? '<details><summary class="small">' + esc(code.length) + ' chars</summary><pre class="code">' + esc(code) + '</pre></details>'
+          : '<span class="small">&mdash;</span>';
+        tr.innerHTML = '' +
+          '<td class="small">' + esc(fmtTs(g.time)) + '</td>' +
+          '<td class="mono small">' + esc(g.client_ip || '') + '</td>' +
+          '<td class="desc">' + esc(g.prompt || '') + '</td>' +
+          '<td>' + okHtml + '</td>' +
+          '<td class="mono small">' + esc(g.model || '') + '</td>' +
+          '<td class="mono small">' + esc(g.input_tokens) + ' / ' + esc(g.output_tokens) + '</td>' +
+          '<td>' + codeCell + '</td>';
+        genRows.appendChild(tr);
+      }
+      setStatus('Loaded ' + gens.length + ' generations', false);
+    } catch (err) {
+      setStatus('Generations load failed: ' + err.message, true);
+    }
+  }
+
+  document.getElementById('genRefreshBtn').addEventListener('click', refreshGenerations);
+
   adminTokenEl.value = localStorage.getItem('world_admin_token') || localStorage.getItem('amyboardworld_admin_token') || '';
   refresh();
+  refreshGenerations();
 })();
 </script>
 </body>

--- a/tulip/server/amyboardworld_db_api.py
+++ b/tulip/server/amyboardworld_db_api.py
@@ -216,12 +216,18 @@ def _ensure_schema() -> None:
               ok INTEGER NOT NULL DEFAULT 0,
               model TEXT NOT NULL DEFAULT '',
               input_tokens INTEGER NOT NULL DEFAULT 0,
-              output_tokens INTEGER NOT NULL DEFAULT 0
+              output_tokens INTEGER NOT NULL DEFAULT 0,
+              code TEXT NOT NULL DEFAULT ''
             );
             CREATE INDEX IF NOT EXISTS idx_gen_created ON generations(created_at_ms DESC);
             CREATE INDEX IF NOT EXISTS idx_gen_ip ON generations(client_ip);
             """
         )
+        # Add the generated-code column to pre-existing generations tables.
+        try:
+            conn.execute("ALTER TABLE generations ADD COLUMN code TEXT NOT NULL DEFAULT ''")
+        except sqlite3.OperationalError:
+            pass  # column already exists
 
 
 @app.on_event("startup")
@@ -1014,6 +1020,53 @@ def list_admin_items(
     return {"items": items[:limit]}
 
 
+@app.get("/api/admin/generations", dependencies=[Depends(_require_admin)])
+def list_admin_generations(
+    limit: int = Query(default=200, ge=1, le=500),
+    q: str = Query(default=""),
+    ip: str = Query(default=""),
+) -> dict[str, Any]:
+    """Audit log of 'prompt to sketch' generations: input prompt, output code, IP, time."""
+    clauses: list[str] = []
+    args: list[Any] = []
+    q_s = q.strip()
+    if q_s:
+        clauses.append("(prompt LIKE ? OR code LIKE ?)")
+        args.extend([f"%{q_s}%", f"%{q_s}%"])
+    ip_s = ip.strip()
+    if ip_s:
+        clauses.append("client_ip = ?")
+        args.append(ip_s)
+    where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+    args.append(limit)
+    with _open_db() as conn:
+        rows = conn.execute(
+            f"""
+            SELECT id, created_at_ms, client_ip, prompt, code, ok, model, input_tokens, output_tokens
+            FROM generations{where}
+            ORDER BY created_at_ms DESC
+            LIMIT ?
+            """,
+            tuple(args),
+        ).fetchall()
+    return {
+        "generations": [
+            {
+                "id": r["id"],
+                "time": r["created_at_ms"],
+                "client_ip": r["client_ip"],
+                "prompt": r["prompt"],
+                "code": r["code"],
+                "ok": bool(r["ok"]),
+                "model": r["model"],
+                "input_tokens": r["input_tokens"],
+                "output_tokens": r["output_tokens"],
+            }
+            for r in rows
+        ]
+    }
+
+
 # ---------------------------------------------------------------------------
 # AMYboard sketch generation via the Claude API
 # ---------------------------------------------------------------------------
@@ -1226,17 +1279,18 @@ def _log_generation(ip: str, prompt: str, result: dict[str, Any]) -> None:
     with _open_db() as conn:
         conn.execute(
             """
-            INSERT INTO generations(created_at_ms, client_ip, prompt, ok, model, input_tokens, output_tokens)
-            VALUES(?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO generations(created_at_ms, client_ip, prompt, ok, model, input_tokens, output_tokens, code)
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 _now_ms(),
                 ip,
-                prompt[:MAX_DESCRIPTION],
+                prompt[:GENERATE_MAX_PROMPT_CHARS],
                 1 if result.get("ok") else 0,
                 GENERATE_MODEL,
                 int(result.get("input_tokens", 0)),
                 int(result.get("output_tokens", 0)),
+                (result.get("code") or "")[:20000],
             ),
         )
         conn.commit()


### PR DESCRIPTION
Adds a viewable generations audit log to the World Admin page.

- **Server:** `generations` gets a `code` column (idempotent `ALTER` migration); `_log_generation` now stores the generated sketch + full prompt. New admin-token-protected `GET /api/admin/generations` (time, IP, prompt, code, ok, model, tokens; `limit`/`q`/`ip` filters).
- **Admin page:** a 'Sketch generations' section (newest first) with the prompt, IP, timestamp, ok/model/tokens, and expandable output code.

Output code is captured going forward; pre-existing rows show blank code. Railway auto-deploys on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)