### PR TITLE
amyboard editor: make channel Level CC-mappable (click the Level label)

### DIFF
--- a/tulip/amyboardweb/static/amy_parameters.js
+++ b/tulip/amyboardweb/static/amy_parameters.js
@@ -27,6 +27,25 @@ window.addEventListener("DOMContentLoaded", function() {
   // AMY's EVENT_FROM_OSC_ARRAY only emits values that differ from reset defaults.
   const amy_knob_definitions = [
     {
+      // Per-channel overall level (VCA). Shown by the dedicated "Level" slider in
+      // the channel strip (dedicated_slider -> kept out of the knob grid), but
+      // registered as a channel knob so its MIDI CC rides the same
+      // save/restore/bulk-send path as every other knob. Same AMY command as the
+      // Level slider: i<ch>v0a<val> (amp on the control osc). Default CC 7 = the
+      // MIDI standard "Channel Volume".
+      section: "Synth",
+      cc: 7,
+      display_name: "level",
+      change_code: "i%iv" + CTL_OSC + "a%v",
+      knob_type: "log",
+      default_value: 1.0,
+      amy_default: 1.0,
+      min_value: 0.001,
+      max_value: 7,
+      offset: 0.1,
+      dedicated_slider: true,
+    },
+    {
       section: "Osc A",
       cc: "",
       display_name: "freq",

--- a/tulip/amyboardweb/static/editor/index.html
+++ b/tulip/amyboardweb/static/editor/index.html
@@ -1423,7 +1423,7 @@
                       </div>
                     </div>
                     <div class="col-12 col-md-auto mt-2 mt-md-0 d-flex align-items-center gap-2 ms-md-2">
-                      <label class="text-nowrap mb-0 text-white" for="synth-level-slider" style="font-size:0.875rem;">Level</label>
+                      <label class="text-nowrap mb-0 text-white" id="synth-level-label" for="synth-level-slider" style="font-size:0.875rem; cursor:pointer;" title="Click to set a MIDI CC for this channel's level">Level</label>
                       <input type="range" class="form-range" id="synth-level-slider" min="0.001" max="7" step="0.001" value="1" style="width:100px;">
                       <input type="number" class="form-control text-center knob-value" id="synth-level-number" min="0.001" max="7" step="0.001" value="1" style="width:60px; font-size:0.7rem; padding:2px 4px;">
                     </div>
@@ -2030,6 +2030,27 @@
             if (synthLevelNumber) synthLevelNumber.value = val.toFixed(3);
           }
         };
+        // Clicking the "Level" label opens the same MIDI-CC popup the knobs use,
+        // targeting the current channel's dedicated_slider "level" knob (defined
+        // in amy_parameters.js). That knob carries only the CC mapping; the slider
+        // above still drives the value.
+        const synthLevelLabel = document.getElementById("synth-level-label");
+        if (synthLevelLabel) {
+          synthLevelLabel.addEventListener("click", function() {
+            var ch = Number(window.current_synth || 1);
+            var list = (window.amy_channel_knobs && window.amy_channel_knobs[ch]) || [];
+            var levelKnob = null;
+            for (var i = 0; i < list.length; i++) {
+              if (list[i] && list[i].dedicated_slider && list[i].display_name === "level") {
+                levelKnob = list[i];
+                break;
+              }
+            }
+            if (levelKnob && typeof window.amy_open_cc_editor === "function") {
+              window.amy_open_cc_editor(levelKnob, synthLevelLabel);
+            }
+          });
+        }
         const savePatchModalEl = document.getElementById("savePatchModal");
         const savePatchNameInput = document.getElementById("save-patch-name");
         const savePatchConfirmButton = document.getElementById("save-patch-confirm-btn");

--- a/tulip/amyboardweb/static/editor_knobs.js
+++ b/tulip/amyboardweb/static/editor_knobs.js
@@ -446,6 +446,41 @@ function init_knobs(knobConfigs, gridId, onChange) {
       editor.container.style.left = `${left}px`;
     }
 
+    function openCcEditor(knobConfig, labelEl) {
+      if (!knobConfig || !labelEl) {
+        return;
+      }
+      const editor = ccEditor();
+      editor.current = knobConfig;
+      editor.error.textContent = "";
+      const sectionName = knobConfig.section ? String(knobConfig.section) : "Knob";
+      const displayName = knobConfig.display_name ? String(knobConfig.display_name) : "";
+      editor.title.textContent = `${sectionName} ${displayName}`.trim();
+      editor.input.value = knobConfig.cc === "" || knobConfig.cc === null || knobConfig.cc === undefined
+        ? ""
+        : String(knobConfig.cc);
+      const isRangeType = !knobConfig.knob_type || knobConfig.knob_type === "log";
+      editor.rangeWrap.style.display = isRangeType ? "block" : "none";
+      if (isRangeType) {
+        const minValue = Number.isFinite(Number(knobConfig.min_value)) ? String(knobConfig.min_value) : "";
+        const maxValue = Number.isFinite(Number(knobConfig.max_value)) ? String(knobConfig.max_value) : "";
+        editor.minInput.value = minValue;
+        editor.maxInput.value = maxValue;
+        editor.logCheckbox.checked = knobConfig.knob_type === "log";
+      }
+      positionCcEditor(editor, labelEl);
+      editor.container.style.display = "block";
+      editor.input.focus();
+      editor.input.select();
+    }
+
+    // Expose one opener globally so an externally-rendered label (e.g. the
+    // channel-strip Level slider's label) can open the same CC popup the grid
+    // knobs use. Registered once; the closure keeps a valid ccEditor instance.
+    if (typeof window !== "undefined" && !window.amy_open_cc_editor) {
+      window.amy_open_cc_editor = openCcEditor;
+    }
+
     function attachCcEditor(labelEl, knobConfig) {
       if (!labelEl) {
         return;
@@ -453,28 +488,7 @@ function init_knobs(knobConfigs, gridId, onChange) {
       labelEl.style.cursor = "pointer";
       labelEl.setAttribute("title", "Click to edit MIDI CC");
       labelEl.addEventListener("click", function() {
-        const editor = ccEditor();
-        editor.current = knobConfig;
-        editor.error.textContent = "";
-        const sectionName = knobConfig.section ? String(knobConfig.section) : "Knob";
-        const displayName = knobConfig.display_name ? String(knobConfig.display_name) : "";
-        editor.title.textContent = `${sectionName} ${displayName}`.trim();
-        editor.input.value = knobConfig.cc === "" || knobConfig.cc === null || knobConfig.cc === undefined
-          ? ""
-          : String(knobConfig.cc);
-        const isRangeType = !knobConfig.knob_type || knobConfig.knob_type === "log";
-        editor.rangeWrap.style.display = isRangeType ? "block" : "none";
-        if (isRangeType) {
-          const minValue = Number.isFinite(Number(knobConfig.min_value)) ? String(knobConfig.min_value) : "";
-          const maxValue = Number.isFinite(Number(knobConfig.max_value)) ? String(knobConfig.max_value) : "";
-          editor.minInput.value = minValue;
-          editor.maxInput.value = maxValue;
-          editor.logCheckbox.checked = knobConfig.knob_type === "log";
-        }
-        positionCcEditor(editor, labelEl);
-        editor.container.style.display = "block";
-        editor.input.focus();
-        editor.input.select();
+        openCcEditor(knobConfig, labelEl);
       });
     }
 
@@ -1046,6 +1060,12 @@ function init_knobs(knobConfigs, gridId, onChange) {
     : {};
 
   knobConfigs.forEach(function(config, index) {
+    if (config && config.dedicated_slider) {
+      // Shown by a dedicated control (the channel-strip Level slider), not the
+      // grid. Skip during section grouping so no empty section header appears;
+      // other knobs keep their indices (onKnobChange ignores the index anyway).
+      return;
+    }
     const sectionName = typeof config.section === "string" ? config.section : "";
     if (!currentSection || currentSection.name !== sectionName) {
       currentSection = { name: sectionName, items: [], units: 0 };


### PR DESCRIPTION
Implements #985 — give the channel-strip **Level** control a clickable label that opens the **same MIDI-CC popup** as the other knobs, so a channel's overall level can be assigned to a CC and balanced from a hardware controller (e.g. when the unit is racked in a eurorack skiff without USB).

### How it works
The Level value is a hard-coded slider (sends `i<ch>v0a<val>` — amp on the control osc). Rather than rebuild it, I registered Level as a **per-channel knob** that carries only the CC mapping, and wired the existing slider's label to the shared CC popup:

- **`amy_parameters.js`** — new channel knob: `section "Synth", display_name "level", change_code "i%iv0a%v"` (identical to the slider's command), `knob_type log`, range **0.001–7**, **default CC 7** (the MIDI standard "Channel Volume"), flagged `dedicated_slider: true`.
- **`editor_knobs.js`** — skip `dedicated_slider` knobs during section grouping (so no grid knob / empty section), and extract/expose `window.amy_open_cc_editor` so an externally-rendered label can open the same popup.
- **`editor/index.html`** — the `Level` label opens the CC popup for the **current channel's** level knob; the slider still drives the value.

Because the knob is registered like any other, its CC rides the existing machinery for free — `send_all_knob_cc_mappings` (re-sent on channel switch / patch load), `applyKnobCcMappingMessage` (restore, matched by `change_code`), and CC-number dedup. Value handling is unchanged (slider + `setSynthLevelFromAmy`); `onKnobChange` ignores the knob index so skipping it from the grid is safe.

### Testing
- JS syntax checked (`node --check`).
- **Not yet browser-tested** — needs a manual pass in the editor: click the Level label → set a CC → confirm it sends/persists per channel, switches channels correctly, and round-trips through Write/Load. Leaving unmerged for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
