### PR TITLE
World admin: admin-only 'Debug: prompt to code' box (no limits)

### DIFF
--- a/tulip/server/amyboardworld_admin.html
+++ b/tulip/server/amyboardworld_admin.html
@@ -123,6 +123,23 @@
     </div>
   </div>
 
+  <div class="panel">
+    <div class="row">
+      <h3 style="margin:0">Debug: prompt &rarr; code</h3>
+      <span class="small">Admin only &middot; no character cap &middot; no rate limit &middot; runs the live AMY sketch generator &middot; spends API credits &middot; not logged.</span>
+    </div>
+    <textarea id="dbgPrompt" rows="4" style="width:100%;box-sizing:border-box" placeholder="Enter any prompt (no length limit)&hellip;"></textarea>
+    <details>
+      <summary class="small">Optional: current sketch (debug edit mode)</summary>
+      <textarea id="dbgCurrent" rows="6" style="width:100%;box-sizing:border-box" placeholder="(optional) existing sketch.py to modify"></textarea>
+    </details>
+    <div class="row">
+      <button id="dbgRunBtn" type="button">Generate</button>
+      <span id="dbgMeta" class="small"></span>
+    </div>
+    <pre class="code" id="dbgOut" style="max-width:none;max-height:480px"></pre>
+  </div>
+
 <script>
 (function() {
   const status = document.getElementById('status');
@@ -363,6 +380,45 @@
   }
 
   document.getElementById('genRefreshBtn').addEventListener('click', refreshGenerations);
+
+  async function runDebugGenerate() {
+    const token = getToken();
+    if (!token) { setStatus('Admin token required', true); return; }
+    const prompt = document.getElementById('dbgPrompt').value;
+    if (!prompt.trim()) { setStatus('Enter a prompt for the debug generator', true); return; }
+    const current = document.getElementById('dbgCurrent').value;
+    const meta = document.getElementById('dbgMeta');
+    const out = document.getElementById('dbgOut');
+    const btn = document.getElementById('dbgRunBtn');
+    meta.textContent = ''; out.textContent = ''; btn.disabled = true;
+    setStatus('Generating...', false);
+    try {
+      const data = await api('/api/admin/generate_debug', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-admin-token': token },
+        body: JSON.stringify({ description: prompt, current_code: current.trim() ? current : null }),
+      });
+      if (data.error) {
+        meta.innerHTML = '<span class="err">error</span>';
+        out.textContent = data.error;
+      } else {
+        const verdict = data.ok
+          ? '<span class="ok">valid sketch</span>'
+          : '<span class="err">invalid: ' + esc(data.reason || '') + '</span>';
+        meta.innerHTML = verdict + ' &middot; ' + esc(data.model || '') + ' &middot; ' +
+          esc(data.input_tokens) + ' in / ' + esc(data.output_tokens) + ' out &middot; ' +
+          esc((data.code || '').length) + ' chars';
+        out.textContent = data.code || '(no code returned)';
+      }
+      setStatus('Debug generate done', false);
+    } catch (err) {
+      setStatus('Debug generate failed: ' + err.message, true);
+    } finally {
+      btn.disabled = false;
+    }
+  }
+
+  document.getElementById('dbgRunBtn').addEventListener('click', runDebugGenerate);
 
   adminTokenEl.value = localStorage.getItem('world_admin_token') || localStorage.getItem('amyboardworld_admin_token') || '';
   refresh();

--- a/tulip/server/amyboardworld_db_api.py
+++ b/tulip/server/amyboardworld_db_api.py
@@ -1462,3 +1462,34 @@ def generate_amyboard_sketch(body: GenerateRequest, request: Request) -> dict[st
         "remaining_today": max(0, GENERATE_PER_IP_PER_DAY - (ip_count + 1)),
         "model": GENERATE_MODEL,
     }
+
+
+class DebugGenerateRequest(BaseModel):
+    description: str
+    current_code: str | None = None
+
+
+@app.post("/api/admin/generate_debug", dependencies=[Depends(_require_admin)])
+def admin_generate_debug(body: DebugGenerateRequest) -> dict[str, Any]:
+    """Admin-only debug box: run the real sketch-generation pipeline on an arbitrary
+    prompt with NO character cap and NO rate limit, returning the generated code plus
+    the validation verdict (never a 422). Same system prompt + AMY_AGENTS guidance +
+    model as the public endpoint, so it shows exactly what the live generator produces.
+    Spends API credits and is NOT written to the generations audit log."""
+    if not CLAUDE_API_KEY:
+        raise HTTPException(status_code=503, detail="Sketch generation is not configured on this server")
+    description = (body.description or "").strip()
+    if not description:
+        raise HTTPException(status_code=400, detail="Enter a prompt")
+    try:
+        result = _generate_sketch_via_claude(description, body.current_code)
+    except Exception as exc:  # noqa: BLE001 — surface the real failure to the admin
+        return {"ok": False, "error": _redact_secrets(f"{type(exc).__name__}: {exc}"), "code": "", "reason": "api error"}
+    return {
+        "ok": result["ok"],
+        "reason": result.get("reason", ""),
+        "code": result["code"],
+        "model": GENERATE_MODEL,
+        "input_tokens": result.get("input_tokens", 0),
+        "output_tokens": result.get("output_tokens", 0),
+    }


### PR DESCRIPTION
Adds a debug box to the World Admin page for testing the sketch generator with arbitrary prompts.

- **Server:** new admin-token-gated `POST /api/admin/generate_debug`. Runs the **real** generation pipeline (`_generate_sketch_via_claude` — same system prompt + AMY_AGENTS guidance + model + validation/one-retry) on the given prompt, with **no character cap and no rate limit**. Returns the generated code plus the validation verdict (`ok`/`reason`) and token usage — never a 422. Not written to the generations audit log.
- **Admin page:** a 'Debug: prompt → code' panel — an unbounded prompt textarea, an optional current-sketch field (edit mode), and an output box showing the code, whether it passed validation, the model, and token counts.

Admin-only; it spends API credits. (Same-pipeline-only by request — no raw/no-system-prompt mode.)