### PR TITLE
ci(amyboard-hwci): post a fresh result comment each run so it actually notifies

### DIFF
--- a/.github/workflows/amyboard-hwci.yml
+++ b/.github/workflows/amyboard-hwci.yml
@@ -25,6 +25,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write            # delete the previous HW CI comment so each run re-notifies
 
 concurrency:
   group: amyboard-hwci          # one physical board → serialize every run
@@ -123,5 +124,11 @@ jobs:
             ].join('\n');
             const { data: comments } = await github.rest.issues.listComments({ owner: context.repo.owner, repo: context.repo.repo, issue_number: pr });
             const existing = comments.find(c => c.body && c.body.includes(marker));
-            if (existing) await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: existing.id, body });
-            else await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: pr, body });
+            // Post a fresh comment every run rather than editing in place: GitHub
+            // only sends notifications/emails for NEW comments, and a new comment
+            // lands at the bottom of the thread where it's actually visible (an
+            // in-place edit is silent). Create first, then delete the previous one,
+            // so there's always exactly one HW CI comment and never zero if the
+            // delete fails.
+            await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: pr, body });
+            if (existing) await github.rest.issues.deleteComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: existing.id });


### PR DESCRIPTION
## Problem

The HW CI result comment is **upserted** — `updateComment` if a `<!-- amyboard-hwci -->` comment already exists, else `createComment`. So after the first run on a PR, every later run **edits that comment in place**. GitHub:

- sends **no notification/email** for comment edits, and
- doesn't move an edited comment to the bottom of the thread,

so the PR author gets no signal the run finished, and the (stale-looking) comment near the top just silently flips. Exactly what happened on #999: yesterday's run created the comment, today's run edited it in place → no email, nothing new to see.

## Fix

Post a **new** comment each run and delete the previous one, so there's still exactly one HW CI comment but it re-notifies and lands at the bottom every time. Create-before-delete so a failed delete leaves one comment, never zero. Adds `issues: write` for `deleteComment`.

## Note on rollout

HW CI is `workflow_run`-triggered, so GitHub always runs it from the **default branch's** copy of the workflow. This change therefore only takes effect **after it's merged to `main`** — it won't demonstrate itself on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)