### PR TITLE
amyboard hwci: reboot-proof the bench (stable udev/ALSA device names)

### DIFF
--- a/.github/workflows/amyboard-hwci.yml
+++ b/.github/workflows/amyboard-hwci.yml
@@ -78,9 +78,16 @@ jobs:
       - name: Flash + drive + record + compare
         id: hwci
         working-directory: hwci
+        # Stable device names from the bench's udev rule (99-amyboard.rules) +
+        # ALSA card id, so a reboot that re-orders ttyACM/card indices can't make
+        # us flash or record the wrong device.
         run: |
           set -o pipefail
-          ~/hwci-venv/bin/python hwci.py --pr "${{ steps.ctx.outputs.pr }}" --port /dev/ttyACM1 2>&1 | tee hwci-run.log
+          ~/hwci-venv/bin/python hwci.py --pr "${{ steps.ctx.outputs.pr }}" \
+            --port /dev/amyboard-dongle \
+            --cdc-port /dev/amyboard-cdc \
+            --audio-device hw:CARD=Device,DEV=0 \
+            2>&1 | tee hwci-run.log
 
       - name: Upload artifacts (recording + serial log + run log)
         if: always()

--- a/tulip/amyboard/hwci/99-amyboard.rules
+++ b/tulip/amyboard/hwci/99-amyboard.rules
@@ -1,0 +1,12 @@
+# AMYboard HW CI bench — stable /dev names so flashing + serial logging do not
+# depend on ttyACM enumeration order across reboots. Match by USB vendor:product
+# (one of each device on this bench).
+#
+# Install on the runner Pi:
+#   sudo install -m 0644 99-amyboard.rules /etc/udev/rules.d/99-amyboard.rules
+#   sudo udevadm control --reload && sudo udevadm trigger --subsystem-match=tty
+#
+# Debug-header USB-serial dongle (esptool flashing): CH9102F
+SUBSYSTEM=="tty", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="55d4", SYMLINK+="amyboard-dongle"
+# AMYboard native USB CDC (MicroPython stdout)
+SUBSYSTEM=="tty", ATTRS{idVendor}=="caf0", ATTRS{idProduct}=="4009", SYMLINK+="amyboard-cdc"

--- a/tulip/amyboard/hwci/README.md
+++ b/tulip/amyboard/hwci/README.md
@@ -41,6 +41,20 @@ python3 -m venv ~/hwci-venv
 ```
 macOS dev: `pip install -r requirements.txt` (adds mido/python-rtmidi/sounddevice).
 
+## Stable device names (udev, recommended on the Pi)
+`ttyACM*` numbering and ALSA card indices are assigned in probe order, so a reboot
+can swap them and make the runner flash or record the wrong device. Install
+[`99-amyboard.rules`](99-amyboard.rules) to pin names by USB vendor:product:
+```
+sudo install -m 0644 99-amyboard.rules /etc/udev/rules.d/99-amyboard.rules
+sudo udevadm control --reload && sudo udevadm trigger --subsystem-match=tty
+```
+That gives `/dev/amyboard-dongle` (the CH9102F flashing dongle) and
+`/dev/amyboard-cdc` (the board's native CDC). Audio is referenced by its stable
+ALSA card id `hw:CARD=Device,DEV=0` (the C-Media capture) rather than `hw:1,0`.
+The CI workflow uses all three; for manual runs pass them with `--port`,
+`--cdc-port`, `--audio-device`.
+
 ## Use
 ```
 python3 hwci.py --list-devices


### PR DESCRIPTION
Follow-up to #994 (merged). The stable-device-name work was pushed to the #994
branch *after* it merged, so it never reached main — this lands it.

The merged workflow flashes \`/dev/ttyACM1\` and records \`hw:1,0\`, both
probe-order assignments that can swap on a Pi reboot and make the runner hit the
wrong device. This pins them:

- **\`99-amyboard.rules\`** — udev SYMLINKs by USB vendor:product →
  \`/dev/amyboard-dongle\` (CH9102F flashing dongle) + \`/dev/amyboard-cdc\`
  (native CDC). Already installed at \`/etc/udev/rules.d/\` on the runner Pi.
- **workflow** — flashes/logs/records via \`/dev/amyboard-dongle\`,
  \`/dev/amyboard-cdc\`, and \`hw:CARD=Device,DEV=0\` (the C-Media capture's
  stable ALSA id) instead of \`/dev/ttyACM1\` + \`hw:1,0\`.
- **README** — documents the udev install + stable names.

Validated on the bench: a full \`--pr 994\` flash → drive → record → compare
through **only** these stable names → PASS (spectral_similarity 0.9999).

This PR will itself trigger an auto HW CI run (via \`workflow_run\` off the
preview), exercising the loop once more before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)