### PR TITLE
amyboard generate: 'share my prompt/result' consent checkbox + admin log field

### DIFF
--- a/tulip/amyboardweb/static/editor/index.html
+++ b/tulip/amyboardweb/static/editor/index.html
@@ -1463,6 +1463,13 @@
                       onclick="generate_sketch_from_prompt()">Create the sketch</button>
                     <span class="small text-muted" id="prompt-to-sketch-status"></span>
                   </div>
+                  <div class="form-check mt-2 mb-1">
+                    <input class="form-check-input" type="checkbox" id="prompt-to-sketch-share" checked>
+                    <label class="form-check-label small" for="prompt-to-sketch-share">
+                      Let others see my prompt and result.
+                      <span class="d-block text-muted" style="font-size:0.85em">We'll show your description and the resultant sketch as an example on our site for others to be inspired by.</span>
+                    </label>
+                  </div>
                   <div class="form-text">
                     This will create or modify a sketch.py for you if you describe what you want. Clear the editor if you want to start from scratch. We'll help you understand how to work with your AMYboard by looking up the documentation. Won't always be perfect, find us on Discord for more help!
                   </div>

--- a/tulip/amyboardweb/static/spss.js
+++ b/tulip/amyboardweb/static/spss.js
@@ -2321,10 +2321,12 @@ async function generate_sketch_from_prompt() {
 
     try {
         var currentCode = (typeof editor !== "undefined" && editor) ? editor.getValue() : "";
+        var shareEl = document.getElementById("prompt-to-sketch-share");
+        var share = shareEl ? !!shareEl.checked : false;
         var resp = await fetch(world_api_url("/api/amyboardworld/generate"), {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ description: description, current_code: currentCode }),
+            body: JSON.stringify({ description: description, current_code: currentCode, share: share }),
         });
 
         var data = {};

--- a/tulip/server/amyboardworld_admin.html
+++ b/tulip/server/amyboardworld_admin.html
@@ -113,6 +113,7 @@
           <th>IP</th>
           <th>Prompt</th>
           <th>OK</th>
+          <th>Share</th>
           <th>Model</th>
           <th>Tokens (in/out)</th>
           <th>Output code</th>
@@ -359,6 +360,7 @@
       for (const g of gens) {
         const tr = document.createElement('tr');
         const okHtml = g.ok ? '<span class="ok">ok</span>' : '<span class="err">fail</span>';
+        const shareHtml = g.share ? '<span class="ok">yes</span>' : '<span class="small">no</span>';
         const code = g.code || '';
         const codeCell = code
           ? '<details><summary class="small">' + esc(code.length) + ' chars</summary><pre class="code">' + esc(code) + '</pre></details>'
@@ -368,6 +370,7 @@
           '<td class="mono small">' + esc(g.client_ip || '') + '</td>' +
           '<td class="desc">' + esc(g.prompt || '') + '</td>' +
           '<td>' + okHtml + '</td>' +
+          '<td>' + shareHtml + '</td>' +
           '<td class="mono small">' + esc(g.model || '') + '</td>' +
           '<td class="mono small">' + esc(g.input_tokens) + ' / ' + esc(g.output_tokens) + '</td>' +
           '<td>' + codeCell + '</td>';

--- a/tulip/server/amyboardworld_db_api.py
+++ b/tulip/server/amyboardworld_db_api.py
@@ -224,7 +224,8 @@ def _ensure_schema() -> None:
               model TEXT NOT NULL DEFAULT '',
               input_tokens INTEGER NOT NULL DEFAULT 0,
               output_tokens INTEGER NOT NULL DEFAULT 0,
-              code TEXT NOT NULL DEFAULT ''
+              code TEXT NOT NULL DEFAULT '',
+              share INTEGER NOT NULL DEFAULT 0
             );
             CREATE INDEX IF NOT EXISTS idx_gen_created ON generations(created_at_ms DESC);
             CREATE INDEX IF NOT EXISTS idx_gen_ip ON generations(client_ip);
@@ -233,6 +234,12 @@ def _ensure_schema() -> None:
         # Add the generated-code column to pre-existing generations tables.
         try:
             conn.execute("ALTER TABLE generations ADD COLUMN code TEXT NOT NULL DEFAULT ''")
+        except sqlite3.OperationalError:
+            pass  # column already exists
+        # Add the share-consent column ("Let others see my prompt and result").
+        # Defaults to 0 (no consent) for old rows, which predate the checkbox.
+        try:
+            conn.execute("ALTER TABLE generations ADD COLUMN share INTEGER NOT NULL DEFAULT 0")
         except sqlite3.OperationalError:
             pass  # column already exists
 
@@ -1049,7 +1056,7 @@ def list_admin_generations(
     with _open_db() as conn:
         rows = conn.execute(
             f"""
-            SELECT id, created_at_ms, client_ip, prompt, code, ok, model, input_tokens, output_tokens
+            SELECT id, created_at_ms, client_ip, prompt, code, ok, model, input_tokens, output_tokens, share
             FROM generations{where}
             ORDER BY created_at_ms DESC
             LIMIT ?
@@ -1068,6 +1075,7 @@ def list_admin_generations(
                 "model": r["model"],
                 "input_tokens": r["input_tokens"],
                 "output_tokens": r["output_tokens"],
+                "share": bool(r["share"]),
             }
             for r in rows
         ]
@@ -1283,12 +1291,12 @@ def _count_generations_since(ip: str, since_ms: int) -> tuple[int, int]:
     return (int(ip_row["n"]) if ip_row else 0, int(all_row["n"]) if all_row else 0)
 
 
-def _log_generation(ip: str, prompt: str, result: dict[str, Any]) -> None:
+def _log_generation(ip: str, prompt: str, result: dict[str, Any], share: bool) -> None:
     with _open_db() as conn:
         conn.execute(
             """
-            INSERT INTO generations(created_at_ms, client_ip, prompt, ok, model, input_tokens, output_tokens, code)
-            VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO generations(created_at_ms, client_ip, prompt, ok, model, input_tokens, output_tokens, code, share)
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 _now_ms(),
@@ -1299,6 +1307,7 @@ def _log_generation(ip: str, prompt: str, result: dict[str, Any]) -> None:
                 int(result.get("input_tokens", 0)),
                 int(result.get("output_tokens", 0)),
                 (result.get("code") or "")[:20000],
+                1 if share else 0,
             ),
         )
         conn.commit()
@@ -1745,6 +1754,10 @@ def _generate_sketch_via_claude(description: str, current_code: str | None) -> d
 class GenerateRequest(BaseModel):
     description: str
     current_code: str | None = None
+    # "Let others see my prompt and result" consent. Default False so any client
+    # that omits it is treated as no-consent; the editor's checkbox is checked by
+    # default and sends share=true explicitly.
+    share: bool = False
 
 
 @app.post("/api/amyboardworld/generate")
@@ -1786,7 +1799,7 @@ def generate_amyboard_sketch(body: GenerateRequest, request: Request) -> dict[st
         raise HTTPException(status_code=status, detail="Sketch generation failed. Please try again later.") from exc
 
     # Every billed attempt (success or validation failure) counts toward limits.
-    _log_generation(ip, description, result)
+    _log_generation(ip, description, result, body.share)
 
     if not result["ok"]:
         raise HTTPException(


### PR DESCRIPTION
Adds an opt-in/opt-out consent checkbox to the prompt→sketch generator and records the choice in the generations audit log. **No public showcase yet** — this only captures the flag for later use.

**Editor** (`static/editor/index.html`, `static/spss.js`): a checkbox next to "Create the sketch", checked by default — *"Let others see my prompt and result."* with sub-text *"We'll show your description and the resultant sketch as an example on our site for others to be inspired by."* The editor sends `share` with the generate request.

**Server** (`amyboardworld_db_api.py`):
- `GenerateRequest.share: bool = False` (omitters → no-consent; the editor sends the real value).
- `generations` table gains a `share` column via idempotent `ALTER TABLE` migration; pre-existing rows default to `0`.
- `/api/admin/generations` returns `share`; `amyboardworld_admin.html` shows a **Share** column (yes/no).

Tested: compiles; migration verified (old rows → 0, new rows record the explicit value, idempotent re-run).

Note: merging auto-deploys the **server** (Railway). The **editor** checkbox needs a separate Vercel deploy of `amyboardweb` to go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
