### PR TITLE
ci: note HW CI is running in the AMYboard PR-preview comment

### DIFF
--- a/.github/workflows/amyboard-pr-preview.yml
+++ b/.github/workflows/amyboard-pr-preview.yml
@@ -130,6 +130,8 @@ jobs:
               `**Editor + flasher:** ${url}/editor/`,
               '',
               "This preview bundles **this PR's firmware** — its flasher only flashes this build (not release/dev). Rebuilt on every push; removed when the PR closes.",
+              '',
+              'The hardware CI has been kicked off and should return within a few minutes, stand by!',
             ].join('\n');
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number,


### PR DESCRIPTION
The **AMYboard HW CI** workflow chains off **AMYboard PR preview** via `workflow_run` (on successful completion, same-repo PRs only), but nothing tells the PR author it's running — so the bench result appears a few minutes later with no heads-up.

Add one line to the preview comment:

> The hardware CI has been kicked off and should return within a few minutes, stand by!

The preview comment is only posted on preview **success** (and fork PRs never reach it — no `VERCEL_TOKEN`), which for same-repo PRs is exactly when HW CI is triggered, so the line is accurate.

This PR also touches the preview workflow's own path filter, so opening it exercises the new comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)