### PR TITLE
community digest bot: scheduled GitHub+Discord triage to #admin-actions

### DIFF
--- a/tulip/server/community_digest.md
+++ b/tulip/server/community_digest.md
@@ -1,0 +1,103 @@
+# Community digest bot
+
+A scheduled Claude Code agent that, every ~12 hours, scans GitHub
+(shorepine/tulipcc + shorepine/amy issues/PRs/discussions) and the community
+Discord channels, then posts a triaged digest to the private **#admin-actions**
+channel: a short "what's going on", a list of **simple actions it recommends**
+(you approve), and a list of **things that need your call**.
+
+- Helper / data layer: [`community_digest.py`](community_digest.py)
+- Routine prompt (the agent's instructions): [`community_digest_routine.md`](community_digest_routine.md)
+
+## Token
+
+The Discord bot token (`WORLD_DISCORD_BOT_TOKEN`, the same one the world DB API
+uses) is read from the environment, or from a local gitignored file:
+
+```
+~/.config/tulip-digest.env   (chmod 600)
+    WORLD_DISCORD_BOT_TOKEN=...
+```
+
+The helper is stdlib-only and **never** prints the token or reads Railway. To
+provision the file from Railway (run in your own terminal):
+
+```bash
+mkdir -p ~/.config && railway variables --json | python3 -c '
+import json, os, sys
+d = json.load(sys.stdin)
+t = d.get("WORLD_DISCORD_BOT_TOKEN") or d.get("AMYBOARDWORLD_DISCORD_BOT_TOKEN")
+assert t, "no Discord bot-token var found"
+p = os.path.expanduser("~/.config/tulip-digest.env")
+open(p, "w").write("WORLD_DISCORD_BOT_TOKEN=" + t + "\n"); os.chmod(p, 0o600)
+print("wrote", p)'
+```
+
+## CLI
+
+```
+python3 tulip/server/community_digest.py gather [--hours N]   # GitHub + Discord activity → JSON
+python3 tulip/server/community_digest.py read-channel <id> [--limit N] [--after <msg_id>]
+python3 tulip/server/community_digest.py post <id> [--text T] # or pipe body on stdin
+python3 tulip/server/community_digest.py delete <id> <msg_id>
+python3 tulip/server/community_digest.py resolve-channel <name>
+```
+
+Config lives at the top of `community_digest.py`: `GH_REPOS`, `SCAN_CHANNELS`
+(the 6 human Discord channels scanned — edit freely), and the #admin-actions
+channel id used by the routine. Discord history is fetched one page deep
+(100 msgs/channel); ample for a 12–24h window.
+
+## Scheduling (local Desktop task — recommended)
+
+The routine needs your local `gh` auth and the local token file, so it runs
+**on your Mac**, not in a cloud routine. (Cloud routines can't see local files /
+`gh` auth; they'd need the token as a cloud env var + the Claude GitHub App.)
+
+1. **The code must be in the checkout the task runs from** — merge this to
+   `main` (or wherever the task's working dir points).
+2. **Grant the routine its one command** in `~/.claude/settings.json` (you must
+   add this yourself — agents can't self-grant permissions). Merge into the
+   existing `permissions.allow` array:
+
+   ```json
+   {
+     "permissions": {
+       "allow": [
+         "Bash(python3 tulip/server/community_digest.py:*)"
+       ]
+     }
+   }
+   ```
+
+   That single rule is all v1 needs: the helper invokes `gh` and Discord as
+   subprocesses, so they aren't separately gated, and v1 never runs `gh`-write
+   commands.
+3. **Create the task:** Desktop app → Routines → New → **Local**. Working dir =
+   the repo root. Instructions: *"Run the community digest routine exactly as
+   described in tulip/server/community_digest_routine.md."* Schedule: every 12h.
+   Permission mode: **`dontAsk`** (only pre-approved commands run; no prompts).
+
+The task fires when your Mac is powered on (it catches up on wake).
+
+### launchd fallback (if you don't want the desktop app to manage it)
+
+```bash
+claude -p "$(cat /Users/bwhitman/outside/tulipcc/tulip/server/community_digest_routine.md)" \
+  --permission-mode dontAsk --output-format json >> ~/.config/tulip-digest.log 2>&1
+```
+
+Wrap that in a `launchd` plist with `StartInterval 43200` (12h).
+
+## v1 vs v2
+
+- **v1 (this):** the agent gathers, triages, and **posts** the digest. It only
+  *recommends* the simple actions — **you** run them by asking Claude Code,
+  referencing the digest's item numbers (e.g. "do 1 and 4"). The digest does not
+  invite Discord replies. Minimal powers: read GitHub, read Discord, post to
+  #admin-actions.
+- **v2 (later):** reply `do 1 4 5` in #admin-actions and the next run executes
+  those approved items (file the bug, add the FAQ line, comment on the issue).
+  That needs (a) the agent granted scoped `gh`-write + post permissions, and
+  (b) a small state file mapping the digest's action numbers → concrete
+  commands so the next run knows what "1, 4, 5" mean.

--- a/tulip/server/community_digest.py
+++ b/tulip/server/community_digest.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Community digest helper for the tulip/amy/amyboard scheduled routine.
+
+Stdlib only (no pip deps) so it runs anywhere python3 is available, including a
+laptop Claude Code routine without a venv. GitHub activity is read via the `gh`
+CLI; Discord via the REST API.
+
+Token handling: the Discord bot token is read from the environment
+(WORLD_DISCORD_BOT_TOKEN, matching the server). If it is not already in the
+environment, it is loaded from a local, gitignored env file -- by default
+~/.config/tulip-digest.env, overridable with $TULIP_DIGEST_ENV. The token is
+never printed, and this helper never touches Railway or any other secret store.
+
+  ~/.config/tulip-digest.env  (chmod 600):
+      WORLD_DISCORD_BOT_TOKEN=...
+
+Subcommands:
+  gather                   Emit recent GitHub + Discord activity as JSON.
+  resolve-channel <name>   Find a Discord channel id by name across the bot's guilds.
+  read-channel <id>        Print recent messages in a channel (activity / approvals).
+  post <id>                Post a message to a channel (body from --text or stdin).
+  delete <id> <msg>        Delete a message (used to clean up test posts).
+  edit <id> <msg>          Replace a message's content (body from --text or stdin).
+"""
+import argparse
+import datetime
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+DISCORD_API = "https://discord.com/api/v10"
+
+# Env var names to check (in order). Matches amyboardworld_db_api.py:90.
+TOKEN_ENV_CANDIDATES = (
+    "WORLD_DISCORD_BOT_TOKEN",
+    "AMYBOARDWORLD_DISCORD_BOT_TOKEN",
+)
+
+# GitHub repos to watch. amyboard has no separate repo -- its issues live in
+# tulipcc.
+GH_REPOS = ("shorepine/tulipcc", "shorepine/amy")
+
+# Discord channels to scan for people having issues. Bot-feed / automated
+# channels (#github, #tulip-world*, #amyboard-world-files) are intentionally
+# excluded -- GitHub activity is gathered directly via gh. Adjust freely.
+SCAN_CHANNELS = (
+    ("general", "1126544387942400106"),
+    ("tulip", "1126572351618822338"),
+    ("amy", "1126572379930361896"),
+    ("amyboard", "1332047647120424993"),
+    ("tulip-app-dev", "1324829560243621919"),
+    ("your-projects", "1510990549040107653"),
+)
+
+# Discord history is fetched one page deep (100 messages/channel). For a 12-24h
+# window in this community that is ample; a busier window could miss older
+# messages. Bump to pagination if that ever becomes real.
+DISCORD_PAGE = 100
+
+
+# --------------------------------------------------------------------------
+# Token / env
+# --------------------------------------------------------------------------
+def _env_file_path():
+    return os.environ.get("TULIP_DIGEST_ENV") or os.path.expanduser(
+        "~/.config/tulip-digest.env"
+    )
+
+
+def _load_env_file():
+    """Populate os.environ from a simple KEY=VALUE file, without overwriting."""
+    path = _env_file_path()
+    try:
+        with open(path, encoding="utf-8") as fh:
+            lines = fh.readlines()
+    except OSError:
+        return
+    for raw in lines:
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, val = line.split("=", 1)
+        key = key.strip()
+        val = val.strip().strip('"').strip("'")
+        if key and key not in os.environ:
+            os.environ[key] = val
+
+
+def get_token():
+    for env in TOKEN_ENV_CANDIDATES:
+        if os.environ.get(env):
+            return os.environ[env]
+    _load_env_file()
+    for env in TOKEN_ENV_CANDIDATES:
+        if os.environ.get(env):
+            return os.environ[env]
+    raise SystemExit(
+        f"Discord bot token not found. Set WORLD_DISCORD_BOT_TOKEN in the "
+        f"environment or in {_env_file_path()} (KEY=VALUE, chmod 600)."
+    )
+
+
+# --------------------------------------------------------------------------
+# Discord REST
+# --------------------------------------------------------------------------
+def discord_request(method, path, token, body=None):
+    url = f"{DISCORD_API}{path}"
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bot {token}")
+    req.add_header("User-Agent",
+                   "TulipCC-CommunityDigest/0.1 (https://tulip.computer)")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            raw = resp.read().decode()
+            return json.loads(raw) if raw else None
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode(errors="replace")
+        raise SystemExit(f"Discord {method} {path} -> HTTP {e.code}: {detail}")
+    except urllib.error.URLError as e:
+        raise SystemExit(f"Discord {method} {path} -> {e}")
+
+
+# --------------------------------------------------------------------------
+# Gather: GitHub (via gh) + Discord activity since a cutoff
+# --------------------------------------------------------------------------
+def _parse_iso(s):
+    if not s:
+        return None
+    try:
+        return datetime.datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _gh(args):
+    """Run a gh command, returning parsed JSON or None on any failure."""
+    try:
+        out = subprocess.run(["gh"] + args, capture_output=True, text=True,
+                             timeout=60)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if out.returncode != 0:
+        return None
+    try:
+        return json.loads(out.stdout or "null")
+    except json.JSONDecodeError:
+        return None
+
+
+def _gh_items(repo, kind, cutoff_dt):
+    """Open issues or PRs updated since cutoff. kind in {'issue','pr'}."""
+    fields = "number,title,author,updatedAt,createdAt,labels,url"
+    if kind == "pr":
+        fields += ",isDraft"
+    data = _gh([kind, "list", "--repo", repo, "--state", "open",
+                "--json", fields, "--limit", "100"]) or []
+    out = []
+    for it in data:
+        dt = _parse_iso(it.get("updatedAt"))
+        if not dt or dt < cutoff_dt:
+            continue
+        row = {
+            "number": it.get("number"),
+            "title": it.get("title"),
+            "author": (it.get("author") or {}).get("login"),
+            "updatedAt": it.get("updatedAt"),
+            "createdAt": it.get("createdAt"),
+            "labels": [l.get("name") for l in it.get("labels", [])],
+            "url": it.get("url"),
+        }
+        if kind == "pr":
+            row["isDraft"] = it.get("isDraft")
+        out.append(row)
+    return out
+
+
+def _gh_discussions(repo, cutoff_dt):
+    owner, name = repo.split("/")
+    query = (
+        "query($owner:String!,$name:String!){"
+        "repository(owner:$owner,name:$name){"
+        "discussions(first:30,orderBy:{field:UPDATED_AT,direction:DESC}){"
+        "nodes{number title url updatedAt createdAt author{login}"
+        " category{name} comments{totalCount} answerChosenAt}}}}"
+    )
+    data = _gh(["api", "graphql", "-f", f"query={query}",
+                "-f", f"owner={owner}", "-f", f"name={name}"])
+    nodes = (((data or {}).get("data") or {}).get("repository") or {})
+    nodes = (nodes.get("discussions") or {}).get("nodes") or []
+    out = []
+    for d in nodes:
+        dt = _parse_iso(d.get("updatedAt"))
+        if not dt or dt < cutoff_dt:
+            continue
+        out.append({
+            "number": d.get("number"),
+            "title": d.get("title"),
+            "author": (d.get("author") or {}).get("login"),
+            "category": (d.get("category") or {}).get("name"),
+            "updatedAt": d.get("updatedAt"),
+            "createdAt": d.get("createdAt"),
+            "comments": (d.get("comments") or {}).get("totalCount"),
+            "answered": bool(d.get("answerChosenAt")),
+            "url": d.get("url"),
+        })
+    return out
+
+
+def _discord_recent(channel_id, token, cutoff_dt):
+    msgs = discord_request(
+        "GET", f"/channels/{channel_id}/messages?limit={DISCORD_PAGE}", token
+    ) or []
+    out = []
+    for m in msgs:
+        dt = _parse_iso(m.get("timestamp"))
+        if not dt or dt < cutoff_dt:
+            continue
+        author = m.get("author", {})
+        if author.get("bot"):
+            continue  # skip webhook feeds and the bot's own posts
+        out.append({
+            "id": m.get("id"),
+            "author": author.get("username"),
+            "timestamp": m.get("timestamp"),
+            "content": m.get("content", ""),
+            "reply_to": (m.get("referenced_message") or {}).get("id"),
+        })
+    return list(reversed(out))  # oldest first
+
+
+def cmd_gather(args):
+    cutoff_dt = (datetime.datetime.now(datetime.timezone.utc)
+                 - datetime.timedelta(hours=args.hours))
+    result = {
+        "generated_since": cutoff_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "window_hours": args.hours,
+        "github": {},
+        "discord": {},
+    }
+    for repo in GH_REPOS:
+        result["github"][repo] = {
+            "issues": _gh_items(repo, "issue", cutoff_dt),
+            "prs": _gh_items(repo, "pr", cutoff_dt),
+            "discussions": _gh_discussions(repo, cutoff_dt),
+        }
+    token = get_token()
+    for name, cid in SCAN_CHANNELS:
+        result["discord"][name] = _discord_recent(cid, token, cutoff_dt)
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+# --------------------------------------------------------------------------
+# Discord one-shot helpers (resolve / read / post / delete)
+# --------------------------------------------------------------------------
+def cmd_resolve_channel(args):
+    token = get_token()
+    name = args.name.lstrip("#").lower()
+    guilds = discord_request("GET", "/users/@me/guilds", token) or []
+    found, allch = [], []
+    for g in guilds:
+        gid, gname = g["id"], g.get("name", "?")
+        channels = discord_request("GET", f"/guilds/{gid}/channels", token) or []
+        for c in channels:
+            entry = (gname, gid, c.get("name", "?"), c["id"], c.get("type"))
+            allch.append(entry)
+            if c.get("name", "").lower() == name:
+                found.append(entry)
+    if found:
+        print("MATCHES:")
+        for gname, gid, cname, cid, ctype in found:
+            print(f"  guild={gname} ({gid})  #{cname}  channel_id={cid}  type={ctype}")
+    else:
+        print(f"No channel named '{name}'. Channels the bot can see:")
+        for gname, gid, cname, cid, ctype in sorted(allch):
+            print(f"  guild={gname} ({gid})  #{cname}  id={cid}  type={ctype}")
+
+
+def cmd_read_channel(args):
+    token = get_token()
+    path = f"/channels/{args.channel}/messages?limit={args.limit}"
+    if args.after:
+        path += f"&after={args.after}"
+    msgs = discord_request("GET", path, token) or []
+    for m in reversed(msgs):  # oldest first
+        author = m.get("author", {})
+        uname = author.get("username", "?")
+        bot = " (bot)" if author.get("bot") else ""
+        ts = m.get("timestamp", "")
+        content = (m.get("content") or "").replace("\n", " ")
+        print(f"[{ts}] {uname}{bot} {m['id']}: {content[:200]}")
+
+
+def cmd_post(args):
+    token = get_token()
+    text = args.text if args.text is not None else sys.stdin.read()
+    msg = discord_request("POST", f"/channels/{args.channel}/messages",
+                          token, {"content": text})
+    print(msg["id"] if msg else "")
+
+
+def cmd_delete(args):
+    token = get_token()
+    discord_request("DELETE",
+                    f"/channels/{args.channel}/messages/{args.message}", token)
+    print(f"deleted {args.message}")
+
+
+def cmd_edit(args):
+    token = get_token()
+    text = args.text if args.text is not None else sys.stdin.read()
+    msg = discord_request("PATCH",
+                          f"/channels/{args.channel}/messages/{args.message}",
+                          token, {"content": text})
+    print(msg["id"] if msg else "")
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    ga = sub.add_parser("gather")
+    ga.add_argument("--hours", type=int, default=24,
+                    help="look-back window in hours (default 24)")
+    ga.set_defaults(func=cmd_gather)
+
+    rc = sub.add_parser("resolve-channel")
+    rc.add_argument("name")
+    rc.set_defaults(func=cmd_resolve_channel)
+
+    rd = sub.add_parser("read-channel")
+    rd.add_argument("channel")
+    rd.add_argument("--limit", type=int, default=30)
+    rd.add_argument("--after", default=None)
+    rd.set_defaults(func=cmd_read_channel)
+
+    po = sub.add_parser("post")
+    po.add_argument("channel")
+    po.add_argument("--text", default=None)
+    po.set_defaults(func=cmd_post)
+
+    dl = sub.add_parser("delete")
+    dl.add_argument("channel")
+    dl.add_argument("message")
+    dl.set_defaults(func=cmd_delete)
+
+    ed = sub.add_parser("edit")
+    ed.add_argument("channel")
+    ed.add_argument("message")
+    ed.add_argument("--text", default=None)
+    ed.set_defaults(func=cmd_edit)
+
+    args = p.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tulip/server/community_digest_routine.md
+++ b/tulip/server/community_digest_routine.md
@@ -1,0 +1,86 @@
+# Community digest routine
+
+You are the **community-digest bot** for the Shore Pine Sound Systems projects
+(Tulip, AMY, AMYboard). You run every ~12 hours, unattended. Your job: scan
+GitHub + Discord, summarize what's going on, and post a digest to the private
+**#admin-actions** channel (id `1512856165321670719`) for Brian to review and
+act on.
+
+Run from the repo root so the relative paths below resolve.
+
+## What to do, in order
+
+1. **Gather.** Run:
+
+   ```
+   python3 tulip/server/community_digest.py gather --hours 14
+   ```
+
+   This emits JSON of recent GitHub activity (open issues/PRs/discussions updated
+   in the window, for shorepine/tulipcc and shorepine/amy) plus Discord messages
+   from the community channels. The 14h window overlaps the 12h cadence so
+   nothing slips between runs.
+
+2. **Avoid repeats.** Read your own most recent digest so you don't repeat
+   unchanged items:
+
+   ```
+   python3 tulip/server/community_digest.py read-channel 1512856165321670719 --limit 20
+   ```
+
+   Focus the new digest on what's *new or changed* since then. It's fine to
+   re-surface a "Needs your call" item if it's still open and important.
+
+3. **Triage** the gathered data into the three sections below. Judgement:
+   - **Skip noise:** greetings, emoji-only messages, well-answered one-offs,
+     off-topic chatter. Order/shipping logistics go to makerfabs, not us — note
+     the *volume* in "What's going on", don't list each one.
+   - **Surface:** unanswered questions, likely bugs, regressions, recurring
+     questions (good FAQ/doc candidates), and anything needing Brian's decision.
+   - Prefer GitHub items and concrete Discord problem reports over showcase/FYI
+     chatter.
+
+4. **Post** the digest to #admin-actions. Write it to a temp file and pipe it:
+
+   ```
+   python3 tulip/server/community_digest.py post 1512856165321670719 < /tmp/digest.txt
+   ```
+
+   **Discord caps a message at 2000 characters** — split into multiple posts by
+   section if needed (e.g. one for "What's going on" + "Simple", a second for
+   "Needs your call"). Use **bare URLs** (Discord does not render `[text](url)`
+   in normal messages). Use `**bold**` for section headers.
+
+## Format (match this shape and altitude)
+
+```
+🌷 **Community digest — <date>**
+
+**What's going on**
+• 3–5 one-line bullets: the big themes — releases, regressions, recurring
+  topics, notable community projects.
+
+**✅ Simple — recommended actions**
+Numbered, concrete, low-risk actions you *recommend*: file a clear bug,
+comment/cross-link an issue, add an FAQ/doc line, pin a canned answer. Each
+item = what + who reported it + the link. Keep them genuinely simple and
+high-confidence. Keep them numbered so Brian can reference an item by number,
+but do NOT invite readers to reply in Discord to trigger anything — nothing
+acts on Discord replies yet (that's v2).
+
+**🤔 Needs your call**
+Lettered list of things needing Brian's judgement: design/roadmap questions,
+ambiguous reports, strategy, open discussions worth his input. Each item =
+the question + brief context + link.
+```
+
+## Hard rules (v1)
+
+- **Read-only except posting to #admin-actions.** Do NOT comment on, label,
+  close, or otherwise modify any GitHub issue/PR/discussion. Do NOT post to any
+  Discord channel other than #admin-actions. You only *recommend* actions; Brian
+  executes them.
+- Never print or echo the bot token.
+- If nothing notable turned up, post a single line ("Quiet period — nothing
+  needs you") rather than padding the digest.
+```


### PR DESCRIPTION
## What this is

A scheduled Claude Code agent that, every ~12h (once scheduled), scans GitHub (shorepine/tulipcc + shorepine/amy issues/PRs/discussions) and the community Discord channels, then posts a triaged digest to the private Discord **#admin-actions** channel:

- **What's going on** — a few-bullet summary of themes
- **✅ Simple — recommended actions** — concrete, low-risk items (file a bug, add an FAQ line, cross-link an issue)
- **🤔 Needs your call** — design/roadmap/ambiguous items needing a human decision

## Files

- `tulip/server/community_digest.py` — stdlib-only helper. `gather` (GitHub via `gh` + Discord REST → JSON), plus `post`/`edit`/`read-channel`/`delete`/`resolve-channel`. Discord bot token read from env or `~/.config/tulip-digest.env`; never touches Railway.
- `tulip/server/community_digest_routine.md` — the prompt the scheduled agent runs.
- `tulip/server/community_digest.md` — setup doc (local Desktop scheduled task + the one permission rule).

## Status

**v1: read-only except posting to #admin-actions.** It *recommends* simple actions but does not execute them — you action them by asking Claude Code, referencing the item numbers. A sample digest has been posted live to #admin-actions.

Not yet scheduled. To turn on: merge, add `Bash(python3 tulip/server/community_digest.py:*)` to `~/.claude/settings.json`, and create a local Desktop scheduled task (mode `dontAsk`) per the setup doc.

**v2 (future):** a ~5-min approval poller + state file so replying `do 1 4 5` in #admin-actions executes those items hands-free.

## Notes

- No submodule or build changes; pure additions under `tulip/server/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
