### PR TITLE
web: serve COOP/COEP cross-origin isolation headers (fix audio in iOS WKWebView / MIDIWeb)

### DIFF
--- a/tulip/amyboardweb/static/mini-coi.js
+++ b/tulip/amyboardweb/static/mini-coi.js
@@ -2,6 +2,12 @@
 /*! mini-coi - Andrea Giammarchi and contributors, licensed under MIT */
 (({ document: d, navigator: { serviceWorker: s } }) => {
   if (d) {
+    // If the server already sends COOP/COEP (Vercel prod/preview + webdev.py),
+    // the page is cross-origin isolated without us. Registering the SW then only
+    // adds a harmful first-load location.reload() that can interrupt the WASM
+    // boot (observed as a blank app / stray textarea on iOS Safari & WKWebView).
+    // Only fall back to the service-worker shim on header-less static hosts.
+    if (self.crossOriginIsolated) return;
     const { currentScript: c } = d;
     s.register(c.src, { scope: c.getAttribute('scope') || '.' }).then(r => {
       r.addEventListener('updatefound', () => location.reload());

--- a/tulip/amyboardweb/vercel.json
+++ b/tulip/amyboardweb/vercel.json
@@ -7,6 +7,22 @@
   ],
   "headers": [
     {
+      "source": "/editor",
+      "headers": [
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+        { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
+        { "key": "Cross-Origin-Resource-Policy", "value": "cross-origin" }
+      ]
+    },
+    {
+      "source": "/editor/(.*)",
+      "headers": [
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+        { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
+        { "key": "Cross-Origin-Resource-Policy", "value": "cross-origin" }
+      ]
+    },
+    {
       "source": "/((?!amy-|amyboard-).*)",
       "headers": [
         {

--- a/tulip/web/build.sh
+++ b/tulip/web/build.sh
@@ -43,6 +43,12 @@ cp site/index.html stage/
 cp -Rf site/webfonts stage/
 cp -Rf ../../assets/css ../../assets/fonts ../../assets/img ../../assets/js stage/
 
+# vercel.json must sit at the deploy root: the release/preview workflows run
+# `vercel deploy stage`, so a vercel.json left in tulip/web/ is ignored. Copy it
+# in so its headers (COOP/COEP cross-origin isolation for /run, plus cache rules)
+# actually get served. (amyboardweb's dev.py does the equivalent copy.)
+cp vercel.json stage/
+
 cp ../../amy/build/amy.js stage/run/amy-$timestamp.js
 cp ../../amy/build/amy.wasm stage/run/amy-$timestamp.wasm
 cp ../../amy/docs/amy.aw.js stage/run/amy-$timestamp.aw.js

--- a/tulip/web/static/index.html
+++ b/tulip/web/static/index.html
@@ -1,6 +1,10 @@
 <!doctype html>
 <html>
   <head>
+      <!-- This page lives at /run/ and references its assets relatively, so pin the
+           base path. Without this, loading /run (no trailing slash) resolves every
+           asset against / and 404s them. Mirrors amyboardweb/editor's <base href="/">. -->
+      <base href="/run/">
       <link rel="stylesheet" href="amyrepl.css"/>
       <title>Tulip Web</title>
       <meta charset="UTF-8">

--- a/tulip/web/static/mini-coi.js
+++ b/tulip/web/static/mini-coi.js
@@ -2,6 +2,12 @@
 /*! mini-coi - Andrea Giammarchi and contributors, licensed under MIT */
 (({ document: d, navigator: { serviceWorker: s } }) => {
   if (d) {
+    // If the server already sends COOP/COEP (Vercel prod/preview + webdev.py),
+    // the page is cross-origin isolated without us. Registering the SW then only
+    // adds a harmful first-load location.reload() that can interrupt the WASM
+    // boot (observed as a blank app / stray textarea on iOS Safari & WKWebView).
+    // Only fall back to the service-worker shim on header-less static hosts.
+    if (self.crossOriginIsolated) return;
     const { currentScript: c } = d;
     s.register(c.src, { scope: c.getAttribute('scope') || '.' }).then(r => {
       r.addEventListener('updatefound', () => location.reload());

--- a/tulip/web/vercel.json
+++ b/tulip/web/vercel.json
@@ -23,7 +23,7 @@
       ]
     },
     {
-      "source": "/((?!run/(amy|tulipcc)-).*)",
+      "source": "/((?!run/amy-|run/tulipcc-).*)",
       "headers": [
         { "key": "Cache-Control", "value": "no-cache" }
       ]

--- a/tulip/web/vercel.json
+++ b/tulip/web/vercel.json
@@ -1,6 +1,22 @@
 {
   "headers": [
     {
+      "source": "/run",
+      "headers": [
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+        { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
+        { "key": "Cross-Origin-Resource-Policy", "value": "cross-origin" }
+      ]
+    },
+    {
+      "source": "/run/(.*)",
+      "headers": [
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+        { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
+        { "key": "Cross-Origin-Resource-Policy", "value": "cross-origin" }
+      ]
+    },
+    {
       "source": "/run/(amy|tulipcc)-(.*)",
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }


### PR DESCRIPTION
## Problem

Per [5of12/MIDIWeb-Hub#23](https://github.com/5of12/MIDIWeb-Hub/issues/23): Tulip Web (`/run`) and the AMYboard editor (`/editor`) produce **no audio inside iOS WKWebView** (e.g. the MIDIWeb app), even though they work in iOS Safari.

Root cause is cross-origin isolation. Both apps need `crossOriginIsolated === true` (for `SharedArrayBuffer` + AudioWorklet + WASM), which requires the document to be served with:

- `Cross-Origin-Opener-Policy: same-origin`
- `Cross-Origin-Embedder-Policy: require-corp`

Today those headers are injected client-side by the `mini-coi.js` **service-worker shim**. Safari honors it; **iOS WKWebView does not**, so isolation never happens and audio is silent.

## Fix

Serve the COOP/COEP/CORP headers **directly from Vercel** via `vercel.json`, so isolation no longer depends on a service worker.

**Scoped to the app routes** (`/run`, `/editor`) rather than `/(.*)`. The marketing landing pages embed a cross-origin **YouTube iframe** and a **createsend newsletter script** — under a global COEP `require-corp`, the newsletter script (no CORP header) would be blocked. Tulip's landing page has no COEP today, so a global rule would be a regression. Scoping targets exactly the pages that need isolation and leaves the marketing pages untouched.

Verified the app routes are COEP-safe: every cross-origin CDN dependency (codemirror, bootstrap, webmidi, jquery from cdnjs / jsdelivr / googleapis) already returns `Cross-Origin-Resource-Policy: cross-origin`, and all same-origin WASM/JS passes COEP inherently. This is the same COEP policy the apps already run under in Safari via `mini-coi`, so resource loading is unchanged.

`mini-coi.js` is left in place as a harmless fallback for non-Vercel/local serving (it sets identical headers).

### Also: `tulip/web/vercel.json` was never deployed

The release/preview workflows run `vercel deploy stage`, but `tulip/web/build.sh` never copied `vercel.json` into `stage/` — so the file was silently ignored in production (its existing cache rules weren't applied either; hashed assets were served with Vercel's default `max-age=0` instead of `immutable`). Added the `cp vercel.json stage/` that `amyboardweb/dev.py` already does.

## How to test (preview deploys)

- **Tulip Web:** `https://tulip-pr-<N>.vercel.app/run/`
- **AMYboard:** `https://amyboard-pr-<N>.vercel.app/editor/`

On each, in the console:
```js
window.crossOriginIsolated === true
typeof SharedArrayBuffer === "function"
```
…and confirm audio (Tulip: bleep on first interaction; AMYboard: Simulate → tap a key). Marketing landing pages (`/`) should be unchanged (no COEP header; YouTube embed still loads).

Final verification of the actual MIDIWeb/WKWebView case needs an iOS device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)