### PR TITLE
editor: harmonize tabs → spaces across all four editors (#580)

### DIFF
--- a/tulip/amyboardweb/static/editor/index.html
+++ b/tulip/amyboardweb/static/editor/index.html
@@ -1153,13 +1153,39 @@
           lint: false
         }, 
         lineNumbers: true, 
-        indentUnit: 4, 
+        indentUnit: 4,
+        // #580: Tab inserts spaces (never a literal tab) so Python indentation
+        // is valid; Tab/Shift-Tab indent/dedent the current selection.
+        extraKeys: {
+          Tab: function(cm) {
+            if (cm.somethingSelected()) {
+              cm.indentSelection("add");
+            } else {
+              cm.replaceSelection(" ".repeat(cm.getOption("indentUnit") || 4), "end");
+            }
+          },
+          "Shift-Tab": function(cm) {
+            cm.indentSelection("subtract");
+          }
+        },
         matchBrackets: true,
         spellCheck: false,
         autocorrect: false,
         theme: "lucario",
         lint: false,
       }); 
+      // #580: never let a literal tab into the document. Content loaded via
+      // setValue (files, shared sketches) or pasted text can contain tabs;
+      // convert each to spaces so getValue() -- and thus every saved file --
+      // stays tab-free and valid Python (and editable in the Tulip CC editor).
+      editor.on("beforeChange", function(cm, change) {
+        if (change.update && change.text.some(function(line) { return line.indexOf("\t") !== -1; })) {
+          var spaces = " ".repeat(cm.getOption("indentUnit") || 4);
+          change.update(change.from, change.to, change.text.map(function(line) {
+            return line.split("\t").join(spaces);
+          }));
+        }
+      });
       editor.on("change", function() {
         window.environment_editor_dirty = true;
       });

--- a/tulip/shared/amyboard-py/pye.py
+++ b/tulip/shared/amyboard-py/pye.py
@@ -1225,8 +1225,8 @@ class Editor:
             pos = 0
             for c in s:
                 if c == "\t":
-                    sb.write(" " * (8 - pos % 8))
-                    pos += 8 - pos % 8
+                    sb.write(" " * (self.tab_size - pos % self.tab_size))
+                    pos += self.tab_size - pos % self.tab_size
                 else:
                     sb.write(c)
                     pos += 1

--- a/tulip/shared/amyboard-py/pye_core.py
+++ b/tulip/shared/amyboard-py/pye_core.py
@@ -1335,8 +1335,8 @@ class Editor:
             pos = 0
             for c in s:
                 if c == "\t":  ## tab is seen
-                    sb.write(" " * (8 - pos % 8))  ## replace by space
-                    pos += 8 - pos % 8
+                    sb.write(" " * (self.tab_size - pos % self.tab_size))  ## replace by space, tab_size wide
+                    pos += self.tab_size - pos % self.tab_size
                 else:
                     sb.write(c)
                     pos += 1

--- a/tulip/shared/editor.c
+++ b/tulip/shared/editor.c
@@ -329,6 +329,29 @@ void editor_open_file(const char *filename) {
         new_lines = 1;
         //if(text[bytes_read-1]!='\n') { new_lines = 0; dbg("adding n\n"); text[bytes_read] = '\n'; bytes_read++; }
 		text[bytes_read] = 0; // end
+
+		// #580: expand tab characters to spaces so files saved with tabs (e.g.
+		// from the web editors) are editable here. The editor stores indentation
+		// as spaces (Tab inserts EDITOR_TAB_SPACES spaces), so a literal tab
+		// would otherwise show as a single un-editable character.
+		uint32_t tab_count = 0;
+		for(uint32_t i=0;i<bytes_read;i++) if(text[i]=='\t') tab_count++;
+		if(tab_count) {
+			uint32_t expanded_len = bytes_read + tab_count*(EDITOR_TAB_SPACES-1);
+			char * expanded = (char*) editor_malloc(expanded_len+3);
+			uint32_t j = 0;
+			for(uint32_t i=0;i<bytes_read;i++) {
+				if(text[i]=='\t') {
+					for(uint8_t s=0;s<EDITOR_TAB_SPACES;s++) expanded[j++] = ' ';
+				} else {
+					expanded[j++] = text[i];
+				}
+			}
+			expanded[j] = 0;
+			editor_free(text);
+			text = expanded;
+			bytes_read = j;
+		}
 		for(uint32_t i=0;i<bytes_read;i++) if(text[i]=='\n') new_lines++;
 		//dbg("File %s has %d lines. %d bytes\n", filename, new_lines,bytes_read);
 		char ** incoming_text_lines = (char**)editor_malloc(sizeof(char*)*(new_lines));

--- a/tulip/web/static/index.html
+++ b/tulip/web/static/index.html
@@ -76,13 +76,39 @@
           lint: false
         }, 
         lineNumbers: true, 
-        indentUnit: 4, 
+        indentUnit: 4,
+        // #580: Tab inserts spaces (never a literal tab) so Python indentation
+        // is valid; Tab/Shift-Tab indent/dedent the selection. Matches the
+        // AMYboard web editor.
+        extraKeys: {
+          Tab: function(cm) {
+            if (cm.somethingSelected()) {
+              cm.indentSelection("add");
+            } else {
+              cm.replaceSelection(" ".repeat(cm.getOption("indentUnit") || 4), "end");
+            }
+          },
+          "Shift-Tab": function(cm) {
+            cm.indentSelection("subtract");
+          }
+        },
         matchBrackets: true,
         spellCheck: false,
         autocorrect: false,
         theme: "lucario",
         lint: false,
       }); 
+      // #580: keep this editor's buffer tab-free (same as the AMYboard web
+      // editor) -- convert any tab arriving via setValue (share links) or paste
+      // into spaces, so editor.save() / run / download produce valid Python.
+      editor.on("beforeChange", function(cm, change) {
+        if (change.update && change.text.some(function(line) { return line.indexOf("\t") !== -1; })) {
+          var spaces = " ".repeat(cm.getOption("indentUnit") || 4);
+          change.update(change.from, change.to, change.text.map(function(line) {
+            return line.split("\t").join(spaces);
+          }));
+        }
+      });
       editor.setSize(null,editor_height);
     
       // Load in the share code if given


### PR DESCRIPTION
Fixes #580.

Literal tab characters in `.py` files break editing and indentation. tulipcc has **four** editors; this PR harmonizes all of them on **4 spaces** so files move cleanly between them.

| # | Editor | Before | After |
|---|--------|--------|-------|
| 1 | Tulip native C — `tulip/shared/editor.c` (`edit()`) | Tab inserted 4 spaces, but a loaded file's tabs stayed literal `\t` — one un-editable char each | `editor_open_file()` expands tabs → 4 spaces on load |
| 2 | Tulip web CodeMirror — `tulip/web/static/index.html` | default Tab inserted a literal `\t` | Tab → spaces (`extraKeys`) + `beforeChange` strips tabs from `setValue`/paste |
| 3 | AMYboard native `pye` — `tulip/shared/amyboard-py/pye.py` (+ `pye_core.py`) | Tab inserted spaces (`tab_size=4`) and `write_tabs="n"` saved spaces, but `expandtabs` on read used a **hardcoded 8-col** tab stop | `expandtabs` now uses `self.tab_size` (4) on read, matching the Tab key |
| 4 | AMYboard web CodeMirror — `tulip/amyboardweb/static/editor/index.html` | default Tab inserted a literal `\t` (dpwe's `IndentationError`) | Tab → spaces (`extraKeys`) + `beforeChange` strips tabs from `setValue`/paste |

The two CodeMirror editors (#2, #4) get identical fixes:
- **`extraKeys`**: `Tab` inserts spaces / indents the selection; `Shift-Tab` dedents.
- **`beforeChange`**: converts any tab arriving via `setValue` (loaded files, share links) or pasted text into spaces, so `getValue()` / `editor.save()` are always tab-free — without touching the many individual save call sites.

#1 addresses the original report (loading tab-files in the CC editor); #4 addresses dpwe's report (typing Tab in the web editor). #2 had the same bug as #4; #3 already used spaces but expanded tab-files to 8 columns on read instead of 4.

### Testing
- macOS Tulip build (`tulip/macos/build.sh`) compiles `editor.c` cleanly and links.
- Both CodeMirror JS changes validated with `node --check`.
- `pye.py` / `pye_core.py` pass `python3 -m py_compile`; new `expandtabs` verified to produce 4-column tab stops (leading tab → 4 spaces, mid-line tabs fill to the next 4-col stop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
