### PR TITLE
docs(amyboard): Windows / USB-MIDI troubleshooting from 2 weeks of community reports

### DIFF
--- a/docs/amyboard/faq.md
+++ b/docs/amyboard/faq.md
@@ -66,7 +66,7 @@ We're actively chasing OS-specific USB issues. Known data points:
 - **Older Intel Macs** sometimes need a replug or restart after each reset before the MIDI port reappears; Apple-silicon Macs don't.
 - **Linux:** add your user to the `dialout` group, then e.g. `screen /dev/ttyACM0 115200`. If `lsusb` only shows the `303a:...` Espressif/JTAG device and never `caf0:4009`, `sudo usbreset 303a:1001` (or `usb_modeswitch -v303a -p1001 -W -R`) often forces the MIDI device to appear.
 
-**Workarounds while we fix the firmware:** the most reliable is to plug AMYboard into an **Android phone or iPad** with a USB-C cable and use [amyboard.com](https://amyboard.com/editor/) there. On Windows, running `msdt.exe -id DeviceDiagnostic` and rebooting often forces it to show up. Full steps in [Troubleshooting](troubleshooting.md#usb-midi-not-recognized).
+**Workarounds while we fix the firmware:** the most reliable is to plug AMYboard into an **Android phone** with a USB-C cable and use [amyboard.com](https://amyboard.com/editor/) there (iPhones/iPads don't do USB MIDI). On Windows, running `msdt.exe -id DeviceDiagnostic` and rebooting often forces it to show up. Full steps in [Troubleshooting](troubleshooting.md#usb-midi-not-recognized).
 
 If you have AMYboard on Windows, please report on Discord (or on [issue #952](https://github.com/shorepine/tulipcc/issues/952)) whether it works -- it helps us narrow the issue.
 

--- a/docs/amyboard/faq.md
+++ b/docs/amyboard/faq.md
@@ -61,10 +61,14 @@ We're actively chasing OS-specific USB issues. Known data points:
 
 - **Works:** Windows 11 ARM, Ubuntu 26 desktop, modern Apple-silicon Macs.
 - Some **Windows 10/11 x64** machines only ever see the USB/JTAG device. First make sure it isn't just stuck in DFU (above). Check **Settings → Bluetooth & devices → Other devices** for "AMYboard", and try a known **data** USB-C cable (many cables are charge-only).
+- The **same board** usually works under the **Arduino** AMY firmware (it enumerates as `caf0:0001`) even when the **MicroPython** `amyboard-full` firmware gets stuck as a `303a:...` JTAG device. So this is a firmware USB/boot issue we can fix -- not your computer.
+- A faint **click/pop in the audio about once per second** means the board is **boot-looping** (seen on some Android phones too, not just Windows). See [Is it a boot loop?](troubleshooting.md#is-it-a-boot-loop).
 - **Older Intel Macs** sometimes need a replug or restart after each reset before the MIDI port reappears; Apple-silicon Macs don't.
-- **Linux:** add your user to the `dialout` group, then e.g. `screen /dev/ttyACM0 115200`. If `dmesg` only shows the Espressif device and never a CDC/ACM serial + MIDI port, tell us your distro on Discord.
+- **Linux:** add your user to the `dialout` group, then e.g. `screen /dev/ttyACM0 115200`. If `lsusb` only shows the `303a:...` Espressif/JTAG device and never `caf0:4009`, `sudo usbreset 303a:1001` (or `usb_modeswitch -v303a -p1001 -W -R`) often forces the MIDI device to appear.
 
-If you have AMYboard on Windows, please report on Discord whether it works -- it helps us narrow the driver issue. More steps in [Troubleshooting](troubleshooting.md).
+**Workarounds while we fix the firmware:** the most reliable is to plug AMYboard into an **Android phone or iPad** with a USB-C cable and use [amyboard.com](https://amyboard.com/editor/) there. On Windows, running `msdt.exe -id DeviceDiagnostic` and rebooting often forces it to show up. Full steps in [Troubleshooting](troubleshooting.md#usb-midi-not-recognized).
+
+If you have AMYboard on Windows, please report on Discord (or on [issue #952](https://github.com/shorepine/tulipcc/issues/952)) whether it works -- it helps us narrow the issue.
 
 ### Can I plug a USB-MIDI keyboard straight into the AMYboard? (USB host)
 

--- a/docs/amyboard/troubleshooting.md
+++ b/docs/amyboard/troubleshooting.md
@@ -50,26 +50,58 @@ Many issues are fixed in newer firmware. Before troubleshooting, [update to the 
 
 ## USB MIDI not recognized
 
- - Did you hit RST? Try that first.
- - AMYboard appears as a USB MIDI device with VID `0xCAF0` and PID `0x4009`.
- - On macOS, open **Audio MIDI Setup** and check if AMYboard appears.
- - On Windows, check Device Manager under "Sound, video and game controllers".
- - Try a different USB port or cable.
- - Some USB hubs can cause issues -- try connecting directly.
+A healthy AMYboard enumerates as **two** USB things at once: a USB **MIDI** device *and* a USB **serial** (CDC) port, with USB VID `0xCAF0` and PID `0x4009`. If you only ever see a *"USB JTAG/serial debug unit"* (VID `0x303A`), the firmware's USB stack never came up -- see [Is it a boot loop?](#is-it-a-boot-loop) below. That is the most common cause of "no USB MIDI" right now, and we're actively working on it ([#952](https://github.com/shorepine/tulipcc/issues/952), [#980](https://github.com/shorepine/tulipcc/issues/980)).
+
+ - Did you hit **RST** after flashing? Try that first.
+ - Use a **data** USB-C cable (many cables are charge-only) and plug **directly** into the computer -- no hubs or extension cables.
+ - Make sure **nothing else is holding the port**: close `mpremote`, serial terminals, the Python REPL, and any DAW that grabbed it. Only one program can own the connection at a time.
+ - On **macOS**, open **Audio MIDI Setup** and check if AMYboard appears.
+ - On **Windows**, check Device Manager under **Sound, video and game controllers** (see the [Windows](#windows) section below).
+ - On **Linux**, check `aplaymidi -l` / `amidi -l` and `lsusb` -- you want to see `caf0:4009`, not `303a:...`.
+
+### Is it a boot loop?
+
+A number of boards get **stuck re-enumerating** instead of finishing boot. Tell-tale signs:
+
+ - It appears **only** as a `303a:...` *USB JTAG/serial debug unit*, never as `caf0:4009`.
+ - You hear a faint **click/pop in the audio out about once per second** -- that's the board rebooting over and over.
+ - `mpremote` connects but hangs with **no `>>>` prompt**, and Ctrl-C won't break in.
+
+A strong clue this is firmware and not your computer: the **Arduino** AMY firmware on the *same board* enumerates fine (as `caf0:0001`, USB MIDI works), while the **MicroPython** `amyboard-full` firmware gets stuck. To get going right now:
+
+ - **First, just retry:** unplug, replug, hit **RST**. It often comes up on the 2nd or 3rd try.
+ - **Most reliable workaround -- use a phone or tablet:** plug AMYboard into an **Android phone or an iPad** with a USB-C cable and open [amyboard.com](https://amyboard.com/editor/) in Chrome there. This works for many people for whom Windows doesn't, and lets you load sketches and patches in the meantime.
+ - **Linux:** force a clean re-enumeration without cutting power -- `sudo usbreset 303a:1001`, or `sudo usb_modeswitch -v303a -p1001 -W -R`. The `caf0:4009` MIDI device then appears.
+ - Try a **known-good data cable** and a **rear/motherboard USB port** -- a port that can't supply enough current can trigger the reboot loop.
+
+### Windows
+
+Windows is the hardest case: once it has cached the board as a JTAG/serial device it tends to keep doing so, even after the board itself is fine.
+
+ - **Confirm the symptom** in Device Manager. A broken board shows as **"USB JTAG/serial debug unit"** (and a **"USB Composite Device"** under *Universal Serial Bus controllers*) but has **nothing** under **Sound, video and game controllers**. A working board shows **AMYboard** under *Sound, video and game controllers*.
+ - **Force a re-detect** (this has worked for several people): run the built-in hardware troubleshooter, apply its fix, and **reboot**:
+   ```
+   msdt.exe -id DeviceDiagnostic
+   ```
+   After the reboot, AMYboard often appears under *Sound, video and game controllers* and the online editor can connect. You may have to repeat this after each unplug/replug until the firmware fix lands.
+ - **Remove ghost devices:** in Device Manager choose **View → Show hidden devices**, then uninstall any greyed-out AMYboard / "USB Serial Device" / JTAG entries and re-scan for hardware. Windows sometimes assigns a **new COM port each time** (COM4 vs COM6, etc.) and only binds MIDI on some of them.
+ - If it works in a **DAW** but not the editor, the board is fine -- it's a browser/WebMIDI issue; see the editor steps below.
 
 ## AMYboard Online issues
 
 ### Web MIDI not working
- - Web MIDI requires Chrome or Edge. Firefox and Safari do not support Web MIDI.
+ - Web MIDI requires **Chrome or Edge** (desktop). Firefox and Safari do not support Web MIDI.
  - Make sure your MIDI device is connected before opening amyboard.com.
  - Click the MIDI device selector and choose your device.
  - On some systems, you may need to grant MIDI access permission.
 
-### AMYboard Online can't find the board
+### "Could not connect to AMYboard" / the "Pull from AMYboard" popup keeps reappearing
 
- - Make sure you are not connected to AYMboard over a serial connection when using AMYboard online.
- - Look at the browsers' JS console to see helpful diagnostic messages.
- - [Re-flash your firmware](firmware.md) if you're having issues.
+ - Make sure you are **not** connected to AMYboard over a serial connection (mpremote, a terminal, the Python REPL) -- disconnect it and try again.
+ - **Clear the site data** for amyboard.com and restart the browser: DevTools → **Application → Storage → Clear site data** (or the address-bar site-settings menu). Stale stored state is a common cause of the Pull popup looping.
+ - If the board responds to MIDI elsewhere (a DAW, MIDIKeys, [a web MIDI tester](https://controllertest.io/midi-tester)) but the editor still can't Pull, **retry the Pull** -- it often succeeds on the second attempt once the board has finished its reboot.
+ - Look at the browser's **JS console** for diagnostic messages.
+ - [Re-flash your firmware](firmware.md) if you're still stuck.
 
 ## MIDI issues
 

--- a/docs/amyboard/troubleshooting.md
+++ b/docs/amyboard/troubleshooting.md
@@ -70,7 +70,7 @@ A number of boards get **stuck re-enumerating** instead of finishing boot. Tell-
 A strong clue this is firmware and not your computer: the **Arduino** AMY firmware on the *same board* enumerates fine (as `caf0:0001`, USB MIDI works), while the **MicroPython** `amyboard-full` firmware gets stuck. To get going right now:
 
  - **First, just retry:** unplug, replug, hit **RST**. It often comes up on the 2nd or 3rd try.
- - **Most reliable workaround -- use a phone or tablet:** plug AMYboard into an **Android phone or an iPad** with a USB-C cable and open [amyboard.com](https://amyboard.com/editor/) in Chrome there. This works for many people for whom Windows doesn't, and lets you load sketches and patches in the meantime.
+ - **Most reliable workaround -- use an Android phone:** plug AMYboard into an **Android phone** with a USB-C cable and open [amyboard.com](https://amyboard.com/editor/) in Chrome there. This works for many people for whom Windows doesn't, and lets you load sketches and patches in the meantime. (iPhones/iPads don't do USB MIDI, so they won't work for this.)
  - **Linux:** force a clean re-enumeration without cutting power -- `sudo usbreset 303a:1001`, or `sudo usb_modeswitch -v303a -p1001 -W -R`. The `caf0:4009` MIDI device then appears.
  - Try a **known-good data cable** and a **rear/motherboard USB port** -- a port that can't supply enough current can trigger the reboot loop.
 


### PR DESCRIPTION
## What

Consolidates the AMYboard **Windows USB-MIDI** findings from the last ~2 weeks of the `#amyboard` Discord (and the dedicated debug thread) into the docs, and adds the workarounds people discovered. Full write-up of everyone's reports is in [#952](https://github.com/shorepine/tulipcc/issues/952).

This is **docs only** — it doesn't attempt the firmware fix, because that needs real hardware to reproduce the boot loop (the new HW-CI bench is the right place for it). It unblocks affected users today and gives a single reference for the steps we keep repeating in chat.

## Why

The reports across Windows, Linux, and even Android converge on one thing: the **MicroPython `amyboard-full` firmware frequently fails to switch from the ROM USB-Serial-JTAG device (`303a:...`) to the TinyUSB CDC+MIDI device (`caf0:4009`)** — so there's no USB MIDI and the board boot-loops (the faint audio "pop ~once per second"). The key tell, reported by multiple people, is that the **Arduino** AMY firmware on the *same board* enumerates fine (`caf0:0001`), which points at the MicroPython USB/boot path rather than the host OS. Windows just makes it stickier because it caches the JTAG-only enumeration.

## Changes

`docs/amyboard/troubleshooting.md`
- Rewrote **USB MIDI not recognized** around the two-device (`caf0:4009` CDC+MIDI) expectation.
- New **Is it a boot loop?** section: the `303a:...`-only + audio-pop + `mpremote`-hangs signature, the Arduino-vs-MicroPython tell, and recoveries — retry, **phone/iPad fallback**, Linux `usbreset` / `usb_modeswitch -v303a -p1001 -W -R`.
- New **Windows** section: `msdt.exe -id DeviceDiagnostic` + reboot, **Show hidden devices** ghost cleanup, COM-port instability, Device Manager checks.
- New editor section for the looping **"Pull from AMYboard"** popup: clear site data, free the port, retry after the reboot.

`docs/amyboard/faq.md`
- Updated the "Known data points" list to match (Arduino-vs-MicroPython tell, boot-loop audio signature also seen on Android, Linux `usbreset`) and added a short "Workarounds while we fix the firmware" note.

## Not in this PR (needs hardware / maintainer call)
- The actual firmware fix for the JTAG↔TinyUSB re-enumeration / boot loop (root cause). Candidate angles for the HW-CI bench are in the [#952](https://github.com/shorepine/tulipcc/issues/952) write-up.
- I intentionally left the editor's WebMIDI connect logic (`spss.js`) alone — it's already heavily tuned for these cases and isn't testable without a board in the loop.

Refs #952, #980.

🤖 Generated with [Claude Code](https://claude.com/claude-code)