### PR TITLE
amyboardweb: fix MIDI messages delivered 2x/4x in web editor

### DIFF
--- a/tulip/amyboardweb/static/spss.js
+++ b/tulip/amyboardweb/static/spss.js
@@ -1128,9 +1128,17 @@ window.refresh_knobs_for_active_channel = async function(options) {
 };
 
 
-async function amy_external_midi_input_js_hook(bytes, len, sysex) {
-    mp.midiInHook(bytes, len, sysex);
-} 
+// AMY's main-thread WASM module calls this (via EM_ASM in
+// amy_event_midi_message_received) for every NON-sysex MIDI message it parses
+// out of amy_process_single_midi_byte(). We deliberately do NOT forward to
+// mp.midiInHook here: the "midimessage" listener in setup_midi_devices() below
+// already forwards every complete message (sysex included) to MicroPython
+// explicitly. Forwarding here as well delivered every non-sysex message to
+// Python twice — the "MIDI CC repeated 2x" bug. Kept as a no-op (not removed)
+// so AMY's `typeof amy_external_midi_input_js_hook === 'function'` check still
+// passes. NOTE: tulip/web (not this file) still relies on this hook as its only
+// path, so don't "fix" it the same way there.
+function amy_external_midi_input_js_hook(bytes, len, sysex) { /* no-op: see comment above */ } 
 
 function safe_midi_port_id(port) {
   try {
@@ -1489,6 +1497,17 @@ async function setup_midi_devices() {
             rawInput.addEventListener('midimessage', _raw_sysex_listener);
         }
     } catch (e) { console.warn('raw sysex listener setup failed:', e); }
+    // setup_midi_devices() runs again on dropdown onchange, statechange, and the
+    // sync/pull flows — and WebMidi.js addListener() APPENDS (it does not
+    // replace). Without clearing first, each re-run stacked another
+    // "midimessage" handler on the same Input, so every incoming message got
+    // delivered (and forwarded to MicroPython + move_knob) N times — the "MIDI
+    // messages repeated 4x/2x" bug. Remove any handler we attached on a previous
+    // run before adding the new one. (No callback arg = remove all "midimessage"
+    // listeners on this WebMidi.js Input wrapper; the raw-sysex and passthru
+    // listeners live on the underlying native MIDIInput via addEventListener and
+    // are unaffected.)
+    try { midiInputDevice.removeListener("midimessage"); } catch (e) {}
     midiInputDevice.addListener("midimessage", e => {
       const data = e.message && e.message.data ? e.message.data : [];
       const status = data.length > 0 ? data[0] : null;


### PR DESCRIPTION
## Summary

Dan reported that each MIDI CC from a LaunchControl was printed **2× (was 4×)** by a web sketch in the editor, while a native MIDI Monitor confirmed the controller sends each message **once**. The duplication is entirely in the web MIDI path (`tulip/amyboardweb/static/spss.js`) — two compounding bugs:

**1. Double delivery to Python (×2).** A non-sysex message reached MicroPython via *two* paths:
- **Path A:** `amy_process_single_midi_byte()` → AMY `convert_midi_bytes_to_messages` → `amy_event_midi_message_received` → main-thread `EM_ASM` → `amy_external_midi_input_js_hook` → `mp.midiInHook`.
- **Path B:** the explicit `mp.midiInHook` in the `"midimessage"` listener (added in e9cc3b09).

`amy_process_single_midi_byte` is cwrapped to the **main-thread** `am` module (`amyModule()`), so AMY's `EM_ASM` hook *does* reach `mp` — the "can't cross the AudioWorklet boundary" assumption in that commit was wrong. Both paths fired → every CC counted twice.

**2. Stacked listeners (×N).** `setup_midi_devices()` re-runs on the dropdown `onchange`, `statechange`, and the sync/pull flows. WebMidi.js `addListener()` *appends*, and the main `"midimessage"` handler was never removed — so each re-run stacked another copy. (The raw-sysex and passthru listeners were already removed before re-adding; the main one wasn't.)

Net effect was **(2 paths) × (N stacked listeners)** — hence 4×, then 2× after redundant `setup_midi_devices()` calls were reduced.

## Fix

- **Neutralize Path A:** `amy_external_midi_input_js_hook` is now a documented no-op, leaving the explicit listener call as the single source. This is the correct path to keep: AMY skips sysex in `convert_midi_bytes_to_messages` ("we do not pass sysex over to python"), so **sysex reaches Python only via Path B** — removing B instead would have silently broken sysex-to-Python.
- **Fix stacking:** `removeListener("midimessage")` before re-adding. Bonus: also fixes the double `move_knob` (CC-learn / live-knob) trigger that rode the same stacked listener.

Robust either way: even if Path A didn't fire, the no-op is harmless and the stacking fix still collapses N→1.

`tulip/web` is a **separate file** and intentionally left as-is — it relies on the AMY `EM_ASM` hook as its only path.

## Test

CI will spin up the PR preview site. To verify: open the editor on the preview, select a MIDI controller, load `midi_btns_patch_sel`, reveal the REPL, and confirm each press now prints **once**. (I could not drive Web MIDI headlessly here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)