### PR TITLE
amyboardweb: drop dead yield_patch_events cwrap binding

### DIFF
--- a/tulip/amyboardweb/static/spss.js
+++ b/tulip/amyboardweb/static/spss.js
@@ -11,7 +11,6 @@ var amyboard_started = false;
 // read later in start_audio() after check_url_env_params() has mutated the URL.
 // Keeps the default run_sketch() path from racing the deferred world-load.
 var _url_env_pending = false;
-var amy_yield_patch_events = null;
 var amy_yield_synth_commands = null;
 var amy_dump_state_to_string_c = null;
 
@@ -216,9 +215,6 @@ if (typeof amyModule === 'function') _amy_wasm_ready = amyModule().then(async fu
   );
   amy_process_single_midi_byte = am.cwrap(
     'amy_process_single_midi_byte', null, ['number, number']
-  );
-  amy_yield_patch_events = am.cwrap(
-    'yield_patch_events', 'number', ['number', 'number', 'number']
   );
   amy_yield_synth_commands = am.cwrap(
     'yield_synth_commands', 'number', ['number', 'number', 'number', 'boolean', 'number']


### PR DESCRIPTION
## What

Removes the only references to AMY's `yield_patch_events` in tulipcc: a dead variable declaration and its `cwrap` binding in `tulip/amyboardweb/static/spss.js`.

```diff
-var amy_yield_patch_events = null;
...
-  amy_yield_patch_events = am.cwrap(
-    'yield_patch_events', 'number', ['number', 'number', 'number']
-  );
```

## Why

Prep so amyboardweb keeps building cleanly once `yield_patch_events` is removed from AMY.

`amy_yield_patch_events` was declared and cwrapped but **never called** — the editor drives AMY entirely through `yield_synth_commands` (`spss.js:530`). So this is a pure dead-code removal with **no behavior change**.

It's also safe to merge **before or after** the AMY-side removal:
- The symbol isn't named in any Makefile / `EXPORTED_FUNCTIONS` list, so removing it from AMY can't cause an "undefined exported symbol" link error.
- `cwrap` resolves lazily and the binding was never invoked, so nothing broke even while AMY still exported it.

## Verification

- `grep -rni yield_patch_events` over tulipcc source (excluding the `micropython` submodule and generated `www/run` / `stage` artifacts) → **no remaining references**.
- `node --check tulip/amyboardweb/static/spss.js` → passes.
- `amy_yield_synth_commands` (the binding actually used) left intact.

A full WASM rebuild wasn't run: `spss.js` is a static asset (not compiled by emcc), and the real post-removal build can't be exercised until AMY actually drops the symbol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)