### PR TITLE
editor: clarify prompt-to-sketch help text

### DIFF
--- a/tulip/amyboardweb/static/editor/index.html
+++ b/tulip/amyboardweb/static/editor/index.html
@@ -1464,7 +1464,7 @@
                     <span class="small text-muted" id="prompt-to-sketch-status"></span>
                   </div>
                   <div class="form-text">
-                    This will create a sketch.py for you if you describe it to us. We'll help you understand how to work with your AMYboard by looking up the documentation. Won't always be perfect, find us on Discord for more help!
+                    This will create or modify a sketch.py for you if you describe what you want. Clear the editor if you want to start from scratch. We'll help you understand how to work with your AMYboard by looking up the documentation. Won't always be perfect, find us on Discord for more help!
                   </div>
                 </div>
               </details>


### PR DESCRIPTION
Updates the help text under the "Create the sketch" prompt in the AMYboard online editor (`tulip/amyboardweb/static/editor/index.html`) to reflect that the generator can **create or modify** the existing `sketch.py` (it receives the current editor contents), and to tell users they can clear the editor to start from scratch.

Text-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)