### PR TITLE
editor: rename run-controls title "Sequencer" -> "Sketch"

### DIFF
--- a/tulip/amyboardweb/static/editor/index.html
+++ b/tulip/amyboardweb/static/editor/index.html
@@ -1487,7 +1487,7 @@
               <div class="row mb-4 mt-1 d-none" id="control-run-controls">
                 <div class="col-12">
                   <div class="border rounded bg-light px-3 py-2 d-flex flex-wrap align-items-center gap-2">
-                    <span class="small fw-semibold">Sequencer:</span>
+                    <span class="small fw-semibold">Sketch:</span>
                     <button type="button" class="btn btn-sm btn-success" onclick="control_sequencer_start();">Start</button>
                     <button type="button" class="btn btn-sm btn-danger" onclick="control_sequencer_stop();">Stop</button>
                     <button type="button" class="btn btn-sm btn-warning" onclick="restart_sketch();">Restart</button>
@@ -1500,7 +1500,7 @@
               <div class="row mb-4 mt-1" id="run-controls">
                 <div class="col-12">
                   <div class="border rounded bg-light px-3 py-2 d-flex flex-wrap align-items-center gap-2">
-                    <span class="small fw-semibold">Sequencer:</span>
+                    <span class="small fw-semibold">Sketch:</span>
                     <button
                       type="button"
                       title="Start sketch"


### PR DESCRIPTION
In the AMYboard online editor, the Start / Stop / Restart button group was titled **Sequencer:** in both run-control bars. This relabels just that title to **Sketch:** — it better reflects that the buttons start/stop/restart the whole sketch, not only the sequencer.

- `#control-run-controls` (control mode) and `#run-controls` (simulate mode) in `tulip/amyboardweb/static/editor/index.html`.
- Title `<span>` text only; the Start/Stop/Restart buttons and their `onclick` handlers are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)