### PR TITLE
community digest: look back 26h for the daily cadence

### DIFF
--- a/tulip/server/community_digest_routine.md
+++ b/tulip/server/community_digest_routine.md
@@ -13,14 +13,15 @@ Run from the repo root so the relative paths below resolve.
 1. **Gather.** Run:
 
    ```
-   python3 tulip/server/community_digest.py gather --hours 14
+   python3 tulip/server/community_digest.py gather --hours 26
    ```
 
    This emits JSON of recent GitHub activity (open issues/PRs/discussions updated
    in the window, for shorepine/tulipcc and shorepine/amy) plus Discord messages
-   from the community channels. The 14h window overlaps the 12h cadence so
-   nothing slips between runs. Read its stdout directly — do not redirect it to a
-   file.
+   from the community channels. The 26h window is a full day plus ~2h of overlap,
+   so nothing slips through the gap between daily runs (the "avoid repeats" step
+   below soaks up the overlap). Read its stdout directly — do not redirect it to
+   a file.
 
 2. **Avoid repeats.** Read your own most recent digest so you don't repeat
    unchanged items:


### PR DESCRIPTION
The scheduled routine runs **daily** (Routines only offer daily/hourly, not every 12h), so the previous 14h `gather` window missed ~10h of activity each day.

Widen the look-back to **26h** — a full day plus ~2h of overlap so nothing falls in the gap between daily runs; the routine's "avoid repeats" step (reads its own last digest) absorbs the small overlap.

One-line change to `community_digest_routine.md` (`--hours 14` → `--hours 26`) plus the explanatory note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
