### PR TITLE
amyboard: per-PR preview site with bundled firmware flashing

### DIFF
--- a/.github/workflows/amyboard-firmware.yml
+++ b/.github/workflows/amyboard-firmware.yml
@@ -1,15 +1,14 @@
 name: AMYboard firmware
 
-# Build the AMYboard ESP32-S3 firmware on every PR and on main, so firmware
-# breakage is caught in CI (the existing desktop-linux job only builds the SDL
-# desktop target). On PRs the built images are uploaded as downloadable
-# artifacts; on main they are also published to the rolling `dev` prerelease
-# (the same assets `tulip/dev.sh firmware` publishes).
+# Build the AMYboard ESP32-S3 firmware on main and publish it to the rolling
+# `dev` prerelease (the same assets `tulip/dev.sh firmware` publishes).
+#
+# PRs are covered by amyboard-pr-preview.yml, which builds the same firmware,
+# uploads it as an artifact, and deploys a flashable preview site — so this
+# workflow no longer runs on pull_request to avoid building the firmware twice.
 
 on:
   push:
-    branches: [ "main" ]
-  pull_request:
     branches: [ "main" ]
 
 # Allow the main-branch run to upload release assets to the `dev` prerelease.

--- a/.github/workflows/amyboard-pr-preview-cleanup.yml
+++ b/.github/workflows/amyboard-pr-preview-cleanup.yml
@@ -1,0 +1,29 @@
+name: AMYboard PR preview cleanup
+
+# Removes the per-PR preview alias (amyboard-pr-<N>.vercel.app) when the PR is
+# merged or closed. The underlying preview deployments age out on Vercel.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove preview alias
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          if [ -z "$VERCEL_TOKEN" ]; then
+            echo "VERCEL_TOKEN not set — nothing to clean up."
+            exit 0
+          fi
+          npm i -g vercel@latest >/dev/null 2>&1
+          vercel alias rm "amyboard-pr-${PR}.vercel.app" --yes \
+            --token "$VERCEL_TOKEN" --scope bwhitmans-projects || \
+            echo "alias amyboard-pr-${PR}.vercel.app not found (already gone) — ok"

--- a/.github/workflows/amyboard-pr-preview.yml
+++ b/.github/workflows/amyboard-pr-preview.yml
@@ -1,0 +1,118 @@
+name: AMYboard PR preview
+
+# Per-PR preview of the AMYboard web editor + flasher, with this PR's firmware
+# bundled in, deployed to a unique URL (amyboard-pr-<N>.vercel.app). The bundled
+# firmware means the preview flasher can ONLY flash this PR's build. Torn down
+# by amyboard-pr-preview-cleanup.yml when the PR closes.
+#
+# Requires repo secret VERCEL_TOKEN (scope: bwhitmans-projects). The amyboard-pr
+# Vercel project is deployed to as preview deployments and aliased per PR.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'amy'
+      - 'tulip/amyboard/**'
+      - 'tulip/amyboardweb/**'
+      - 'tulip/shared/amyboard-py/**'
+      - '.github/workflows/amyboard-pr-preview.yml'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: amyboard-pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      # --- Firmware (.bin set) ---
+      - name: Build AMYboard firmware
+        uses: espressif/esp-idf-ci-action@v1
+        with:
+          esp_idf_version: v5.4.1
+          target: esp32s3
+          path: tulip/amyboard
+          command: >-
+            python -m pip install littlefs-python &&
+            idf.py -DMICROPY_BOARD=AMYBOARD build &&
+            cd .. &&
+            python fs_create.py amyboard
+
+      # --- Web stage/ (amy + amyboard WASM + static) ---
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Install web build deps
+        run: pip install numpy
+      - uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: 4.0.22
+      - name: Build amyboardweb stage/
+        run: |
+          cd tulip/amyboardweb
+          python3 dev.py --build-only
+
+      # --- Bundle this PR's firmware into the site ---
+      - name: Bundle firmware into stage/
+        run: |
+          mkdir -p tulip/amyboardweb/stage/firmware
+          cp tulip/amyboard/dist/amyboard-full-AMYBOARD.bin \
+             tulip/amyboard/dist/amyboard-firmware-AMYBOARD.bin \
+             tulip/amyboard/dist/amyboard-sys.bin \
+             tulip/amyboardweb/stage/firmware/
+
+      # --- Deploy preview + stable per-PR alias ---
+      - name: Deploy preview to Vercel
+        id: deploy
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          if [ -z "$VERCEL_TOKEN" ]; then
+            echo "::error::VERCEL_TOKEN secret is not set — add it (scope bwhitmans-projects) to enable PR previews."
+            exit 1
+          fi
+          npm i -g vercel@latest >/dev/null 2>&1
+          cd tulip/amyboardweb
+          vercel link --yes --token "$VERCEL_TOKEN" --scope bwhitmans-projects --project amyboard-pr --cwd stage
+          url=$(vercel deploy stage --token "$VERCEL_TOKEN" --scope bwhitmans-projects --yes)
+          alias="amyboard-pr-${PR}.vercel.app"
+          vercel alias set "$url" "$alias" --token "$VERCEL_TOKEN" --scope bwhitmans-projects
+          echo "url=https://$alias" >> "$GITHUB_OUTPUT"
+
+      # --- Comment (upsert) the preview URL on the PR ---
+      - name: Comment preview URL
+        if: success()
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.url }}
+        with:
+          script: |
+            const url = process.env.PREVIEW_URL;
+            const marker = '<!-- amyboard-pr-preview -->';
+            const body = [
+              marker,
+              '### 🔌 AMYboard PR preview',
+              '',
+              `**Editor + flasher:** ${url}/editor/`,
+              '',
+              "This preview bundles **this PR's firmware** — its flasher only flashes this build (not release/dev). Rebuilt on every push; removed when the PR closes.",
+            ].join('\n');
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body });
+            }

--- a/.github/workflows/amyboard-pr-preview.yml
+++ b/.github/workflows/amyboard-pr-preview.yml
@@ -61,6 +61,16 @@ jobs:
             cd .. &&
             python fs_create.py amyboard
 
+      - name: Upload firmware artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: amyboard-firmware
+          if-no-files-found: error
+          path: |
+            tulip/amyboard/dist/amyboard-firmware-AMYBOARD.bin
+            tulip/amyboard/dist/amyboard-full-AMYBOARD.bin
+            tulip/amyboard/dist/amyboard-sys.bin
+
       # --- Web stage/ (amy + amyboard WASM + static) ---
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/amyboard-pr-preview.yml
+++ b/.github/workflows/amyboard-pr-preview.yml
@@ -30,6 +30,20 @@ jobs:
   preview:
     runs-on: ubuntu-latest
     steps:
+      # Fail fast on a missing/mis-scoped token, before the ~15-min build.
+      - name: Verify Vercel token can access the team
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          if [ -z "$VERCEL_TOKEN" ]; then
+            echo "::error::VERCEL_TOKEN secret is not set — add it (scope bwhitmans-projects)."; exit 1
+          fi
+          npm i -g vercel@latest >/dev/null 2>&1
+          if ! vercel project ls --scope bwhitmans-projects --token "$VERCEL_TOKEN" >/dev/null 2>&1; then
+            echo "::error::VERCEL_TOKEN cannot access the 'bwhitmans-projects' team — recreate the token with that scope."; exit 1
+          fi
+          echo "Vercel token OK for bwhitmans-projects."
+
       - uses: actions/checkout@v4
         with:
           submodules: recursive

--- a/tulip/amyboardweb/static/esptool/js/script.js
+++ b/tulip/amyboardweb/static/esptool/js/script.js
@@ -19,15 +19,19 @@ const noReset = document.getElementById("noReset");
 
 // Firmware channel: the "dev" site flashes test builds from the rolling 'dev'
 // GitHub prerelease; everywhere else flashes the real (latest) release.
+// Per-PR preview sites (amyboard-pr-<N>.vercel.app) bundle their own firmware
+// under /firmware on the same origin, so a preview can only ever flash that
+// PR's build.
 const FIRMWARE_BASES = {
     release: "https://github.com/shorepine/tulipcc/releases/latest/download",
     dev:     "https://github.com/shorepine/tulipcc/releases/download/dev",
+    pr:      "/firmware",
 };
 
 function channelFromSearch(search) {
     try {
         const v = new URLSearchParams(search || "").get("channel");
-        return v === "dev" || v === "release" ? v : null;
+        return (v === "dev" || v === "release" || v === "pr") ? v : null;
     } catch (e) {
         return null;
     }
@@ -43,6 +47,7 @@ function resolveFirmwareChannel() {
 
     const host = (window.location.hostname || "").toLowerCase();
     if (host === "amyboard.com" || host === "www.amyboard.com") return "release";
+    if (host.includes("amyboard-pr")) return "pr";
     if (host.includes("amyboard-dev")) return "dev";
     if (host === "localhost" || host === "127.0.0.1") return "dev";
     return "release";
@@ -142,6 +147,10 @@ document.addEventListener("DOMContentLoaded", () => {
         if (firmwareChannel === "dev") {
             channelBadge.textContent =
                 "DEV channel — flashing test builds from the rolling 'dev' release, not a stable version.";
+            channelBadge.classList.remove("hidden");
+        } else if (firmwareChannel === "pr") {
+            channelBadge.textContent =
+                "PR PREVIEW — flashing this pull request's firmware build, not a stable version.";
             channelBadge.classList.remove("hidden");
         } else {
             channelBadge.classList.add("hidden");


### PR DESCRIPTION
Per-PR AMYboard previews: every PR (touching amy / amyboard / amyboardweb) gets its **own URL** — `amyboard-pr-<N>.vercel.app` — running the web editor + flasher, with **that PR's firmware bundled in**, so the preview can only ever flash that PR's build. Torn down when the PR closes.

### How it works
- **`amyboard-pr-preview.yml`** (on PR): builds the AMYboard firmware (`idf.py -DMICROPY_BOARD=AMYBOARD` + `fs_create.py`) and the web `stage/` (amy/amyboard → WASM via emsdk 4.0.22), copies the `.bin` set into `stage/firmware/`, `vercel deploy`s to the **`amyboard-pr`** project, aliases it to `amyboard-pr-<N>.vercel.app`, and upserts a comment with the URL.
- **flasher (`esptool/js/script.js`)**: new `pr` channel — on an `amyboard-pr-*` host it flashes the bundled same-origin `/firmware/` bins instead of the release/dev GitHub assets (also `?channel=pr`). Shows a "PR PREVIEW" badge.
- **`amyboard-pr-preview-cleanup.yml`** (on PR close): removes the `amyboard-pr-<N>` alias.

### ⚠️ Requires one secret
Add a repo secret **`VERCEL_TOKEN`** (a Vercel token for the `bwhitmans-projects` scope):
```
gh secret set VERCEL_TOKEN --repo shorepine/tulipcc
```
Until it's set, the preview job builds firmware+web then fails at the deploy step with a clear message. The `amyboard-pr` Vercel project already exists. Once the secret is in, **this PR will self-demonstrate** (it touches amyboardweb, so the preview runs on it).

### Notes
- Vercel CLI behavior in CI (link/deploy/alias) can need a small tweak on first real run — happy to iterate once the token is in.
- Builds run on PRs from same-repo branches (secrets aren't exposed to fork PRs).
- ~20 MB of firmware `.bin`s per preview; full firmware build (~10 min) runs per push (concurrency-cancelled).

Companion to the firmware-artifact CI (#992) and make-web CI (amy #730).

🤖 Generated with [Claude Code](https://claude.com/claude-code)