### PR TITLE
amyboard HW CI: run the bench on AMY PRs (no duplication)

### DIFF
--- a/.github/workflows/amyboard-hwci.yml
+++ b/.github/workflows/amyboard-hwci.yml
@@ -43,13 +43,18 @@ concurrency:
 
 jobs:
   hwci:
-    # workflow_dispatch (manual), or a same-repo PR whose preview succeeded.
-    # Fork PRs never run on the self-hosted Pi.
+    # workflow_dispatch (manual), or a preview that succeeded in THIS repo's
+    # context. head_repository == this repo means the preview ran AS tulipcc (not
+    # a fork) — true for a Tulip PR (pull_request) and for an AMY PR (repository_
+    # dispatch / workflow_dispatch, already same-repo-gated on the amy side). Fork
+    # code never runs on the self-hosted Pi.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.event == 'pull_request' &&
-       github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.head_repository.full_name == github.repository)
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_repository.full_name == github.repository &&
+       (github.event.workflow_run.event == 'pull_request' ||
+        github.event.workflow_run.event == 'repository_dispatch' ||
+        github.event.workflow_run.event == 'workflow_dispatch'))
     runs-on: [self-hosted, amyboard-hwci]
     timeout-minutes: 30
     steps:
@@ -59,7 +64,7 @@ jobs:
         with:
           script: |
             const owner = context.repo.owner, repo = context.repo.repo;
-            let pr, sha, previewRunId;
+            let pr, sha, previewRunId, isAmy = false;
             if (context.eventName === 'workflow_dispatch') {
               pr = Number(context.payload.inputs.pr);
               const { data } = await github.rest.pulls.get({ owner, repo, pull_number: pr });
@@ -76,18 +81,48 @@ jobs:
                 return;
               }
               previewRunId = preview.id;
-            } else { // workflow_run
+            } else { // workflow_run (a preview build completed)
               const run = context.payload.workflow_run;
-              const assoc = run.pull_requests && run.pull_requests[0];
-              if (!assoc) { core.setFailed('workflow_run has no associated same-repo PR; skipping.'); return; }
-              pr = assoc.number;
               sha = run.head_sha;
               previewRunId = run.id;
+              if (run.event === 'pull_request') {           // Tulip PR
+                const assoc = run.pull_requests && run.pull_requests[0];
+                if (!assoc) { core.setFailed('workflow_run has no associated same-repo PR; skipping.'); return; }
+                pr = assoc.number;
+              } else {                                       // AMY PR (dispatch/manual)
+                isAmy = true;   // PR number + repo + firmware URL come from the amy-ctx artifact
+              }
             }
-            core.setOutput('pr', String(pr));
+            core.setOutput('is_amy', String(isAmy));
+            core.setOutput('pr', pr ? String(pr) : '');
             core.setOutput('sha', sha);
             core.setOutput('preview_run_id', String(previewRunId));
-            core.info(`HW CI for PR #${pr} @ ${sha} (preview run ${previewRunId})`);
+            core.info(`HW CI: amy=${isAmy} pr=${pr || '-'} @ ${sha} (preview run ${previewRunId})`);
+
+      # AMY runs only: pull the identity the preview stashed — which AMY PR built
+      # this firmware, where to fetch it, and where to comment. Required (we can't
+      # flash without the firmware URL), so no continue-on-error.
+      - name: Download AMY context (AMY runs only)
+        if: steps.ctx.outputs.is_amy == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: amy-ctx
+          path: amy-ctx
+          run-id: ${{ steps.ctx.outputs.preview_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Set PR / TARGET_REPO / FW_ARG once, so every step below is event-agnostic.
+      # AMY: firmware from the amyboard-amypr-<N> Vercel preview (hwci.py --url);
+      # Tulip: firmware from amyboard-pr-<N> (hwci.py --pr). The python parse
+      # validates repo/alias before they reach $GITHUB_ENV.
+      - name: Resolve run params (PR number, comment repo, firmware source)
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.ctx.outputs.is_amy }}" = "true" ]; then
+            python3 -c 'import json,re; d=json.load(open("amy-ctx/ctx.json")); pr=int(d["amy_pr"]); repo=d["amy_repo"]; alias=d["alias"]; assert re.fullmatch(r"[\w.-]+/[\w.-]+",repo) and re.fullmatch(r"[\w-]+",alias); print(f"PR={pr}\nTARGET_REPO={repo}\nFW_ARG=--url https://{alias}.vercel.app/firmware/amyboard-full-AMYBOARD.bin")' >> "$GITHUB_ENV"
+          else
+            { echo "PR=${{ steps.ctx.outputs.pr }}"; echo "TARGET_REPO=${{ github.repository }}"; echo "FW_ARG=--pr ${{ steps.ctx.outputs.pr }}"; } >> "$GITHUB_ENV"
+          fi
 
       - name: Fetch hwci/ at the PR head (public tarball; runner has no git)
         run: |
@@ -120,7 +155,9 @@ jobs:
         working-directory: hwci
         run: |
           set -o pipefail
-          ~/hwci-venv/bin/python hwci.py --pr "${{ steps.ctx.outputs.pr }}" \
+          # $FW_ARG is `--pr <N>` (Tulip) or `--url <amyboard-amypr-N…/…AMYBOARD.bin>`
+          # (AMY) — set by "Resolve run params". Unquoted so it splits into 2 args.
+          ~/hwci-venv/bin/python hwci.py $FW_ARG \
             --port /dev/amyboard-dongle \
             --cdc-port /dev/amyboard-cdc \
             --audio-device hw:CARD=Device,DEV=0 \
@@ -159,7 +196,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: hwci-pr${{ steps.ctx.outputs.pr }}
+          name: hwci-${{ steps.ctx.outputs.is_amy == 'true' && 'amy' || 'tulip' }}-pr${{ env.PR }}
           if-no-files-found: warn
           path: |
             hwci/hwci_basic-recording.wav
@@ -171,21 +208,33 @@ jobs:
             hwci/tulip-run.log
 
       - name: Comment results on the PR
-        if: always() && steps.ctx.outputs.pr != ''
+        if: always() && env.PR != ''
         uses: actions/github-script@v7
+        env:
+          IS_AMY: ${{ steps.ctx.outputs.is_amy }}
+          AMY_OUTCOME: ${{ steps.amy.outcome }}
+          TULIP_OUTCOME: ${{ steps.tulip.outcome }}
         with:
+          # AMY runs comment cross-repo on the AMY PR → need a token with write on
+          # shorepine/amy. Tulip runs comment in-repo with the default token.
+          github-token: ${{ steps.ctx.outputs.is_amy == 'true' && secrets.HWCI_BRIDGE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
-            const pr = Number('${{ steps.ctx.outputs.pr }}');
-            const amyPass = '${{ steps.amy.outcome }}' === 'success';
-            const tulipPass = '${{ steps.tulip.outcome }}' === 'success';
+            const isAmy = process.env.IS_AMY === 'true';
+            const [owner, repo] = process.env.TARGET_REPO.split('/');   // amy or tulipcc
+            const pr = Number(process.env.PR);
+            const amyPass = process.env.AMY_OUTCOME === 'success';
+            const tulipPass = process.env.TULIP_OUTCOME === 'success';
             const line = (ok) => ok
               ? '✅ **PASS** — flashed this PR’s firmware; all checks matched the references.'
               : '❌ **FAIL** — a check did not match, or the run errored. See the log/artifacts.';
+            // Artifacts/logs live on this run, which is always in tulipcc.
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const marker = '<!-- hwci-bench -->';
+            const head = ['### 🎛️ HW CI (physical bench)'];
+            if (isAmy) head.push('_Built from this AMY PR, pinned into the tulipcc `amy` submodule._');
             const body = [
               marker,
-              '### 🎛️ HW CI (physical bench)',
+              ...head,
               '',
               `**AMYboard** (USB-MIDI + AMY \`zP\` → audio): ${line(amyPass)}`,
               '',
@@ -195,14 +244,14 @@ jobs:
               '',
               '<sub>Self-hosted bench. Audio spectral-compared to `ref/hwci_basic.wav` + `ref/tulip_basic.wav`; Tulip screenshot pixel-compared to `ref/tulip_screenshot.png`. Both analog outs share one capture card, so the tests run sequentially.</sub>',
             ].join('\n');
-            const { data: comments } = await github.rest.issues.listComments({ owner: context.repo.owner, repo: context.repo.repo, issue_number: pr });
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number: pr });
             const existing = comments.find(c => c.body && c.body.includes(marker));
             // Post a fresh comment every run rather than editing in place: GitHub
             // only notifies on NEW comments, and a new comment lands at the bottom
             // of the thread where it's visible. Create first, then delete the
             // previous one, so there's always exactly one and never zero.
-            await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: pr, body });
-            if (existing) await github.rest.issues.deleteComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: existing.id });
+            await github.rest.issues.createComment({ owner, repo, issue_number: pr, body });
+            if (existing) await github.rest.issues.deleteComment({ owner, repo, comment_id: existing.id });
 
       - name: Mark job failed if either board failed
         if: always()

--- a/.github/workflows/amyboard-pr-preview.yml
+++ b/.github/workflows/amyboard-pr-preview.yml
@@ -24,18 +24,64 @@ on:
       - 'tulip/shared/**'
       - '.github/workflows/amyboard-pr-preview.yml'
 
+  # Fired by shorepine/amy's amyboard-hwci-trigger.yml on an AMY PR: build this
+  # pipeline with the `amy` submodule pinned to client_payload.amy_sha, then chain
+  # to HW CI (which comments back on the AMY PR). See the AMY-PR plumbing below.
+  repository_dispatch:
+    types: [amy-pr]
+
+  # Manual fallback for an AMY *fork* PR (auto-dispatch is same-repo only): a
+  # maintainer supplies the fork's amy PR number + SHA after reviewing the diff.
+  workflow_dispatch:
+    inputs:
+      amy_pr:
+        description: "AMY PR number (for the preview alias + result comment)"
+        required: true
+      amy_sha:
+        description: "AMY commit SHA to pin the submodule to"
+        required: true
+
 permissions:
   contents: read
   pull-requests: write
 
 concurrency:
-  group: amyboard-pr-preview-${{ github.event.pull_request.number }}
+  # Namespace by event so an AMY PR #N and a Tulip PR #N never cancel each other.
+  group: amyboard-pr-preview-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.client_payload.amy_pr || github.event.inputs.amy_pr }}
   cancel-in-progress: true
 
 jobs:
   preview:
     runs-on: ubuntu-latest
     steps:
+      # Normalize the trigger: a Tulip PR (pull_request) vs an AMY PR (dispatched
+      # from shorepine/amy, or manual for a fork). Everything downstream keys off
+      # these outputs instead of github.event.pull_request.* directly.
+      - name: Resolve PR context (Tulip PR vs AMY PR)
+        id: ctx
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const ev = context.eventName;
+            let isAmy = false, num, amySha = '', amyRepo = 'shorepine/amy';
+            if (ev === 'pull_request') {
+              num = context.payload.pull_request.number;            // Tulip PR
+            } else if (ev === 'repository_dispatch') {               // AMY PR (auto)
+              isAmy = true;
+              const cp = context.payload.client_payload || {};
+              num = cp.amy_pr; amySha = cp.amy_sha || ''; amyRepo = cp.amy_repo || amyRepo;
+            } else if (ev === 'workflow_dispatch') {                 // AMY fork PR (manual)
+              isAmy = true;
+              num = context.payload.inputs.amy_pr; amySha = context.payload.inputs.amy_sha || '';
+            }
+            if (isAmy && !amySha) { core.setFailed('AMY run requires an amy SHA'); return; }
+            core.setOutput('is_amy', String(isAmy));
+            core.setOutput('num', String(num));
+            core.setOutput('amy_sha', amySha);
+            core.setOutput('amy_repo', amyRepo);
+            core.setOutput('alias', `${isAmy ? 'amyboard-amypr' : 'amyboard-pr'}-${num}`);
+            core.info(`event=${ev} pr=${num} amy=${isAmy} sha=${amySha || '-'}`);
+
       # Fail fast on a missing/mis-scoped token, before the ~15-min build.
       - name: Verify Vercel token can access the team
         env:
@@ -53,6 +99,24 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      # For an AMY PR, point the `amy` submodule at the PR's commit so the firmware
+      # is built from THIS PR's AMY code — the whole reason for the dispatch. The
+      # build reads amy sources by path (esp32_common.cmake → ../../amy/src), so
+      # checking out the working tree is all that's needed.
+      - name: Pin amy submodule to the PR SHA (AMY runs only)
+        if: steps.ctx.outputs.is_amy == 'true'
+        env:
+          AMY_SHA: ${{ steps.ctx.outputs.amy_sha }}
+        run: |
+          set -euo pipefail
+          case "$AMY_SHA" in
+            ""|*[!0-9a-fA-F]*) echo "::error::bad amy SHA: '$AMY_SHA'"; exit 1 ;;
+          esac
+          cd amy
+          git fetch origin "$AMY_SHA"
+          git checkout --detach "$AMY_SHA"
+          echo "amy pinned to:"; git log -1 --oneline
 
       # --- Firmware (.bin sets) ---
       # Build AMYBOARD then TULIP4_R11 in ONE esp-idf container: the two targets
@@ -127,7 +191,10 @@ jobs:
         id: deploy
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          PR: ${{ github.event.pull_request.number }}
+          # amyboard-pr-<N> for Tulip PRs, amyboard-amypr-<N> for AMY PRs — one
+          # Vercel project, a distinct per-PR alias, so the two PR-number spaces
+          # can never collide on the same hostname.
+          ALIAS_HOST: ${{ steps.ctx.outputs.alias }}
         run: |
           if [ -z "$VERCEL_TOKEN" ]; then
             echo "::error::VERCEL_TOKEN secret is not set — add it (scope bwhitmans-projects) to enable PR previews."
@@ -137,13 +204,46 @@ jobs:
           cd tulip/amyboardweb
           vercel link --yes --token "$VERCEL_TOKEN" --scope bwhitmans-projects --project amyboard-pr --cwd stage
           url=$(vercel deploy stage --token "$VERCEL_TOKEN" --scope bwhitmans-projects --yes)
-          alias="amyboard-pr-${PR}.vercel.app"
+          alias="${ALIAS_HOST}.vercel.app"
           vercel alias set "$url" "$alias" --token "$VERCEL_TOKEN" --scope bwhitmans-projects
           echo "url=https://$alias" >> "$GITHUB_OUTPUT"
 
+      # Thread the AMY-PR identity to the HW CI run. HW CI chains off this run via
+      # workflow_run and otherwise has no way to know which AMY PR built the
+      # firmware, where to fetch it, or where to comment — so hand it off here.
+      - name: Publish AMY context for HW CI
+        if: steps.ctx.outputs.is_amy == 'true'
+        env:
+          AMY_PR: ${{ steps.ctx.outputs.num }}
+          AMY_REPO: ${{ steps.ctx.outputs.amy_repo }}
+          AMY_SHA: ${{ steps.ctx.outputs.amy_sha }}
+          ALIAS_HOST: ${{ steps.ctx.outputs.alias }}
+        run: |
+          mkdir -p amy-ctx
+          python3 - <<'PY' > amy-ctx/ctx.json
+          import json, os
+          json.dump({
+              "amy_pr":   int(os.environ["AMY_PR"]),   # int() validates it's numeric
+              "amy_repo": os.environ["AMY_REPO"],
+              "amy_sha":  os.environ["AMY_SHA"],
+              "alias":    os.environ["ALIAS_HOST"],
+          }, open(1, "w"))
+          PY
+          cat amy-ctx/ctx.json
+
+      - name: Upload AMY context artifact
+        if: steps.ctx.outputs.is_amy == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: amy-ctx
+          path: amy-ctx/ctx.json
+          if-no-files-found: error
+
       # --- Comment (upsert) the preview URL on the PR ---
+      # Tulip PRs only. AMY-PR runs get a single result comment posted on the AMY
+      # PR by the HW CI workflow instead (this run has no Tulip PR to comment on).
       - name: Comment preview URL
-        if: success()
+        if: success() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         env:
           PREVIEW_URL: ${{ steps.deploy.outputs.url }}


### PR DESCRIPTION
## What

Lets a **shorepine/amy** PR exercise the physical AMYboard bench, reusing *all* of the machinery that already lives here — firmware build, Vercel preview/flasher, self-hosted Pi runner, `hwci.py`, reference audio. Nothing is duplicated; the two existing workflows just gain an alternate entry point.

The companion half is a ~30-line trigger workflow in shorepine/amy (separate PR) that fires a `repository_dispatch(amy-pr)` here with the PR's amy SHA.

## How it flows

```
amy PR (src/**, same-repo only) → repository_dispatch(amy-pr)
  → amyboard-pr-preview: pin `amy` submodule to the PR SHA, build firmware,
    deploy amyboard-amypr-<N>, upload amy-ctx artifact
  → amyboard-hwci (workflow_run): flash that firmware, run the bench,
    comment pass/fail back on the amy PR
```

## Changes

- **`amyboard-pr-preview.yml`** — adds `repository_dispatch: [amy-pr]` + a manual `workflow_dispatch` (fork fallback). On an AMY run it pins the `amy` submodule to the dispatched SHA, deploys under `amyboard-amypr-<N>` (so AMY PR #N can't collide with Tulip PR #N on the alias), and uploads an `amy-ctx` artifact carrying the PR identity.
- **`amyboard-hwci.yml`** — gate widened to accept the dispatched preview (still requires `head_repository == this repo`, so fork code never runs on the Pi); reads `amy-ctx`, flashes from the `amyboard-amypr` preview via `hwci.py --url`, and comments cross-repo on the amy PR.

## Safety

- **Existing Tulip PR behavior is unchanged** — on a `pull_request` event `is_amy` is false, every new step is skipped, and the Vercel alias + firmware arg resolve exactly as before.
- **Fork code never reaches the bench** — the amy side only dispatches for same-repo (non-fork) branches; this side additionally requires the preview to have run in this repo's context.

## Required before it works

- Repo secret **`HWCI_BRIDGE_TOKEN`** — a token with `pull-requests: write` (+ `issues: write`) on shorepine/amy, used here to comment results back on the amy PR. ✅ already added.
- **Must be merged to `main`** — `repository_dispatch` and `workflow_run` only fire from the default branch, so this is inert until merged.

## Testing

After this + the amy-side trigger are both on `main`, open a small amy PR touching `src/**` and watch it post a "dispatched" note, build, run the bench, and comment pass/fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)