### PR TITLE
Admin debug box: show reference-tool lookup count

### DIFF
--- a/tulip/server/amyboardworld_admin.html
+++ b/tulip/server/amyboardworld_admin.html
@@ -405,7 +405,9 @@
         const verdict = data.ok
           ? '<span class="ok">valid sketch</span>'
           : '<span class="err">invalid: ' + esc(data.reason || '') + '</span>';
+        const lookups = data.tool_calls || 0;
         meta.innerHTML = verdict + ' &middot; ' + esc(data.model || '') + ' &middot; ' +
+          esc(lookups) + ' lookup' + (lookups === 1 ? '' : 's') + ' &middot; ' +
           esc(data.input_tokens) + ' in / ' + esc(data.output_tokens) + ' out &middot; ' +
           esc((data.code || '').length) + ' chars';
         out.textContent = data.code || '(no code returned)';


### PR DESCRIPTION
Surfaces the `tool_calls` field (already returned by `/api/admin/generate_debug`) in the admin **Debug: prompt → code** meta line, so admins can see how many reference lookups the agentic generator made for a given prompt (e.g. `valid sketch · claude-sonnet-4-6 · 3 lookups · 1234 in / 567 out · 890 chars`). `0 lookups` indicates the single-shot path.

Tiny, isolated UI change (`amyboardworld_admin.html`), no server/behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)