### PR TITLE
CI: build AMYboard ESP32-S3 firmware on PRs and main

### DIFF
--- a/.github/workflows/amyboard-firmware.yml
+++ b/.github/workflows/amyboard-firmware.yml
@@ -34,6 +34,7 @@ jobs:
           # Build the AMYBOARD board, then assemble the flashable .bin set
           # (fs_create.py lives in tulip/ and writes tulip/amyboard/dist/).
           command: >-
+            python -m pip install littlefs-python &&
             idf.py -DMICROPY_BOARD=AMYBOARD build &&
             cd .. &&
             python fs_create.py amyboard

--- a/.github/workflows/amyboard-firmware.yml
+++ b/.github/workflows/amyboard-firmware.yml
@@ -1,0 +1,63 @@
+name: AMYboard firmware
+
+# Build the AMYboard ESP32-S3 firmware on every PR and on main, so firmware
+# breakage is caught in CI (the existing desktop-linux job only builds the SDL
+# desktop target). On PRs the built images are uploaded as downloadable
+# artifacts; on main they are also published to the rolling `dev` prerelease
+# (the same assets `tulip/dev.sh firmware` publishes).
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+# Allow the main-branch run to upload release assets to the `dev` prerelease.
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # amy + micropython (and their nested submodules) are needed to build.
+          submodules: recursive
+
+      - name: Build AMYboard firmware + assemble images
+        uses: espressif/esp-idf-ci-action@v1
+        with:
+          esp_idf_version: v5.4.1
+          target: esp32s3
+          path: tulip/amyboard
+          # Build the AMYBOARD board, then assemble the flashable .bin set
+          # (fs_create.py lives in tulip/ and writes tulip/amyboard/dist/).
+          command: >-
+            idf.py -DMICROPY_BOARD=AMYBOARD build &&
+            cd .. &&
+            python fs_create.py amyboard
+
+      - name: Upload firmware artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: amyboard-firmware
+          if-no-files-found: error
+          path: |
+            tulip/amyboard/dist/amyboard-firmware-AMYBOARD.bin
+            tulip/amyboard/dist/amyboard-full-AMYBOARD.bin
+            tulip/amyboard/dist/amyboard-sys.bin
+
+      - name: Publish to the rolling 'dev' prerelease (main only)
+        if: github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release view dev >/dev/null 2>&1 || \
+            gh release create dev --prerelease \
+              --title "AMYboard dev (rolling)" \
+              --notes "Rolling AMYboard development build. Flash from https://amyboard-dev.vercel.app — this is NOT a stable release."
+          gh release upload --clobber dev \
+            tulip/amyboard/dist/amyboard-firmware-AMYBOARD.bin \
+            tulip/amyboard/dist/amyboard-full-AMYBOARD.bin \
+            tulip/amyboard/dist/amyboard-sys.bin


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds the **AMYboard ESP32-S3 firmware** on every PR and on `main`. Until now CI only built the SDL desktop target (`desktop-linux.yml`), so firmware breakage wasn't caught.

**What it does**
- Checks out with `submodules: recursive` (amy + micropython).
- Builds via `espressif/esp-idf-ci-action@v1` (ESP-IDF v5.4.1, target esp32s3): `idf.py -DMICROPY_BOARD=AMYBOARD build`, then `python fs_create.py amyboard` to assemble the flashable images — mirroring `tulip/dev.sh firmware`.
- **PRs:** uploads `amyboard-{firmware,full,sys}-AMYBOARD.bin` as downloadable artifacts.
- **main:** also publishes those to the rolling `dev` prerelease (same assets `dev.sh firmware` publishes), so a push to main refreshes the dev firmware automatically.

**Notes / for review**
- The `main → dev prerelease` publish step makes `./dev.sh firmware` redundant for firmware on main. If you'd rather keep dev publishing manual, drop that last step (PR artifacts still build on every push).
- ESP-IDF + MicroPython in CI can be finicky (mpy-cross, submodules); this first cut may need a tweak once the run executes — that's what the PR run will show.

Companion: AMY also doesn't build `make web` in CI (which is how shorepine/amy#728's WASM break slipped through) — see shorepine/amy#730.

🤖 Generated with [Claude Code](https://claude.com/claude-code)