### PR TITLE
World admin: v-scrollable file/message + generations lists

### DIFF
--- a/tulip/server/amyboardworld_admin.html
+++ b/tulip/server/amyboardworld_admin.html
@@ -21,6 +21,9 @@
     .desc { max-width: 400px; }
     pre.code { white-space: pre-wrap; max-width: 640px; max-height: 320px; overflow: auto; background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 6px; padding: 8px; margin: 4px 0 0; font-size: 12px; }
     details summary { cursor: pointer; }
+    .scroll-table { max-height: 60vh; overflow-y: auto; border: 1px solid #e5e7eb; border-radius: 6px; }
+    .scroll-table table { margin: 0; }
+    .scroll-table thead th { position: sticky; top: 0; background: #fff; box-shadow: inset 0 -1px 0 #e5e7eb; z-index: 1; }
   </style>
 </head>
 <body>
@@ -74,6 +77,7 @@
   <div id="status" class="small"></div>
 
   <div class="panel">
+    <div class="scroll-table">
     <table>
       <thead>
         <tr>
@@ -90,6 +94,7 @@
       </thead>
       <tbody id="rows"></tbody>
     </table>
+    </div>
   </div>
 
   <div class="panel">
@@ -100,6 +105,7 @@
       <button id="genRefreshBtn" type="button">Refresh generations</button>
     </div>
     <div class="small">"Prompt to sketch" audit log (newest first). Output code is captured going forward.</div>
+    <div class="scroll-table">
     <table>
       <thead>
         <tr>
@@ -114,6 +120,7 @@
       </thead>
       <tbody id="genRows"></tbody>
     </table>
+    </div>
   </div>
 
 <script>


### PR DESCRIPTION
Small UI fix: wrap both list tables (files/messages and the new Sketch generations log) in a fixed-height (60vh) scroll container with a sticky header, so long lists don't push the rest of the page down. Header stays visible while scrolling (box-shadow border, since the table uses border-collapse: collapse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)