### PR TITLE
amyboard docs: fix reversed DIP switch ON/OFF for 10Vpp modular

### DIFF
--- a/docs/amyboard/README.md
+++ b/docs/amyboard/README.md
@@ -86,8 +86,8 @@ If multiple power supplies are connected AMYboard will use the highest available
 
 There are 4 DIP switches on the back of the AMYboard that set the audio input and output levels. All 4 switches should be set the same way, depending on how you're using AMYboard:
 
- - **Line level equipment** (headphones, speakers, audio interface, mixer): set all 4 DIP switches to **ON** -- each switch pushed toward the **bottom** of the board, toward the white opto-isolator chip.
- - **Modular synth** (10Vpp Eurorack signals): set all 4 DIP switches to **OFF** -- each switch pushed toward the **top** of the back of the board, toward the 10-pin power jack.
+ - **Line level equipment** (headphones, speakers, audio interface, mixer): set all 4 DIP switches to **OFF** -- each switch pushed toward the **top** of the back of the board, toward the 10-pin power jack.
+ - **Modular synth** (10Vpp Eurorack signals): set all 4 DIP switches to **ON** -- each switch pushed toward the **bottom** of the board, toward the white opto-isolator chip.
 
 See the [Modular Synth Setup](modular.md) page for more details on 10Vpp operation.
 

--- a/docs/amyboard/modular.md
+++ b/docs/amyboard/modular.md
@@ -17,7 +17,7 @@ You can also 3D print your own front panel for whatever use case you have in min
 
 ## 10vpp Operation
 
-Most modular synthesis units operate at 10Vpp, where an audio signal swings between -5V and +5V. Out of the box, AMYboard is "line level" at 1Vpp. To change the audio input and output of AMYboard to 10Vpp, you need to change the DIP switches on the back of the board to "OFF" / closed.
+Most modular synthesis units operate at 10Vpp, where an audio signal swings between -5V and +5V. Out of the box, AMYboard is "line level" at 1Vpp. To change the audio input and output of AMYboard to 10Vpp, you need to change the DIP switches on the back of the board to "ON" / closed.
 
 <img src="https://raw.githubusercontent.com/shorepine/tulipcc/main/www/img/dip_switches.png" width=600>
 


### PR DESCRIPTION
## Problem

The AMYboard docs described the DIP switch ON/OFF positions backwards for modular 10Vpp operation, in two places.

## Correct mapping

- **ON** — switches toward the **bottom** of the board (back side, toward the white opto-isolator chip) = **10Vpp** modular operation.
- **OFF** — switches toward the **10-pin modular power connector** = **1Vpp** line-level audio in/out.

## Changes

- **`docs/amyboard/README.md`** (DIP switches section): swapped the switch position/direction between the line-level and modular bullets so line level = OFF (toward the power jack) and modular 10Vpp = ON (toward the opto-isolator chip).
- **`docs/amyboard/modular.md`** (10vpp Operation): changed "set the DIP switches to **OFF** / closed" to "**ON** / closed" for 10Vpp. This is now consistent with the existing "Switches 1–4 ... when closed" electrical notes (closed = ON = 10Vpp-friendly), which were already correct and are left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)