### PR TITLE
amyboard FAQ: add CME H2MIDI Pro as a ready-made USB-host->TRS bridge

### DIFF
--- a/docs/amyboard/faq.md
+++ b/docs/amyboard/faq.md
@@ -68,7 +68,7 @@ If you have AMYboard on Windows, please report on Discord whether it works -- it
 
 ### Can I plug a USB-MIDI keyboard straight into the AMYboard? (USB host)
 
-No -- AMYboard is **USB device/gadget mode only**: it appears to a computer as a MIDI device, but it **can't host** a USB controller plugged into it. (Tulip does USB host; AMYboard's hardware doesn't.) To play it from a keyboard without a computer, use the **TRS/DIN MIDI in** jack, or put a small **USB-host-to-TRS-MIDI bridge** in between -- an RP2040/RP2350 board works well for this (a community member built exactly that).
+No -- AMYboard is **USB device/gadget mode only**: it appears to a computer as a MIDI device, but it **can't host** a USB controller plugged into it. (Tulip does USB host; AMYboard's hardware doesn't.) To play it from a keyboard without a computer, use the **TRS/DIN MIDI in** jack, or put a small **USB-host-to-TRS-MIDI bridge** in between -- you can build one from an RP2040/RP2350 board (a community member did exactly that), or buy a ready-made box like the [CME H2MIDI Pro](https://www.amazon.com/dp/B0DQYD3L7D) (~$49).
 
 ---
 


### PR DESCRIPTION
Adds a ready-made $49 option (CME H2MIDI Pro, clean Amazon ASIN link) next to the DIY RP2040/RP2350 bridge in the USB-host FAQ answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)