### PR TITLE
amyboard: fix Windows USB MIDI end-to-end — S3 PHY→OTG mux, MIDI IAD, browser-restart UX, editor spinner (#952, #980)

### DIFF
--- a/.github/workflows/amyboard-pr-preview.yml
+++ b/.github/workflows/amyboard-pr-preview.yml
@@ -14,6 +14,9 @@ on:
     paths:
       - 'amy'
       - 'tulip/amyboard/**'
+      # AMYboard firmware also compiles shared ESP32-S3 sources from here
+      # (e.g. tulip/esp32s3/usb.c), so changes there must rebuild the preview.
+      - 'tulip/esp32s3/**'
       - 'tulip/amyboardweb/**'
       - 'tulip/shared/amyboard-py/**'
       - '.github/workflows/amyboard-pr-preview.yml'

--- a/tulip/amyboard/mp_usbd_descriptor.c
+++ b/tulip/amyboard/mp_usbd_descriptor.c
@@ -28,7 +28,10 @@
 #include "py/mpconfig.h"
 
 #if MICROPY_HW_ENABLE_USBDEV
-#define CONFIG_TOTAL_LEN_MIDI  (TUD_CONFIG_DESC_LEN + TUD_MIDI_DESC_LEN + TUD_CDC_DESC_LEN)
+// + 8 for the MIDI/Audio Interface Association Descriptor added by hand in the
+// config array below (TUD_MIDI_DESCRIPTOR doesn't emit one). An IAD is 8 bytes;
+// this must be counted here or wTotalLength is short and enumeration breaks.
+#define CONFIG_TOTAL_LEN_MIDI  (TUD_CONFIG_DESC_LEN + TUD_MIDI_DESC_LEN + TUD_CDC_DESC_LEN + 8)
 
 #include "amyboard_usbd.h"
 #include "tusb.h"
@@ -78,6 +81,20 @@ const uint8_t mp_usbd_builtin_desc_cfg[CONFIG_TOTAL_LEN_MIDI] = {
     // Interface number, string index, EP Out & EP In address, EP size
     TUD_CDC_DESCRIPTOR(ITF_NUM_CDC, 4, EPNUM_CDC_NOTIF,
         8, EPNUM_CDC_OUT, EPNUM_CDC_IN, 64),
+
+    // Interface Association Descriptor for the MIDI (USB Audio) function.
+    // TUD_MIDI_DESCRIPTOR emits the Audio-Control + MIDI-Streaming interfaces but
+    // NO IAD. The CDC function above has one, so the device advertises IADs -- and
+    // when IADs are present, Windows' usbccgp groups *every* function by IAD. An
+    // audio function with no IAD makes some Windows builds bind the generic USB
+    // Audio driver to the WHOLE device (no composite parent -> no CDC serial port,
+    // no WebMIDI-visible MIDI port), which is the AMYboard "shows up as a sound
+    // card, not composite" report. Associate ITF_NUM_MIDI + ITF_NUM_MIDI_STREAMING
+    // as one Audio function so usbccgp enumerates it cleanly on every Windows.
+    // 8 bytes: bLength, bDescriptorType(IAD=0x0B), bFirstInterface, bInterfaceCount,
+    //          bFunctionClass(AUDIO=1), bFunctionSubClass(AUDIO_CONTROL=1),
+    //          bFunctionProtocol(0), iFunction(0).
+    0x08, TUSB_DESC_INTERFACE_ASSOCIATION, ITF_NUM_MIDI, 0x02, TUSB_CLASS_AUDIO, 0x01, 0x00, 0x00,
 
     TUD_MIDI_DESCRIPTOR(ITF_NUM_MIDI, 0, EPNUM_MIDI, 0x80 | EPNUM_MIDI, 64),
 

--- a/tulip/amyboardweb/static/editor/index.html
+++ b/tulip/amyboardweb/static/editor/index.html
@@ -1265,7 +1265,11 @@
       </div>
 
       <!-- Syncing modal (control mode) -->
-      <div class="modal fade" id="syncingModal" tabindex="-1" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
+      <!-- No 'fade': Bootstrap's fade defers display:block to an async animation
+           callback, which races _hide_syncing_modal() when a pull completes
+           faster than the ~150ms fade and leaves the spinner stuck on screen
+           (#952). Synchronous show/hide avoids the race. -->
+      <div class="modal" id="syncingModal" tabindex="-1" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
         <div class="modal-dialog modal-dialog-centered" style="max-width:420px;">
           <div class="modal-content">
             <div class="modal-body text-center px-4 py-4">

--- a/tulip/amyboardweb/static/esptool/index.html
+++ b/tulip/amyboardweb/static/esptool/index.html
@@ -95,7 +95,7 @@
             <div class="progress-bar hidden"><div></div></div>
           </div>
           <div id="upgradeComplete" class="upgrade-complete hidden">
-            Upgrade complete. Make sure to hit RST to reboot your AMYboard and then <a href="#" onclick="window.location.reload(); return false;">reload this page</a>.
+            Upgrade complete! Hit RST to reboot your AMYboard, then <b>fully quit and reopen your browser</b> (close all its windows) before going back to the editor &mdash; don't just reload the page. Especially on Windows, browsers won't detect the AMYboard's USB&nbsp;MIDI ports until they're restarted.
           </div>
         </div>
       </div>

--- a/tulip/amyboardweb/static/esptool/index.html
+++ b/tulip/amyboardweb/static/esptool/index.html
@@ -63,6 +63,7 @@
             <li><B>Fully erase and re-flash AMYboard</b>. This will remove any stored patches or environments. (Your SD card is safe.) Use this only if you're having issues.
           </ul>
           <li>Wait a minute until the progress bar disappears. Hit RST. Your AMYboard should be updated!</li>
+          <li><b>Now fully quit and reopen your browser</b> (close all of its windows, not just this tab) before going back to the editor &mdash; <b>don't just reload the page</b>. Especially on Windows, browsers won't detect the AMYboard's USB&nbsp;MIDI ports until they're restarted.</li>
         </UL>
         <button id="butConnect" type="button">Search for AMYboard</button>
       </div>

--- a/tulip/amyboardweb/static/spss.js
+++ b/tulip/amyboardweb/static/spss.js
@@ -4351,6 +4351,7 @@ function _clear_pull_button_gate(reason) {
 // always has the chance to confirm/change MIDI ports first. This is the
 // ONE syncing modal the editor exposes; no separate auto-spinner path.
 function _show_syncing_modal() {
+    console.log('[DBG-MODAL] GATE _show_syncing_modal() skip_gate=' + _skip_pull_gate + '\n' + new Error().stack);
     if (amyboard_mode !== 'control') return Promise.resolve();
     var el = document.getElementById('syncingModal');
     if (!el || !window.bootstrap) return Promise.resolve();
@@ -4391,6 +4392,7 @@ function _show_syncing_modal() {
 // (Windows-Chrome post-zB reload) where the click already happened on
 // the previous page and we need to resume in busy state.
 function _show_syncing_modal_busy() {
+    console.log('[DBG-MODAL] BUSY _show_syncing_modal_busy()\n' + new Error().stack);
     var el = document.getElementById('syncingModal');
     if (el && window.bootstrap) {
         bootstrap.Modal.getOrCreateInstance(el, { backdrop: 'static', keyboard: false }).show();
@@ -4465,6 +4467,7 @@ async function start_pull_from_amyboard() {
 }
 
 function _show_syncing_modal_error() {
+    console.log('[DBG-MODAL] ERROR _show_syncing_modal_error()\n' + new Error().stack);
     var spinner = document.getElementById('sync-modal-spinner');
     var error = document.getElementById('sync-modal-error');
     var retryBtn = document.getElementById('sync-modal-retry-btn');
@@ -4487,6 +4490,7 @@ function _show_syncing_modal_error() {
 }
 
 function _hide_syncing_modal() {
+    console.log('[DBG-MODAL] HIDE _hide_syncing_modal()\n' + new Error().stack);
     var el = document.getElementById('syncingModal');
     if (!el) return;
     // Reject any pending green-button gate so awaiting callers stop

--- a/tulip/amyboardweb/static/spss.js
+++ b/tulip/amyboardweb/static/spss.js
@@ -4351,7 +4351,6 @@ function _clear_pull_button_gate(reason) {
 // always has the chance to confirm/change MIDI ports first. This is the
 // ONE syncing modal the editor exposes; no separate auto-spinner path.
 function _show_syncing_modal() {
-    console.log('[DBG-MODAL] GATE _show_syncing_modal() skip_gate=' + _skip_pull_gate + '\n' + new Error().stack);
     if (amyboard_mode !== 'control') return Promise.resolve();
     var el = document.getElementById('syncingModal');
     if (!el || !window.bootstrap) return Promise.resolve();
@@ -4392,7 +4391,6 @@ function _show_syncing_modal() {
 // (Windows-Chrome post-zB reload) where the click already happened on
 // the previous page and we need to resume in busy state.
 function _show_syncing_modal_busy() {
-    console.log('[DBG-MODAL] BUSY _show_syncing_modal_busy()\n' + new Error().stack);
     var el = document.getElementById('syncingModal');
     if (el && window.bootstrap) {
         bootstrap.Modal.getOrCreateInstance(el, { backdrop: 'static', keyboard: false }).show();
@@ -4467,7 +4465,6 @@ async function start_pull_from_amyboard() {
 }
 
 function _show_syncing_modal_error() {
-    console.log('[DBG-MODAL] ERROR _show_syncing_modal_error()\n' + new Error().stack);
     var spinner = document.getElementById('sync-modal-spinner');
     var error = document.getElementById('sync-modal-error');
     var retryBtn = document.getElementById('sync-modal-retry-btn');
@@ -4490,7 +4487,6 @@ function _show_syncing_modal_error() {
 }
 
 function _hide_syncing_modal() {
-    console.log('[DBG-MODAL] HIDE _hide_syncing_modal()\n' + new Error().stack);
     var el = document.getElementById('syncingModal');
     if (!el) return;
     // Reject any pending green-button gate so awaiting callers stop

--- a/tulip/esp32s3/usb.c
+++ b/tulip/esp32s3/usb.c
@@ -37,12 +37,49 @@
 #include "esp_private/usb_phy.h"
 static usb_phy_handle_t phy_hdl;
 
+#if CONFIG_IDF_TARGET_ESP32S3
+// WORKAROUND for https://github.com/hathach/tinyusb/issues/2943
+// On the ESP32-S3 the USB D+/D- pins power up muxed to the ROM USB-Serial-JTAG
+// controller; the app must switch the mux to the USB-OTG (TinyUSB) PHY. As of
+// ESP-IDF >= 5.2 the usb_new_phy() init no longer flips that mux reliably/early
+// enough, so the host enumerates the JTAG device (303a:1001, "USB JTAG/serial
+// debug unit") and keeps it -- our TinyUSB CDC+MIDI device (caf0:4009) never
+// appears. It manifests worst on Windows (and direct-connect); a USB hub masks
+// it by changing the reset timing. Force the DP/DM mux to the internal OTG PHY
+// by hand instead, matching the merged CircuitPython workaround
+// (adafruit/circuitpython#9973, diagnosed by TinyUSB's maintainer).
+#include "esp_private/periph_ctrl.h"
+#include "soc/periph_defs.h"
+#include "soc/usb_pins.h"
+#include "soc/rtc_cntl_struct.h"
+#include "soc/usb_wrap_struct.h"
+#include "driver/gpio.h"
+#endif
 
 
 void usb_init(void) {
     // ref: https://github.com/espressif/esp-usb/blob/4b6a798d0bed444fff48147c8dcdbbd038e92892/device/esp_tinyusb/tinyusb.c
 
     // Configure USB PHY
+    #if CONFIG_IDF_TARGET_ESP32S3
+    // Manually route the DP/DM pads to the internal OTG PHY (see note above).
+    // We deliberately bypass usb_new_phy() here, so phy_hdl stays NULL on S3 --
+    // usb_usj_mode() below is written to tolerate that.
+    (void)phy_hdl;
+    periph_module_reset(PERIPH_USB_MODULE);
+    periph_module_enable(PERIPH_USB_MODULE);
+
+    USB_WRAP.otg_conf.pad_enable = 1;
+    // USB_OTG uses the internal PHY
+    USB_WRAP.otg_conf.phy_sel = 0;
+    // phy_sel is controlled by the SW register value below
+    RTCCNTL.usb_conf.sw_hw_usb_phy_sel = 1;
+    // sw_usb_phy_sel = 1 -> USB_OTG connected to the internal PHY
+    RTCCNTL.usb_conf.sw_usb_phy_sel = 1;
+
+    gpio_set_drive_capability(USBPHY_DM_NUM, GPIO_DRIVE_CAP_3);
+    gpio_set_drive_capability(USBPHY_DP_NUM, GPIO_DRIVE_CAP_3);
+    #else
     usb_phy_config_t phy_conf = {
         .controller = USB_PHY_CTRL_OTG,
         .otg_mode = USB_OTG_MODE_DEVICE,
@@ -52,6 +89,7 @@ void usb_init(void) {
 
     // Init ESP USB Phy
     usb_new_phy(&phy_conf, &phy_hdl);
+    #endif
 
     // Init MicroPython / TinyUSB
     mp_usbd_init();
@@ -76,9 +114,15 @@ static usb_phy_handle_t phy_hdl;
 #endif
 
 void usb_usj_mode(void) {
-    // Switch the USB PHY back to Serial/Jtag mode, disabling OTG support
+    // Switch the USB PHY back to Serial/Jtag mode, disabling OTG support.
     // This should be run before jumping to bootloader.
-    usb_del_phy(phy_hdl);
+    // usb_init() configures the OTG PHY by hand on the ESP32-S3 and never creates
+    // a phy handle (see the #2943 workaround above), so only delete one if it
+    // exists -- otherwise usb_del_phy(NULL) would fail the bootloader-entry path.
+    if (phy_hdl != NULL) {
+        usb_del_phy(phy_hdl);
+        phy_hdl = NULL;
+    }
     usb_phy_config_t phy_conf = {
         .controller = USB_PHY_CTRL_SERIAL_JTAG,
     };

--- a/tulip/esp32s3/usb.c
+++ b/tulip/esp32s3/usb.c
@@ -54,6 +54,7 @@ static usb_phy_handle_t phy_hdl;
 #include "soc/rtc_cntl_struct.h"
 #include "soc/usb_wrap_struct.h"
 #include "driver/gpio.h"
+#include "esp_rom_sys.h"
 #endif
 
 
@@ -79,6 +80,15 @@ void usb_init(void) {
 
     gpio_set_drive_capability(USBPHY_DM_NUM, GPIO_DRIVE_CAP_3);
     gpio_set_drive_capability(USBPHY_DP_NUM, GPIO_DRIVE_CAP_3);
+
+    // Switching the mux above moves the PHY off the ROM USB-Serial-JTAG, dropping
+    // that device's D+ pull-up -- i.e. the host sees the 303a:1001 JTAG device
+    // disconnect. Hold here before TinyUSB (mp_usbd_init below) re-asserts the
+    // pull-up as caf0:4009, so a stubborn host has time to register the
+    // disconnect and re-enumerate the new device instead of keeping the JTAG one.
+    // Confirmed via USBView (#952) that a bare USB3 root port otherwise stays on
+    // 303a:1001 forever and never sees AMYboard's MIDI device.
+    esp_rom_delay_us(250 * 1000);  // 250 ms disconnect window
     #else
     usb_phy_config_t phy_conf = {
         .controller = USB_PHY_CTRL_OTG,


### PR DESCRIPTION
Fixes the AMYboard "USB MIDI doesn't work on Windows" reports (#952), debugged and **validated end-to-end on a clean Windows 10 x64 machine (direct USB3) + the HW-CI bench**. Five distinct issues, each its own commit.

## Firmware
1. **ESP32-S3 never switched USB-Serial-JTAG → OTG** — `tulip/esp32s3/usb.c`. On a bare USB3 root port the board stayed enumerated as the ROM JTAG device (`303a:1001`) and never appeared as `caf0:4009`, so there was no MIDI device at all. Force the DP/DM mux to the internal OTG PHY (TinyUSB [#2943](https://github.com/hathach/tinyusb/issues/2943) / CircuitPython [#9973](https://github.com/adafruit/circuitpython/pull/9973)), **and hold 250 ms after the switch** so a stubborn host registers the disconnect and re-enumerates — the mux force alone wasn't enough on a direct USB3 port (a hub masked it). ✅ *USBView: direct-USB3 now shows `caf0:4009`.*
2. **MIDI function had no IAD** — `tulip/amyboard/mp_usbd_descriptor.c`. Added an Audio Interface Association Descriptor before the MIDI descriptor so Windows `usbccgp` enumerates it as a proper composite (CDC + MIDI). ✅ *USBView: composite with COM + MIDI.*

## Web / UX
3. **Browser won't see the new MIDI device until fully restarted** — `esptool/index.html`. Chrome's WebMIDI on Windows only picks the device up after a full browser **restart**, not a page reload — almost certainly behind a large share of "I flashed it but the editor never sees it." Updated the flasher steps + the post-upgrade box to say *quit and reopen the browser*. ✅ *device appears after a full restart.*
4. **"Pulling from AMYboard…" spinner stuck forever** — `editor/index.html`. Bootstrap's `fade` defers the modal's `display:block` into an async animation callback; a fast pull (zI ready in ~19 ms) hides the modal first, then the deferred show re-displays it with no way to dismiss. Dropped `fade` on the syncing modal → synchronous show/hide. ✅ *spinner now closes after a pull.*

## CI
5. `amyboard-pr-preview.yml` also triggers on `tulip/esp32s3/**` (AMYboard firmware compiles shared sources from there, so a fix in `usb.c` needs to rebuild the preview).

Refs #952, #980.

🤖 Generated with [Claude Code](https://claude.com/claude-code)