### PR TITLE
Release Tulip continuously on merge to main (firmware + web)

### DIFF
--- a/.github/workflows/amyboard-pr-preview.yml
+++ b/.github/workflows/amyboard-pr-preview.yml
@@ -18,7 +18,10 @@ on:
       # (e.g. tulip/esp32s3/usb.c), so changes there must rebuild the preview.
       - 'tulip/esp32s3/**'
       - 'tulip/amyboardweb/**'
-      - 'tulip/shared/amyboard-py/**'
+      # All of shared/ (py + C) is frozen into AMYboard firmware, so any change must
+      # rebuild the preview. It also produces the tulip-firmware artifact that
+      # tulip-pr-preview reuses for tulip.upgrade(pr=N).
+      - 'tulip/shared/**'
       - '.github/workflows/amyboard-pr-preview.yml'
 
 permissions:

--- a/.github/workflows/tulip-pr-preview.yml
+++ b/.github/workflows/tulip-pr-preview.yml
@@ -1,9 +1,10 @@
 name: Tulip web PR preview
 
 # Per-PR preview of Tulip Web, deployed to a unique URL (tulip-pr-<N>.vercel.app)
-# on the 'tulip-pr' Vercel project. Mirrors amyboard-pr-preview.yml (web half only —
-# Tulip Web has no flasher, so no firmware is bundled). Torn down when the PR closes
-# by amyboard-pr-preview-cleanup.yml (extend that to tulip-pr if desired).
+# on the 'tulip-pr' Vercel project. It also bundles this PR's TULIP4_R11 firmware at
+# /firmware/ (reused from the AMYboard-PR-preview run's tulip-firmware artifact — not
+# rebuilt here) so a pro can `tulip.upgrade(pr=<N>)` to the PR build. Torn down when
+# the PR closes by amyboard-pr-preview-cleanup.yml (extend that to tulip-pr if desired).
 #
 # Requires repo secret VERCEL_TOKEN (scope: bwhitmans-projects).
 
@@ -13,12 +14,14 @@ on:
     paths:
       - 'amy'
       - 'tulip/web/**'
+      - 'tulip/esp32s3/**'
       - 'tulip/shared/**'
       - 'www/**'
       - '.github/workflows/tulip-pr-preview.yml'
 
 permissions:
   contents: read
+  actions: read            # download the tulip-firmware artifact from the AMYboard PR preview run
   pull-requests: write
 
 concurrency:
@@ -60,6 +63,49 @@ jobs:
           cd tulip/web
           ./build.sh
 
+      # Bundle this PR's TULIP4_R11 firmware at /firmware/ so a pro can
+      # tulip.upgrade(pr=<N>). It's already built by the AMYboard PR preview (for HW
+      # CI), so we reuse that run's tulip-firmware artifact instead of rebuilding.
+      # Best-effort: web-only PRs don't run the AMYboard preview → deploy without it.
+      # (build.sh wipes stage/, so this must run AFTER the build.)
+      - name: Find the AMYboard PR preview run (has the tulip-firmware artifact)
+        id: fw
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner, repo = context.repo.repo;
+            const sha = context.payload.pull_request.head.sha;
+            for (let i = 0; i < 50; i++) {  // wait up to ~25 min (it's heavier than this job)
+              const { data } = await github.rest.actions.listWorkflowRunsForRepo({ owner, repo, head_sha: sha, per_page: 50 });
+              const run = data.workflow_runs.find(r => r.name === 'AMYboard PR preview');
+              if (run && run.status === 'completed') {
+                core.info(`AMYboard PR preview run ${run.id}: ${run.conclusion}`);
+                core.setOutput('run_id', run.conclusion === 'success' ? String(run.id) : '');
+                return;
+              }
+              if (i === 0) core.info('waiting for the AMYboard PR preview (it builds the Tulip firmware)…');
+              await new Promise(r => setTimeout(r, 30000));
+            }
+            core.info('AMYboard PR preview not finished in time — deploying web only (no PR firmware).');
+            core.setOutput('run_id', '');
+
+      - name: Download this PR's tulip-firmware artifact
+        if: steps.fw.outputs.run_id != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: tulip-firmware
+          path: tulip/web/stage/firmware
+          run-id: ${{ steps.fw.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Flatten firmware into stage/firmware/
+        if: steps.fw.outputs.run_id != ''
+        run: |
+          cd tulip/web/stage/firmware
+          # ensure the .bin files sit at the root of /firmware/ (not nested)
+          find . -mindepth 2 -name '*.bin' -exec mv -f {} . \; 2>/dev/null || true
+          echo "bundled firmware:"; ls -la
+
       - name: Deploy preview + per-PR alias
         id: deploy
         env:
@@ -80,18 +126,23 @@ jobs:
         uses: actions/github-script@v7
         env:
           PREVIEW_URL: ${{ steps.deploy.outputs.url }}
+          HAS_FW: ${{ steps.fw.outputs.run_id != '' }}
         with:
           script: |
             const url = process.env.PREVIEW_URL;
+            const pr = context.issue.number;
             const marker = '<!-- tulip-pr-preview -->';
-            const body = [
+            const lines = [
               marker,
               '### 🌷 Tulip Web PR preview',
               '',
               `**Tulip Web:** ${url}/run/`,
-              '',
-              "This preview builds **this PR's** Tulip Web. Rebuilt on every push; removed when the PR closes.",
-            ].join('\n');
+            ];
+            if (process.env.HAS_FW === 'true') {
+              lines.push('', `**Flash a Tulip to this build:** on-device run \`tulip.upgrade(pr=${pr})\`.`);
+            }
+            lines.push('', "Rebuilt on every push; removed when the PR closes.");
+            const body = lines.join('\n');
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number,
             });

--- a/.github/workflows/tulip-pr-preview.yml
+++ b/.github/workflows/tulip-pr-preview.yml
@@ -1,0 +1,103 @@
+name: Tulip web PR preview
+
+# Per-PR preview of Tulip Web, deployed to a unique URL (tulip-pr-<N>.vercel.app)
+# on the 'tulip-pr' Vercel project. Mirrors amyboard-pr-preview.yml (web half only —
+# Tulip Web has no flasher, so no firmware is bundled). Torn down when the PR closes
+# by amyboard-pr-preview-cleanup.yml (extend that to tulip-pr if desired).
+#
+# Requires repo secret VERCEL_TOKEN (scope: bwhitmans-projects).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'amy'
+      - 'tulip/web/**'
+      - 'tulip/shared/**'
+      - 'www/**'
+      - '.github/workflows/tulip-pr-preview.yml'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: tulip-pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify Vercel token can access the team
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          if [ -z "$VERCEL_TOKEN" ]; then
+            echo "::error::VERCEL_TOKEN secret is not set (scope bwhitmans-projects)."; exit 1
+          fi
+          npm i -g vercel@latest >/dev/null 2>&1
+          if ! vercel project ls --scope bwhitmans-projects --token "$VERCEL_TOKEN" >/dev/null 2>&1; then
+            echo "::error::VERCEL_TOKEN cannot access the 'bwhitmans-projects' team."; exit 1
+          fi
+          echo "Vercel token OK for bwhitmans-projects."
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Install web build deps
+        run: pip install numpy
+      - uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: 4.0.22
+
+      - name: Build Tulip web stage/
+        run: |
+          cd tulip/web
+          ./build.sh
+
+      - name: Deploy preview + per-PR alias
+        id: deploy
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          npm i -g vercel@latest >/dev/null 2>&1
+          cd tulip/web
+          vercel link --yes --token "$VERCEL_TOKEN" --scope bwhitmans-projects --project tulip-pr --cwd stage
+          url=$(vercel deploy stage --token "$VERCEL_TOKEN" --scope bwhitmans-projects --yes)
+          alias="tulip-pr-${PR}.vercel.app"
+          vercel alias set "$url" "$alias" --token "$VERCEL_TOKEN" --scope bwhitmans-projects
+          echo "url=https://$alias" >> "$GITHUB_OUTPUT"
+
+      - name: Comment preview URL
+        if: success()
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.url }}
+        with:
+          script: |
+            const url = process.env.PREVIEW_URL;
+            const marker = '<!-- tulip-pr-preview -->';
+            const body = [
+              marker,
+              '### 🌷 Tulip Web PR preview',
+              '',
+              `**Tulip Web:** ${url}/run/`,
+              '',
+              "This preview builds **this PR's** Tulip Web. Rebuilt on every push; removed when the PR closes.",
+            ].join('\n');
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body });
+            }

--- a/.github/workflows/tulip-release.yml
+++ b/.github/workflows/tulip-release.yml
@@ -1,0 +1,83 @@
+name: Tulip firmware release
+
+# Continuous Tulip FIRMWARE release on push to main: build TULIP4_R11 and publish
+# to the rolling 'tulip' GitHub release, kept NON-latest (--latest=false) so it
+# never displaces releases/latest (the monthly combined release). On-device
+# tulip.upgrade() reads releases/tags/tulip (see get_latest_release() in
+# tulip/shared/py/tulip.py). Mirrors the firmware job of amyboard-release.yml.
+#
+# Only TULIP4_R11 is shipped; TDECK/N16R8/N32R8 are developer-only (build them by
+# hand with `idf.py -DMICROPY_BOARD=<board> build`).
+#
+# Paths are firmware-only (NOT tulip/web/**) so a web-only change doesn't bump the
+# firmware release date; the web app is deployed separately by tulip-web-release.yml.
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'amy'
+      - 'tulip/esp32s3/**'
+      - 'tulip/shared/**'
+      - 'tulip/fs/tulip/**'
+      - '.github/workflows/tulip-release.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: tulip-firmware-release      # serialize releases; never cancel a half-done one
+  cancel-in-progress: false
+
+jobs:
+  firmware:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write                # create + clobber the 'tulip' release
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # amy + micropython (and nested submodules) are needed to build.
+          submodules: recursive
+
+      - name: Build TULIP4_R11 firmware + assemble images
+        uses: espressif/esp-idf-ci-action@v1
+        with:
+          esp_idf_version: v5.4.1
+          target: esp32s3
+          path: tulip/esp32s3
+          command: >-
+            python -m pip install littlefs-python &&
+            idf.py -DMICROPY_BOARD=TULIP4_R11 build &&
+            cd .. &&
+            python fs_create.py tulip
+
+      - name: Upload firmware artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: tulip-firmware
+          if-no-files-found: error
+          path: |
+            tulip/esp32s3/dist/tulip-firmware-TULIP4_R11.bin
+            tulip/esp32s3/dist/tulip-full-TULIP4_R11.bin
+            tulip/esp32s3/dist/tulip-sys.bin
+
+      - name: Publish to the rolling 'tulip' release (kept non-latest)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Create the rolling release once, explicitly NOT 'latest' so it never
+          # displaces releases/latest (the monthly combined Tulip release).
+          if ! gh release view tulip >/dev/null 2>&1; then
+            gh release create tulip \
+              --latest=false \
+              --target "$GITHUB_SHA" \
+              --title "Tulip (rolling release)" \
+              --notes "Rolling Tulip release built from main (TULIP4_R11). OTA'd by tulip.upgrade(). Updated on every push to main; not a tagged version."
+          fi
+          gh release upload --clobber tulip \
+            tulip/esp32s3/dist/tulip-firmware-TULIP4_R11.bin \
+            tulip/esp32s3/dist/tulip-full-TULIP4_R11.bin \
+            tulip/esp32s3/dist/tulip-sys.bin
+          # Refresh the body with the exact released commit for provenance.
+          gh release edit tulip \
+            --notes "Rolling Tulip release (TULIP4_R11), built from main @ ${GITHUB_SHA}. OTA'd by tulip.upgrade(). Updated on every push to main; not a tagged version."

--- a/.github/workflows/tulip-web-release.yml
+++ b/.github/workflows/tulip-web-release.yml
@@ -1,0 +1,74 @@
+name: Tulip web release
+
+# Continuous Tulip WEB release on push to main: build tulip/web/stage/ and deploy
+# it --prod to the 'tulip' Vercel project (tulip.computer). Mirrors the web job of
+# amyboard-release.yml. Firmware is released separately by tulip-release.yml.
+#
+# Paths are web-only (+ amy/shared, which the WASM is built from) so a firmware-only
+# change doesn't redeploy the site. During the gh-pages -> Vercel cutover, static.yml
+# still also publishes www/ to GitHub Pages; once tulip.computer is served by Vercel,
+# remove static.yml + www/ (and this workflow's www/** path).
+#
+# Requires repo secret VERCEL_TOKEN (scope: bwhitmans-projects).
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'amy'
+      - 'tulip/web/**'
+      - 'tulip/shared/**'
+      - 'www/**'
+      - '.github/workflows/tulip-web-release.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: tulip-web-release          # serialize prod deploys; never cancel a half-done one
+  cancel-in-progress: false
+
+jobs:
+  web:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Verify Vercel token can access the team
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          if [ -z "$VERCEL_TOKEN" ]; then
+            echo "::error::VERCEL_TOKEN secret is not set (scope bwhitmans-projects)."; exit 1
+          fi
+          npm i -g vercel@latest >/dev/null 2>&1
+          if ! vercel project ls --scope bwhitmans-projects --token "$VERCEL_TOKEN" >/dev/null 2>&1; then
+            echo "::error::VERCEL_TOKEN cannot access the 'bwhitmans-projects' team."; exit 1
+          fi
+          echo "Vercel token OK for bwhitmans-projects."
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Install web build deps
+        run: pip install numpy
+      - uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: 4.0.22
+
+      - name: Build Tulip web stage/
+        run: |
+          cd tulip/web
+          ./build.sh
+
+      - name: Deploy to Vercel production (tulip.computer)
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          set -euo pipefail
+          npm i -g vercel@latest >/dev/null 2>&1
+          cd tulip/web
+          vercel link --yes --token "$VERCEL_TOKEN" --scope bwhitmans-projects --project tulip --cwd stage
+          vercel deploy stage --prod --yes --token "$VERCEL_TOKEN" --scope bwhitmans-projects

--- a/tulip/release.sh
+++ b/tulip/release.sh
@@ -31,8 +31,10 @@ rm ../.submodules_ok
 cd esp32s3
 source ~/esp/esp-idf-v5.4.1/export.sh 
 
-# Otherwise, compile all boards. If upload set, upload them
-declare -a boards=("TULIP4_R11" "TDECK" "N16R8" "N32R8")
+# Otherwise, compile all boards. If upload set, upload them.
+# TDECK / N16R8 / N32R8 are developer-only now (build them manually with
+# `idf.py -DMICROPY_BOARD=<board> build`); releases ship only TULIP4_R11.
+declare -a boards=("TULIP4_R11")
 for i in "${boards[@]}"
 do
     rm -rf build

--- a/tulip/shared/py/tulip.py
+++ b/tulip/shared/py/tulip.py
@@ -113,9 +113,20 @@ def desktop_copy_sys(dest):
         os.system(cmd)
 
 
-def get_latest_release():
+def get_latest_release(pr=None):
     import json
     from upysh import rm
+    # A specific PR's firmware comes from that PR's Vercel preview bundle, not a
+    # GitHub release: upgrade(pr=N) lets a pro OTA a PR build. The preview must
+    # exist (an open PR that built + bundled firmware); otherwise the download 404s.
+    if pr is not None:
+        if board() == "AMYBOARD":
+            base = 'https://amyboard-pr-%d.vercel.app/firmware' % pr
+            return ('%s/amyboard-firmware-AMYBOARD.bin' % base, 'pr-%d' % pr,
+                    '%s/amyboard-sys.bin' % base, 'pr-%d' % pr)
+        base = 'https://tulip-pr-%d.vercel.app/firmware' % pr
+        return ('%s/tulip-firmware-%s.bin' % (base, board()), 'pr-%d' % pr,
+                '%s/tulip-sys.bin' % base, 'pr-%d' % pr)
     # AMYboard and Tulip each release continuously from main to their own rolling
     # release tag ('amyboard' / 'tulip'), kept non-latest so they never displace
     # releases/latest (the monthly combined release). Only TULIP4_R11 firmware is
@@ -145,7 +156,9 @@ def get_latest_release():
         return (mine['browser_download_url'], mine['updated_at'], sys['browser_download_url'], sys['updated_at'])
     return (None, None, None, None)
 
-def upgrade():
+def upgrade(pr=None):
+    # pr=N OTAs to PR #N's firmware (from tulip-pr-<N>/amyboard-pr-<N>.vercel.app);
+    # otherwise the rolling release for this board. Pros can test a PR build directly.
     import time, sys, os
     import tuliprequests as urequests
     try:
@@ -173,11 +186,13 @@ def upgrade():
     # Checks for a new firmware from Github, asks if you want to upgrade to it
     sec_size = 4096
 
-    (latest_mine_url, latest_mine_date, latest_sys_url, latest_sys_date) = get_latest_release()
+    (latest_mine_url, latest_mine_date, latest_sys_url, latest_sys_date) = get_latest_release(pr)
     if(latest_mine_url is None):
         print("Could not find firmware and system folder for board %s" % (board()))
         return
 
+    if pr is not None:
+        print("Upgrading to PR #%d firmware (from its Vercel preview)." % (pr))
     print("For board: %s" % (board()))
     print("Latest firmware: %s" % (latest_mine_date))
     print("Latest /sys    : %s" % (latest_sys_date))

--- a/tulip/shared/py/tulip.py
+++ b/tulip/shared/py/tulip.py
@@ -116,14 +116,15 @@ def desktop_copy_sys(dest):
 def get_latest_release():
     import json
     from upysh import rm
-    # AMYboard releases continuously from main to its own rolling 'amyboard'
-    # release; Tulip boards track the monthly combined 'latest' release. (The
-    # 'amyboard' release is kept non-latest so it never displaces releases/latest,
-    # which Tulip OTA depends on.)
+    # AMYboard and Tulip each release continuously from main to their own rolling
+    # release tag ('amyboard' / 'tulip'), kept non-latest so they never displace
+    # releases/latest (the monthly combined release). Only TULIP4_R11 firmware is
+    # published to the 'tulip' release; the developer-only boards (TDECK/N16R8/
+    # N32R8) aren't there, so their upgrade() finds nothing and returns None.
     if board() == "AMYBOARD":
         release_api = 'https://api.github.com/repos/shorepine/tulipcc/releases/tags/amyboard'
     else:
-        release_api = 'https://api.github.com/repos/shorepine/tulipcc/releases/latest'
+        release_api = 'https://api.github.com/repos/shorepine/tulipcc/releases/tags/tulip'
     url_save(release_api,'releases_temp.json')
     j = json.load(open('releases_temp.json','r'))
     rm('releases_temp.json')

--- a/tulip/web/build.sh
+++ b/tulip/web/build.sh
@@ -9,7 +9,11 @@ else
   SED_INPLACE=(-i '')
 fi
 
-source ../shared/grab_submodules.sh
+# In CI the checkout already provides submodules (and Linux needs no mpy-cross
+# patch); only bootstrap them for local builds.
+if [ -z "${CI:-}" ]; then
+  source ../shared/grab_submodules.sh
+fi
 
 timestamp=$(date +%Y%m%d%H%M%S)
 
@@ -25,9 +29,13 @@ mkdir stage
 mkdir stage/run
 
 cp static/* stage/run
-cp -Rf ../../www/img stage
-cp -Rf ../../www/webfonts stage
-cp -Rf ../../www/css stage
+
+# Full tulip.computer landing (the site root): index.html + assets. Sourced from
+# www/ for now — www/ moves into tulip/web after the Vercel/DNS cutover. The web
+# app lives under stage/run (below); www/run build output is NOT copied (it's
+# regenerated here).
+cp ../../www/index.html stage/
+cp -Rf ../../www/css ../../www/fonts ../../www/img ../../www/js ../../www/webfonts stage/
 
 cp ../../amy/build/amy.js stage/run/amy-$timestamp.js
 cp ../../amy/build/amy.wasm stage/run/amy-$timestamp.wasm

--- a/tulip/web/deploy.sh
+++ b/tulip/web/deploy.sh
@@ -1,11 +1,30 @@
 #!/bin/bash
-# deploys web build to github pages
+# Deploys the built stage/ to the 'tulip' Vercel project (tulip.computer).
+# Run ./build.sh first to (re)generate stage/. Mirrors amyboardweb/deploy.sh.
 
-set -e
+set -euo pipefail
 
-git rm -f ../../www/run/*
-mkdir ../../www/run
-cp stage/run/* ../../www/run/
-git add ../../www/run/*
-git commit -a -m "deploying Tulip Web"
-git push -u origin HEAD
+VERCEL_SCOPE="bwhitmans-projects"
+VERCEL_PROJECT="tulip"
+STAGE_DIR="stage"
+
+current_project=""
+project_json="$STAGE_DIR/.vercel/project.json"
+if [ -f "$project_json" ]; then
+  current_project=$(python3 - <<PY
+import json
+try:
+    with open("$project_json", "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    print(data.get("projectName", ""))
+except Exception:
+    print("")
+PY
+  )
+fi
+
+if [ "$current_project" != "$VERCEL_PROJECT" ]; then
+  vercel link --yes --scope "$VERCEL_SCOPE" --project "$VERCEL_PROJECT" --cwd "$STAGE_DIR"
+fi
+
+vercel deploy "$STAGE_DIR" --prod --yes --scope "$VERCEL_SCOPE"

--- a/tulip/web/vercel.json
+++ b/tulip/web/vercel.json
@@ -1,0 +1,16 @@
+{
+  "headers": [
+    {
+      "source": "/run/(amy|tulipcc)-(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
+      "source": "/((?!run/(amy|tulipcc)-).*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Releases Tulip continuously on merge to `main` (firmware + web), mirroring AMYboard.

### Firmware
- Builds **only TULIP4_R11** now — TDECK/N16R8/N32R8 become developer-only (build by hand with `idf.py -DMICROPY_BOARD=<board>`). Changed `release.sh`; added `tulip-release.yml`.
- On push to `main`, TULIP4_R11 → a rolling **`tulip`** GitHub release (`--latest=false`, like the `amyboard` tag).
- `tulip.py` `get_latest_release()` now points Tulip OTA at `releases/tags/tulip` (was `releases/latest`). Monthly `release.sh`/`releases/latest` is unchanged; existing Tulips OTA from `latest` until reflashed, then track `tulip`.

### Web (gh-pages → Vercel, like amyboardweb)
- `build.sh` now assembles the **full** site into `stage/` (landing + `/run` app); `deploy.sh` deploys `stage/` to the **`tulip`** Vercel project; added `vercel.json`. `build.sh` skips `grab_submodules` under CI (the checkout provides submodules).
- **`tulip-pr-preview.yml`**: PR → `tulip-pr-<N>.vercel.app` (this PR's preview is building now).
- **`tulip-web-release.yml`**: push to `main` → Vercel **prod** = `tulip.computer`.

### Cutover (no downtime)
The landing is still sourced from `www/` (65 MB, mostly images), and **`www/` + `static.yml` (gh-pages) stay live** until `tulip.computer` is cut over to Vercel. After merge + the prod deploy, attach the domain + flip DNS; once verified, a follow-up `git mv www/ → tulip/web` removes gh-pages (no duplicate blobs, no downtime).

## Needs (Vercel / domains)
- [ ] `tulip` + `tulip-pr` Vercel projects (created by the deploy via the existing `VERCEL_TOKEN`, scope `bwhitmans-projects`) — confirm the preview deploy below succeeds.
- [ ] **Attach `tulip.computer`** to the `tulip` Vercel project + update DNS (Vercel gives the record). Then I remove gh-pages + `www/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
