### PR TITLE
amyboard-release: trigger on tulip/esp32s3/** changes

### DIFF
--- a/.github/workflows/amyboard-release.yml
+++ b/.github/workflows/amyboard-release.yml
@@ -23,6 +23,9 @@ on:
     paths:
       - 'amy'
       - 'tulip/amyboard/**'
+      # AMYboard firmware also compiles shared ESP32-S3 sources from here
+      # (e.g. tulip/esp32s3/usb.c), so changes there must trigger a release.
+      - 'tulip/esp32s3/**'
       - 'tulip/amyboardweb/**'
       - 'tulip/shared/**'
       - '.github/workflows/amyboard-release.yml'


### PR DESCRIPTION
## What

Add `tulip/esp32s3/**` to the `paths:` filter of the **AMYboard release** workflow (`.github/workflows/amyboard-release.yml`).

## Why

The AMYboard firmware compiles shared ESP32-S3 sources out of `tulip/esp32s3/` (most relevantly `usb.c` — the USB PHY-mux + MIDI-IAD fixes from #999). But the release workflow's `paths:` filter didn't list that directory:

```yaml
paths:
  - 'amy'
  - 'tulip/amyboard/**'
  - 'tulip/amyboardweb/**'
  - 'tulip/shared/**'
  - '.github/workflows/amyboard-release.yml'
```

So a **firmware-only** fix that lands solely in `tulip/esp32s3/` would *not* trigger a release. #999 only shipped to the rolling `amyboard` release because it happened to also touch `tulip/amyboard/` and `tulip/amyboardweb/`. A future ESP32-S3-only fix would silently not release.

This mirrors the same path (and comment) already added to `amyboard-pr-preview.yml` in #999, so the preview/HW-CI and the release path filters stay in sync.

## Scope check

- `amyboard-pr-preview.yml` — already has `tulip/esp32s3/**` (added in #999). ✅
- `amyboard-hwci.yml` — chains off the preview via `workflow_run`, no `paths:` filter of its own, so nothing to change. ✅
- `amyboard-firmware.yml` — no longer exists on `main` (replaced by `amyboard-release.yml`). ✅

Only `amyboard-release.yml` had the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)