### PR TITLE
Generator: cache tool-loop history + fix 24h rate-limit message

### DIFF
--- a/tulip/server/amyboardworld_admin.html
+++ b/tulip/server/amyboardworld_admin.html
@@ -406,9 +406,11 @@
           ? '<span class="ok">valid sketch</span>'
           : '<span class="err">invalid: ' + esc(data.reason || '') + '</span>';
         const lookups = data.tool_calls || 0;
+        const cached = data.cache_read_input_tokens || 0;
         meta.innerHTML = verdict + ' &middot; ' + esc(data.model || '') + ' &middot; ' +
           esc(lookups) + ' lookup' + (lookups === 1 ? '' : 's') + ' &middot; ' +
-          esc(data.input_tokens) + ' in / ' + esc(data.output_tokens) + ' out &middot; ' +
+          esc(data.input_tokens) + ' in' + (cached ? ' (+' + esc(cached) + ' cached)' : '') +
+          ' / ' + esc(data.output_tokens) + ' out &middot; ' +
           esc((data.code || '').length) + ' chars';
         out.textContent = data.code || '(no code returned)';
       }

--- a/tulip/server/amyboardworld_db_api.py
+++ b/tulip/server/amyboardworld_db_api.py
@@ -1597,6 +1597,28 @@ def _run_reference_tool(name: str, tool_input: Any) -> dict[str, Any]:
         return {"content": f"Tool error: {type(exc).__name__}: {exc}", "is_error": True}
 
 
+def _apply_rolling_cache_breakpoint(messages: list[dict[str, Any]]) -> None:
+    """Keep ONE rolling prompt-cache breakpoint on the most recent message so the
+    tool-loop history (big re-sent tool results like a whole doc) is read from
+    cache at ~0.1x on later turns instead of re-sent at full price. The static
+    system/tools breakpoint plus this one is 2 total — well under the 4 limit.
+
+    We only ever attach cache_control to the plain dict blocks we build (the
+    tool_result / text turns); assistant turns hold SDK block objects and are left
+    untouched (they're still covered by the prefix that the breakpoint caches)."""
+    for msg in messages:
+        content = msg.get("content")
+        if isinstance(content, list):
+            for blk in content:
+                if isinstance(blk, dict):
+                    blk.pop("cache_control", None)
+    if not messages:
+        return
+    last_content = messages[-1].get("content")
+    if isinstance(last_content, list) and last_content and isinstance(last_content[-1], dict):
+        last_content[-1]["cache_control"] = {"type": "ephemeral"}
+
+
 def _generate_sketch_via_claude(description: str, current_code: str | None) -> dict[str, Any]:
     """Generate a sketch via the Anthropic API, running an agentic reference-tool
     loop (search/read this repo's sketches+docs+libs) until the model produces a
@@ -1628,9 +1650,12 @@ def _generate_sketch_via_claude(description: str, current_code: str | None) -> d
     frame += "\n\nOutput only the contents of sketch.py."
     messages: list[dict[str, Any]] = [{"role": "user", "content": frame}]
 
-    totals = {"in": 0, "out": 0, "cache": 0}
+    totals = {"in": 0, "out": 0, "cache": 0, "cache_create": 0}
 
     def _create(use_tools: bool) -> Any:
+        # Roll the cache breakpoint to the newest message so the loop's growing
+        # history is cache-read on later turns instead of re-sent at full price.
+        _apply_rolling_cache_breakpoint(messages)
         kwargs: dict[str, Any] = dict(
             model=GENERATE_MODEL,
             max_tokens=GENERATE_MAX_TOKENS,
@@ -1644,6 +1669,7 @@ def _generate_sketch_via_claude(description: str, current_code: str | None) -> d
         totals["in"] += getattr(u, "input_tokens", 0) or 0
         totals["out"] += getattr(u, "output_tokens", 0) or 0
         totals["cache"] += getattr(u, "cache_read_input_tokens", 0) or 0
+        totals["cache_create"] += getattr(u, "cache_creation_input_tokens", 0) or 0
         return r
 
     tool_calls = 0
@@ -1711,6 +1737,7 @@ def _generate_sketch_via_claude(description: str, current_code: str | None) -> d
         "input_tokens": totals["in"],
         "output_tokens": totals["out"],
         "cache_read_input_tokens": totals["cache"],
+        "cache_creation_input_tokens": totals["cache_create"],
         "tool_calls": tool_calls,
     }
 
@@ -1735,11 +1762,11 @@ def generate_amyboard_sketch(body: GenerateRequest, request: Request) -> dict[st
     since_ms = _now_ms() - 24 * 60 * 60 * 1000
     ip_count, global_count = _count_generations_since(ip, since_ms)
     if global_count >= GENERATE_GLOBAL_PER_DAY:
-        raise HTTPException(status_code=429, detail="Sketch generation is busy today — please try again tomorrow")
+        raise HTTPException(status_code=429, detail="Sketch generation is busy right now — please try again later")
     if ip_count >= GENERATE_PER_IP_PER_DAY:
         raise HTTPException(
             status_code=429,
-            detail=f"Daily limit reached ({GENERATE_PER_IP_PER_DAY} sketches/day). Try again tomorrow.",
+            detail=f"Limit reached ({GENERATE_PER_IP_PER_DAY} sketches per 24 hours). Please try again later.",
         )
 
     try:
@@ -1803,5 +1830,6 @@ def admin_generate_debug(body: DebugGenerateRequest) -> dict[str, Any]:
         "model": GENERATE_MODEL,
         "input_tokens": result.get("input_tokens", 0),
         "output_tokens": result.get("output_tokens", 0),
+        "cache_read_input_tokens": result.get("cache_read_input_tokens", 0),
         "tool_calls": result.get("tool_calls", 0),
     }

--- a/tulip/server/test_reference_tools.py
+++ b/tulip/server/test_reference_tools.py
@@ -76,6 +76,35 @@ check("dispatch search", m._run_reference_tool("search_reference", {"query": "re
 check("dispatch unknown is error", m._run_reference_tool("nope", {}).get("is_error") is True)
 check("dispatch bad input type tolerated", m._run_reference_tool("list_reference", None).get("content") is not None)
 
+# --- rolling prompt-cache breakpoint ---
+
+def _count_cc(msgs):
+    n = 0
+    for msg in msgs:
+        c = msg.get("content")
+        if isinstance(c, list):
+            n += sum(1 for b in c if isinstance(b, dict) and "cache_control" in b)
+    return n
+
+
+_msgs = [
+    {"role": "user", "content": "frame string"},
+    {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "a", "content": "x"}]},
+]
+m._apply_rolling_cache_breakpoint(_msgs)
+check("cache: marks newest message", _msgs[-1]["content"][-1].get("cache_control") == {"type": "ephemeral"})
+check("cache: exactly one breakpoint", _count_cc(_msgs) == 1)
+# advance a turn — breakpoint must move, not accumulate
+_msgs.append({"role": "user", "content": [{"type": "tool_result", "tool_use_id": "b", "content": "y"}]})
+m._apply_rolling_cache_breakpoint(_msgs)
+check("cache: still exactly one breakpoint after advancing", _count_cc(_msgs) == 1)
+check("cache: breakpoint moved to newest", _msgs[-1]["content"][-1].get("cache_control") == {"type": "ephemeral"})
+check("cache: old breakpoint cleared", "cache_control" not in _msgs[1]["content"][-1])
+# string-only last message (initial frame / corrective retry): no crash, no breakpoint
+_msgs_str = [{"role": "user", "content": "hello"}]
+m._apply_rolling_cache_breakpoint(_msgs_str)
+check("cache: string content tolerated", _count_cc(_msgs_str) == 0)
+
 # --- agentic loop control flow (mocked Anthropic client, no network) ---
 import types  # noqa: E402
 
@@ -87,7 +116,7 @@ def _ns(**kw):
 
 
 def _usage():
-    return _ns(input_tokens=10, output_tokens=5, cache_read_input_tokens=2)
+    return _ns(input_tokens=10, output_tokens=5, cache_read_input_tokens=2, cache_creation_input_tokens=3)
 
 
 def _tool_use(name="search_reference", inp=None, _id="t1"):
@@ -130,7 +159,12 @@ try:
     check("loop: 2 tool calls serviced", res["tool_calls"] == 2)
     check("loop: returns the sketch", "import amy" in res["code"])
     check("loop: tokens accumulated across turns", res["input_tokens"] == 30 and res["output_tokens"] == 15)
+    check("loop: cache fields accumulated", res["cache_read_input_tokens"] == 6 and res["cache_creation_input_tokens"] == 9)
     check("loop: first call sent tools", "tools" in rec["calls"][0])
+    check("loop: a cache breakpoint was set on a later turn",
+          any(isinstance(msg.get("content"), list)
+              and any(isinstance(b, dict) and "cache_control" in b for b in msg["content"])
+              for call in rec["calls"] for msg in call["messages"]))
 
     # Turn cap: model keeps calling tools forever; loop must stop and force a final answer.
     cap = m.GENERATE_MAX_TOOL_TURNS


### PR DESCRIPTION
## What

Two fixes to the AMYboard sketch generator:

1. **Message-history prompt caching.** The agentic loop re-sent its whole growing history (including big `read_reference` payloads like `synth.md`) at full price on every turn — the dominant cost. Now a single **rolling cache breakpoint** sits on the newest message so that prefix is read from cache (~0.1×) on later turns. With the static system/tools breakpoint that's 2 total (under the 4-breakpoint limit). Expected **~3–4× lower** per-generation cost on multi-lookup runs. Also tracks `cache_creation` tokens and shows cache reads in the admin debug box (e.g. `12345 in (+50000 cached)`).
2. **Honest rate-limit messages.** The cap is a rolling 24h window, not a calendar day, so the old "Try again tomorrow" was misleading. Now: `Limit reached (N sketches per 24 hours). Please try again later.` (and the global one says "busy right now").

## Tests

`test_reference_tools.py` extended: rolling-breakpoint behavior (marks newest, moves rather than accumulates, tolerates string content) and loop cache-field accumulation. Full suite passes (49 checks).

## Notes

- Server/UI only; no `amy` pin change, no new deps.
- The rolling breakpoint only touches the plain dict blocks we build (tool_result/text turns); SDK assistant blocks are left untouched but still covered by the cached prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)