### PR TITLE
docs(amyboard): clarify "no spaces" sketch name + "free the serial port before flashing" notes

### DIFF
--- a/docs/amyboard/firmware.md
+++ b/docs/amyboard/firmware.md
@@ -8,6 +8,8 @@ There are three ways to upgrade the firmware on your AMYboard. The easiest is us
 
 The [AMYboard Online editor](https://amyboard.com/editor) includes a built-in firmware upgrader that works right from your browser using WebSerial. We recommend using Google Chrome for this. 
 
+**Before you start, close anything else that's using the serial port.** Only one program can talk to the board at a time. Quit the **Arduino IDE** (including its Serial Monitor), any `mpremote` or `screen` session, the Python REPL, and any DAW or serial terminal first. Otherwise the browser won't be able to connect when you click **Search for AMYboard**.
+
 1. Connect your AMYboard to your computer over USB.
 2. Hold down both buttons on the side of the AMYboard, then release RST first, then release BOOT. This puts the board into bootloader mode.
 3. Open the firmware upgrade page and click **Search for AMYboard**.
@@ -58,6 +60,8 @@ If your AMYboard won't boot or you need a completely fresh flash, you can use `e
 1. Download the latest `amyboard-full-AMYBOARD.bin` from the [`amyboard` release](https://github.com/shorepine/tulipcc/releases/tag/amyboard) (the rolling AMYboard release, updated on every push to main).
 
 2. Connect your AMYboard over USB and put it in bootloader mode (hold both buttons, release RST first, then BOOT).
+
+   Make sure nothing else is using the serial port first — close the Arduino IDE, any `mpremote` or `screen` session, and any serial monitor, or `esptool` won't be able to open the port.
 
 3. Install `esptool` if you haven't already, and flash the image:
 

--- a/docs/amyboard/troubleshooting.md
+++ b/docs/amyboard/troubleshooting.md
@@ -48,6 +48,16 @@ Many issues are fixed in newer firmware. Before troubleshooting, [update to the 
  - On Windows, check Device Manager for COM ports.
  - Make sure no other program (serial monitor, DAW) is using the port.
 
+## Can't flash / the firmware upgrader won't connect
+
+Only **one** program can use the serial port at a time, so before flashing make sure nothing else has it open. A port held by another program is the most common reason **Search for AMYboard** never connects.
+
+ - **Close the Arduino IDE** (or at least its **Serial Monitor**) -- it holds the port open and blocks flashing.
+ - **Quit any `mpremote` session** connected to the board, and close the Python REPL or any serial terminal.
+ - **Quit any `screen` session** on the port -- `Ctrl-A` then `K` to kill it.
+ - Any **DAW** that grabbed the port will block flashing too -- close it.
+ - When in doubt, unplug and replug the AMYboard, then click **Search for AMYboard** again.
+
 ## USB MIDI not recognized
 
 A healthy AMYboard enumerates as **two** USB things at once: a USB **MIDI** device *and* a USB **serial** (CDC) port, with USB VID `0xCAF0` and PID `0x4009`. If you only ever see a *"USB JTAG/serial debug unit"* (VID `0x303A`), the firmware's USB stack never came up -- see [Is it a boot loop?](#is-it-a-boot-loop) below. That is the most common cause of "no USB MIDI" right now, and we're actively working on it ([#952](https://github.com/shorepine/tulipcc/issues/952), [#980](https://github.com/shorepine/tulipcc/issues/980)).

--- a/tulip/amyboardweb/static/editor/index.html
+++ b/tulip/amyboardweb/static/editor/index.html
@@ -1649,8 +1649,8 @@
                         <div class="form-text">1-20 chars: A-Z, a-z, 0-9.</div>
                       </div>
                       <div class="col-12 col-md-4">
-                        <label for="editor_filename" class="form-label mb-1">Sketch name</label>
-                        <input type="text" id="editor_filename" class="small form-control" maxlength="20" placeholder="Sketch Name" />
+                        <label for="editor_filename" class="form-label mb-1">Sketch name (no spaces!)</label>
+                        <input type="text" id="editor_filename" class="small form-control" maxlength="20" placeholder="my_sketch" />
                         <div class="form-text">1-20 chars: A-Z, a-z, 0-9, -, _.</div>
                       </div>
                       <div class="col-12 col-md-4">


### PR DESCRIPTION
Two small AMYboard doc fixes (requested).

## 1. AMYboard World tab — make "no spaces" explicit
`tulip/amyboardweb/static/editor/index.html` (the `static/` source, not the built `stage/`):
- Field header: `Sketch name` → **`Sketch name (no spaces!)`**
- Input placeholder: `Sketch Name` (contained a space) → `my_sketch`, so the hint doesn't contradict the new label.

## 2. "Close other serial-port users before flashing"
Only one program can own the serial port, so the Arduino IDE / a `mpremote` or `screen` session / a serial monitor will block the flasher from connecting.

- **`docs/amyboard/firmware.md`** — pre-flash note added where it applies:
  - **Option 1** (web upgrader, "easiest"): bold callout before the steps.
  - **Option 3** (esptool): one-line reminder under the bootloader step.
  - **Option 2** (OTA via serial) intentionally left alone — that flow *requires* an active serial session.
- **`docs/amyboard/troubleshooting.md`** — new **"Can't flash / the firmware upgrader won't connect"** section, for the after-it-failed case.

Docs only — no code/build changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)