### PR TITLE
fix(esp32s3): stop tulip.wifi() crashing with "No free interrupt inputs for AES interrupt"

### DIFF
--- a/.github/workflows/tulip-pr-preview.yml
+++ b/.github/workflows/tulip-pr-preview.yml
@@ -99,12 +99,15 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Flatten firmware into stage/firmware/
+        id: flat
         if: steps.fw.outputs.run_id != ''
         run: |
           cd tulip/web/stage/firmware
           # ensure the .bin files sit at the root of /firmware/ (not nested)
           find . -mindepth 2 -name '*.bin' -exec mv -f {} . \; 2>/dev/null || true
           echo "bundled firmware:"; ls -la
+          # expose the bundled .bin filenames so the PR comment can link each one
+          echo "bins=$(ls *.bin 2>/dev/null | paste -sd, -)" >> "$GITHUB_OUTPUT"
 
       - name: Deploy preview + per-PR alias
         id: deploy
@@ -127,6 +130,7 @@ jobs:
         env:
           PREVIEW_URL: ${{ steps.deploy.outputs.url }}
           HAS_FW: ${{ steps.fw.outputs.run_id != '' }}
+          FW_BINS: ${{ steps.flat.outputs.bins }}
         with:
           script: |
             const url = process.env.PREVIEW_URL;
@@ -139,7 +143,17 @@ jobs:
               `**Tulip Web:** ${url}/run/`,
             ];
             if (process.env.HAS_FW === 'true') {
-              lines.push('', `**Flash a Tulip to this build:** on-device run \`tulip.upgrade(pr=${pr})\`.`);
+              // Direct links to each firmware file bundled at /firmware/, ordered
+              // full -> app -> sys so the full image (USB-flash at 0x0, no Wi-Fi
+              // needed) is first. The per-file note says which to use.
+              const rank = (b) => b.includes('full') ? 0 : b.includes('sys') ? 2 : 1;
+              const note = (b) => b.includes('full') ? 'full image, USB-flash at `0x0` with esptool (no Wi‑Fi needed)'
+                                : b.includes('sys')  ? 'filesystem/system partition'
+                                : 'app image (OTA partition)';
+              const bins = (process.env.FW_BINS || '').split(',').filter(Boolean).sort((a, b) => rank(a) - rank(b));
+              lines.push('', '**Firmware (this PR build):**');
+              for (const b of bins) lines.push(`- [\`${b}\`](${url}/firmware/${b}) — ${note(b)}`);
+              lines.push('', `On-device OTA: \`tulip.upgrade(pr=${pr})\` (needs Wi‑Fi).`);
             }
             lines.push('', "Rebuilt on every push; removed when the PR closes.");
             const body = lines.join('\n');

--- a/tulip/esp32s3/boards/sdkconfig.tulip
+++ b/tulip/esp32s3/boards/sdkconfig.tulip
@@ -18,6 +18,16 @@ CONFIG_SPIRAM_IGNORE_NOTFOUND=y
 CONFIG_SPIRAM_USE_CAPS_ALLOC=y
 CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC=y
 
+# Make the hardware AES accelerator busy-wait instead of allocating its own
+# interrupt. The RGB LCD (GDMA bounce buffers), I2S audio, USB host (LEVEL1) and
+# the Wi-Fi/BT MAC already consume the few free low-priority interrupt slots on
+# the S3, so when Wi-Fi's WPA2 handshake triggers the first hardware-AES op,
+# esp_aes_intr_alloc() fails with "No free interrupt inputs for AES interrupt"
+# and calls abort() (IDF default CONFIG_MBEDTLS_AES_USE_INTERRUPT=y). Polling
+# removes that interrupt dependency; the only cost is the CPU busy-waiting during
+# long AES operations (TLS), which is acceptable here.
+CONFIG_MBEDTLS_AES_USE_INTERRUPT=n
+
 CONFIG_FREERTOS_USE_TRACE_FACILITY=n
 CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS=y
 CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP=y


### PR DESCRIPTION
## Problem

A TULIP4_R11 user reports `tulip.wifi("ssid", "pass")` crashes **every time** with:

```
No free interrupt inputs for AES interrupt
```

This is a tulipcc/IDF-config bug — deterministic, reproducible for anyone on this firmware — not a user issue.

## Root cause

Wi-Fi's WPA2 handshake triggers a hardware-AES operation. On the ESP32-S3, IDF's default `CONFIG_MBEDTLS_AES_USE_INTERRUPT=y` makes the AES driver allocate a **dedicated interrupt** for it (`esp_aes_intr_alloc()` → `esp_intr_alloc(ETS_AES_INTR_SOURCE, …)`).

But by the time Wi-Fi starts, tulipcc has already consumed the few free low-priority interrupt slots:

- **RGB LCD** — GDMA bounce buffers, refreshing continuously (`esp32s3_display.c`)
- **I2S audio** (AMY) — continuous DMA
- **USB host** — `ESP_INTR_FLAG_LEVEL1` (`usb_host.c:526`)
- the **Wi-Fi/BT MAC**, which grabs several when `active(True)` runs

So `esp_intr_alloc` returns `ESP_ERR_NOT_FOUND`, IDF logs `"No free interrupt inputs for AES interrupt"`, and `esp_aes_intr_alloc()` then calls **`abort()`** — fatal by design. Nothing in tulipcc overrode the default, and this likely surfaced with the ESP-IDF 5.4.1 bump (older IDF busy-waited instead of using an interrupt).

## Fix

One line in the shared `tulip/esp32s3/boards/sdkconfig.tulip` (included by every ESP32-S3 board **and** AMYboard):

```
CONFIG_MBEDTLS_AES_USE_INTERRUPT=n
```

The hardware AES accelerator now **busy-waits/polls** for completion instead of needing its own interrupt — removing the allocation that was aborting. The only cost is the CPU busy-waiting during long AES ops (TLS); DMA still does the work and audio runs on its own core. This is Espressif's recommended remedy for interrupt exhaustion.

## Testing

This PR exercises the exact crash path on real hardware. The **AMYboard PR preview** workflow rebuilds the TULIP4_R11 firmware *with this fix* (it triggers on `tulip/esp32s3/**`), and **HW CI** then flashes that build onto the physical Tulip and runs `tulip_hwci.py --require-wifi`, which calls `tulip.wifi(...)` on-device (`tulip_hwci.py:285`). Before this fix that step crashes; with it, Wi-Fi should connect and the screenshot upload should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)