### PR TITLE
docs(amyboard): fix CV-out example to actually create the synth

### DIFF
--- a/docs/amyboard/modular.md
+++ b/docs/amyboard/modular.md
@@ -43,12 +43,14 @@ You can route an entire AMY synth's audio to a CV output using `set_cv_out`. The
 ```python
 import amy, amyboard
 
-# Create a synth and route it to CV1
-amy.send(synth=5, wave=amy.SAW_DOWN, vel=1, freq=0.5)
+# Create a synth (num_voices + oscs_per_voice define it) and route it to CV1
+amy.send(synth=5, num_voices=1, oscs_per_voice=1, wave=amy.SAW_DOWN, vel=1, freq=0.5)
 amyboard.set_cv_out(channel=0, synth=5)
 ```
 
 This sends a 0.5Hz saw wave out CV1 at full range (-10V to +10V). You can change the waveform, frequency, or amplitude at any time with `amy.send(synth=5, ...)`.
+
+> **The first `amy.send` must actually create the synth.** A synth only exists once it has voices, so the creating command needs `num_voices` **and** `oscs_per_voice` (or a `patch`, which supplies `oscs_per_voice` for you). Without them the synth is never allocated — `set_cv_out` then has no oscillators to read and the CV output never changes.
 
 To stop it, release the note or clear the mapping:
 


### PR DESCRIPTION
## Problem

A user reported that this snippet from [`docs/amyboard/modular.md`](https://github.com/shorepine/tulipcc/blob/main/docs/amyboard/modular.md) didn't change the CV output:

```python
amy.send(synth=5, wave=amy.SAW_DOWN, vel=1, freq=0.5)
amyboard.set_cv_out(channel=0, synth=5)
```

The comment said "Create a synth", but that `amy.send` **does not create synth 5**. With none of `num_voices` / `oscs_per_voice` / `patch` set, AMY's dispatcher (`amy.c`, `AMY_IS_SET(e->num_voices) || ...` guard) skips `patches_load_patch`, so no instrument or voices are ever allocated. Two things then fail:

1. **CV never updates.** `set_cv_out`'s render hook `synth_for_osc()` (`tulip/shared/amy_connector.c`) calls `instrument_get_num_voices(5)`, which returns 0 — no oscillator is owned by synth 5 — so the hook returns 0 and never writes the DAC.
2. **The note-on is dropped** with `note-on with no note for synth 5 - ignored` (`patches.c`), since there's no note/preset and the synth has no single voice.

This was verified against the AMY commit currently pinned in this repo (`ff59eb27`).

## Fix

Add `num_voices=1, oscs_per_voice=1` to the creating `amy.send`, and add a note explaining that a synth needs `num_voices` **and** `oscs_per_voice` (or a `patch`) to exist before `set_cv_out` has anything to read.

Docs-only change.