### PR TITLE
docs: point Tulip firmware pointers at the rolling `tulip` release; dev-only boards build-it-yourself

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -19,7 +19,7 @@ For help, the community of people that can help out with Tulip are
 
 ## Always upgrade Tulip first
 
-First, always [upgrade your Tulip to the latest firmware](tulip_flashing.md). If your Tulip is running, and the keyboard and Wi-Fi are working, try to first upgrade to a release by running `tulip.wifi(ssid, password)` and then `tulip.upgrade()`. Take a note of the date of the Tulip OS that shows on the screen after you reboot it. The date should match the [latest release of Tulip](https://github.com/shorepine/tulipcc/releases).  If it's older, try again, or try to flash manually. 
+First, always [upgrade your Tulip to the latest firmware](tulip_flashing.md). If your Tulip is running, and the keyboard and Wi-Fi are working, try to first upgrade to a release by running `tulip.wifi(ssid, password)` and then `tulip.upgrade()`. Take a note of the date of the Tulip OS that shows on the screen after you reboot it. The date should match our [rolling `tulip` release](https://github.com/shorepine/tulipcc/releases/tag/tulip), which we update on every change.  If it's older, try again, or try to flash manually. 
 
 <img src="https://raw.githubusercontent.com/shorepine/tulipcc/main/docs/pics/tulipv4r11_front.png" width=600>
 

--- a/docs/tulip_flashing.md
+++ b/docs/tulip_flashing.md
@@ -18,11 +18,11 @@ It will ask you if you want to upgrade your firmware and/or your `/sys` folder (
 
 ## Flash Tulip from a compiled release
 
-If you've got an unflashed Tulip, just finished a DIY, or somehow messed up the flash / firmware, you can flash the entire Tulip and filesystem with one file from our releases. We aim to release versions of Tulip regularly. You can find the latest in our [releases section](https://github.com/shorepine/tulipcc/releases/latest). 
+If you've got an unflashed Tulip, just finished a DIY, or somehow messed up the flash / firmware, you can flash the entire Tulip and filesystem with one file from our releases. We release new versions of Tulip continuously, on every change. You can always find the latest in our [rolling `tulip` release](https://github.com/shorepine/tulipcc/releases/tag/tulip). 
 
-**If you have the [Tulip from Makerfabs](https://tulip.computer/)**, you can directly download the latest full firmware binary here: [TULIP4_R11](https://github.com/shorepine/tulipcc/releases/latest/download/tulip-full-TULIP4_R11.bin).
+**If you have the [Tulip from Makerfabs](https://tulip.computer/)**, you can directly download the latest full firmware binary here: [TULIP4_R11](https://github.com/shorepine/tulipcc/releases/download/tulip/tulip-full-TULIP4_R11.bin).
 
-**If you made your own Tulip**: it's [`N16R8`](https://github.com/shorepine/tulipcc/releases/latest/download/tulip-full-N16R8.bin) if you've got a 16MB flash, or [`N32R8`](https://github.com/shorepine/tulipcc/releases/latest/download/tulip-full-N32R8.bin) if a 32MB flash. If you have a [T-Deck](../tulip/tdeck/README.md) it's [`TDECK`](https://github.com/shorepine/tulipcc/releases/latest/download/tulip-full-TDECK.bin).
+**If you made your own Tulip** (a DIY `N16R8`/`N32R8` board, or a [T-Deck](../tulip/tdeck/README.md)): these are developer-only boards now, so we no longer ship prebuilt binaries for them. [Build and flash the firmware yourself](#compile-and-flash-tulipcc-for-esp32-s3) for your board — it's quick and documented below.
 
 Connect your Tulip to your computer with a USB cable. **Note**: Many Tulip-capable boards have two USB ports, one called UART, TTL or Serial, and one called NATIVE, JTAG, or Host. You should use the UART one if available and try the NATIVE one if not. For example, on the Tulip CC, you can use either USB port, but if you use the NATIVE port you have to hold down the BOOT button while attaching the USB cable. We recommend flashing using the top UART USB connector. On the T-Deck, you only have access to the NATIVE port, and you may need to hold down the BOOT button (the trackball button) while you turn it on. If you've tried both ports and the following commands can't find a serial port to flash to, ensure that you've [installed a driver.](https://github.com/WCHSoftGroup/ch34xser_macos)
 


### PR DESCRIPTION
## Summary
Post-release-migration docs cleanup. Now that Tulip firmware ships **continuously** to the rolling [`tulip`](https://github.com/shorepine/tulipcc/releases/tag/tulip) GitHub release (not the monthly `releases/latest`), the user-facing flashing/troubleshooting docs are updated to match, and the dropped boards are repointed at the build instructions.

### `docs/tulip_flashing.md`
- The general "find the latest in our **releases section**" link → the rolling **`tulip`** release.
- The **TULIP4_R11** full-binary direct download → `releases/download/tulip/tulip-full-TULIP4_R11.bin` (verified live: HTTP 200).
- **N16R8 / N32R8 / TDECK** are developer-only boards now — we no longer ship prebuilt binaries for them. Their download links are replaced with a pointer to the in-page **"Compile and flash TulipCC for ESP32-S3"** section, which already documents exactly those `MICROPY_BOARD` values and how to build + flash them.

### `docs/troubleshooting.md`
- The post-`tulip.upgrade()` "the date should match the **latest release**" check → the rolling **`tulip`** release.

## Out of scope (intentionally left)
- `docs/tulip_desktop.md` — the macOS **Tulip Desktop** app still ships on the monthly release cadence, not the rolling firmware release.
- `docs/amyboard/firmware.md` — already points at the rolling **`amyboard`** release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)