### PR TITLE
Don't forward Tulip screenshots to the Discord files channel

### DIFF
--- a/tulip/server/amyboardworld_db_api.py
+++ b/tulip/server/amyboardworld_db_api.py
@@ -764,7 +764,10 @@ async def upload_tulip_file(
         created_at_ms=created_at_ms,
         client_ip=_client_ip(request),
     )
-    _discord_notify(DISCORD_TULIP_FILES_CHANNEL_ID, f"{user} ### {desc[:MAX_DESCRIPTION]} ## {filename} ({len(contents)} bytes)")
+    # Don't forward Tulip screenshots to the Discord files channel — too noisy.
+    # The file is still stored and served by the API; we just skip the notification.
+    if not (filename == "screenshot.png" and desc == "Tulip Screenshot"):
+        _discord_notify(DISCORD_TULIP_FILES_CHANNEL_ID, f"{user} ### {desc[:MAX_DESCRIPTION]} ## {filename} ({len(contents)} bytes)")
     return {"ok": True, "id": item_id}
 
 


### PR DESCRIPTION
## What

Skip the Discord notification to the **tulip-world-files** channel for Tulip screenshots — uploads with filename `screenshot.png` **and** description `Tulip Screenshot`. They're noisy in the channel.

## Details

In the `/api/tulipworld/upload` handler (`tulip/server/amyboardworld_db_api.py`), the upload is still stored in the DB/blob store and served by the API exactly as before — only the `_discord_notify` call is gated:

```python
# Don't forward Tulip screenshots to the Discord files channel — too noisy.
# The file is still stored and served by the API; we just skip the notification.
if not (filename == "screenshot.png" and desc == "Tulip Screenshot"):
    _discord_notify(DISCORD_TULIP_FILES_CHANNEL_ID, ...)
```

The match is exact and safe: `_normalize_description` only collapses whitespace, so `"Tulip Screenshot"` is preserved. All other uploads still forward to Discord as before.

## Deploy note

This is server code on Railway, which auto-deploys on push to `main` — so the change takes effect once this PR is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)