### PR TITLE
community digest: route recurring-Q fixes to the FAQ, never Discord

### DIFF
--- a/docs/amyboard/faq.md
+++ b/docs/amyboard/faq.md
@@ -25,6 +25,14 @@ AMYboard comes with 3 things in a box:
 
 Boards are sold through Makerfabs and they ship in "batches" based on order sizes. For example, before AMYboard launched, they made a small batch, which sold out quickly at launch, so they made a bigger batch. Batches take a couple of weeks for them to manufacture boards. You should look at the [AMYboard page on Makerfabs](https://www.makerfabs.com/amyboard.html) to see the latest shipping estimate. 
 
+### How do I check my order or shipping status? (And the Makerfabs login won't work!)
+
+All orders, payments, and shipping are handled by [Makerfabs](https://www.makerfabs.com/amyboard.html) -- we (the AMYboard team) can't look up or change orders. For anything about your order or delivery:
+
+- **Order & tracking questions:** use the [Makerfabs contact page](https://www.makerfabs.com/contact) -- they're responsive.
+- **Tracking number:** it arrives in a **separate email** from your order confirmation, often a little later. Check your inbox (and spam) before assuming nothing shipped.
+- **Can't log in to the Makerfabs site?** Their login has been intermittent lately -- let the page fully load and try a couple of times.
+
 ### How do I power it?
 
 Three ways, and AMYboard uses the highest voltage present: **USB-C** (5V), **Eurorack 10-pin** (+12V), or the **I2C host / Grove** port (3.3V, e.g. from a Tulip). You don't need a computer -- a plain USB power supply is fine. See [Power Supplies](README.md#power-supplies).

--- a/tulip/server/community_digest_routine.md
+++ b/tulip/server/community_digest_routine.md
@@ -69,8 +69,8 @@ Run from the repo root so the relative paths below resolve.
 
 **✅ Simple — recommended actions**
 Numbered, concrete, low-risk actions you *recommend*: file a clear bug,
-comment/cross-link an issue, add an FAQ/doc line, pin a canned answer. Each
-item = what + who reported it + the link. Keep them genuinely simple and
+comment/cross-link an issue, or add an FAQ/doc line (e.g. to
+`docs/amyboard/faq.md`). Each item = what + who reported it + the link. Keep them genuinely simple and
 high-confidence. Keep them numbered so Brian can reference an item by number,
 but do NOT invite readers to reply in Discord to trigger anything — nothing
 acts on Discord replies yet (that's v2).
@@ -89,9 +89,15 @@ the question + brief context + link.
   not write temp files, run other shell commands, or use file-edit tools — they
   will be blocked.
 - **Read-only except posting to #admin-actions.** Do NOT comment on, label,
-  close, or otherwise modify any GitHub issue/PR/discussion. Do NOT post to any
-  Discord channel other than #admin-actions. You only *recommend* actions; Brian
+  close, or otherwise modify any GitHub issue/PR/discussion. The bot must
+  **never write to any Discord channel other than #admin-actions** — no posting
+  or pinning in #amyboard, #general, etc. You only *recommend* actions; Brian
   executes them.
+- **Recommend FAQ/doc or GitHub fixes, never Discord ones.** For recurring
+  community questions, propose adding to the docs/FAQ (e.g.
+  `docs/amyboard/faq.md`) or filing/commenting on a GitHub issue — never
+  "post/pin a canned answer in #channel". The bot does not speak to the
+  community.
 - Never print or echo the bot token.
 - If nothing notable turned up, post a single line ("Quiet period — nothing
   needs you") rather than padding the digest.


### PR DESCRIPTION
Maintainer policy: the community-digest bot must only ever write to the private **#admin-actions** channel — never post or pin in public Discord channels.

- **Routine prompt** (`community_digest_routine.md`): hard-rules now state the bot never writes to any Discord channel but #admin-actions, and that recommended actions must be FAQ/doc/GitHub fixes — never "post/pin a canned answer in #channel".
- **FAQ** (`docs/amyboard/faq.md`): added an order/shipping-status entry under "Buying & the board itself" (Makerfabs handles orders; tracking comes in a separate email; the site login has been flaky) — this is the recurring #amyboard question, now answered durably in docs instead of a Discord pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
