### PR TITLE
amyboardweb: cache-control headers to prevent stale builds

### DIFF
--- a/tulip/amyboardweb/vercel.json
+++ b/tulip/amyboardweb/vercel.json
@@ -4,5 +4,25 @@
       "source": "/proxy",
       "destination": "/api/firmware"
     }
+  ],
+  "headers": [
+    {
+      "source": "/((?!amy-|amyboard-).*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache"
+        }
+      ]
+    },
+    {
+      "source": "/(amyboard|amy)-(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Fixes the stale-build symptom (e.g. the Safari `AttributeError: 'module' object has no attribute 'restart_sketch'`): with no `Cache-Control` headers, browsers heuristically cache the editor's HTML / `spss.js` and serve an old build whose `amyboard` WASM module predates a function the JS calls.

Adds `headers` to `tulip/amyboardweb/vercel.json`:
- **Everything except the timestamped WASM blobs → `no-cache`** (store but always revalidate). HTML, `spss.js`, generated JS and CSS are non-hashed, so they must revalidate to pick up new deploys. Revalidation returns `304` when unchanged, so it's cheap.
- **Timestamped blobs (`amy-<ts>.*`, `amyboard-<ts>.*`) → `public, max-age=31536000, immutable`**. Their filenames are unique per build, so they're safe to cache forever.

A negative lookahead (`/((?!amy-|amyboard-).*)`) keeps the two rules non-overlapping, so correctness doesn't depend on Vercel's header precedence.

Note: this is forward-looking — already-cached responses keep their old (header-less) lifetime until they expire or a hard refresh; from the first fetch of the new build onward, entry points always revalidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)