### PR TITLE
docs: warn about power draw when connecting AMYboard to Tulip over grove

### DIFF
--- a/docs/amyboard/README.md
+++ b/docs/amyboard/README.md
@@ -82,6 +82,8 @@ AMYboard can be powered 3 ways:
 
 If multiple power supplies are connected AMYboard will use the highest available voltage. 
 
+When powered only over the I2C host / Grove port (for example, from a Tulip), AMYboard draws about **350 mA** from that 3.3V line. Make sure whatever supplies the port can spare it. If your Tulip reboots in a loop after you connect an AMYboard, see [Quick start - Tulip](#quick-start---tulip) below.
+
 ## DIP switches
 
 There are 4 DIP switches on the back of the AMYboard that set the audio input and output levels. All 4 switches should be set the same way, depending on how you're using AMYboard:
@@ -112,6 +114,8 @@ Before you do anything else, upgrade your firmware! The easiest way is online vi
 ## Quick start - Tulip
 
 If you have a [Tulip Creative Computer](https://tulip.computer), you can directly connect your AMYboard to it via the GROVE port and the back I2C HOST connector. Tulip will power and communicate with the AMYboard! 
+
+> **⚠️ Power note:** when the AMYboard is powered this way it pulls about **350 mA** off the Tulip's 3.3V rail, on top of the Tulip's own ~575 mA. A weak USB charger, a charge-only or thin USB-C cable, an unpowered hub, or a low battery may then sag the Tulip's supply enough to brown out the ESP32-S3 -- which shows up as the Tulip **rebooting in a loop**. If that happens, power the Tulip from a solid **1–2 A** 5V supply with a good data USB-C cable (no hub), or **power the AMYboard from its own USB-C** -- it uses the highest voltage present, so it'll run off its own 5V instead of drawing from the Tulip.
 
 In Tulip, just
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -27,9 +27,24 @@ First, always [upgrade your Tulip to the latest firmware](tulip_flashing.md). If
 
 First be certain that your Tulip is switched on (the switch to the right, facing your Tulip) and being powered properly. Even if your Tulip is not showing the REPL screen, it should be showing an LCD backlight glow (there are no other LEDs on Tulip.) Make sure your USB connector or battery is seated properly. The USB adapter should support at least 1A of power. 
 
+If this only started after you connected an **AMYboard** or another Grove / I2C accessory, it's likely a power problem -- see [Tulip reboots in a loop after connecting an AMYboard or I2C accessory](#tulip-reboots-in-a-loop-after-connecting-an-amyboard-or-i2c-accessory).
+
 If you think your Tulip is powered properly but not booting, try to first reset the Tulip. Flip the power switch on and off a few times. Hit the RESET button a few times. Try unplugging your USB keyboard if you have one. Wait a few seconds. There are rare instances (usually temperature related) where the chip may not boot properly, but a reboot or two will usually fix it. 
 
 If your Tulip makes a startup noise but doesn't show the screen, there may be an issue with your screen. The startup "bleep" should only happen if the system boots properly.
+
+## Tulip reboots in a loop after connecting an AMYboard or I2C accessory
+
+If your Tulip boots fine on its own but starts **rebooting in a loop** (or won't reach the REPL) once you connect an [AMYboard](amyboard/README.md) or another I2C / Grove accessory, it's almost always a **power** problem -- not a fault with either board.
+
+Powered accessories draw current from the Tulip's 3.3V rail through the Grove port. An AMYboard, for example, pulls about **350 mA** on top of the Tulip's own ~575 mA. If your power source can't supply both, the Tulip's voltage sags and the ESP32-S3's brownout protection resets the chip, over and over.
+
+To fix it:
+
+ * Use a **strong 5V supply (1–2 A)** and a known-good **data** USB-C cable, plugged in directly -- not through a hub.
+ * **Power the accessory separately** if it can be -- an AMYboard, for instance, has its own USB-C and will run off that (it uses the highest voltage present) instead of drawing from the Tulip.
+ * [Check the diagnostic output](#see-the-diagnostic-output-of-a-tulip) over the serial port -- a `Brownout detector was triggered` message confirms it's power.
+ * Try a freshly charged battery, or USB vs. battery, to rule out a weak source.
 
 ## Flash a Tulip manually
 


### PR DESCRIPTION
Addresses the documentation part of #1026 (Tulip power boot loop when an AMYboard is connected over grove / I2C host).

## Why

Connecting an AMYboard to a Tulip via the Tulip's **grove / STEMMA I2C header** and the AMYboard's back **"tulip" I2C host port** powers the AMYboard from the Tulip's 3.3V rail. Per our own docs that's **~350 mA** ([faq.md](https://github.com/shorepine/tulipcc/blob/main/docs/amyboard/faq.md#L249)), on top of the Tulip's own **~575 mA @ 5V** ([README.md:60](https://github.com/shorepine/tulipcc/blob/main/README.md#L60)) — and the docs already call for a **≥1A** supply. On a weak charger / thin cable / unpowered hub / low battery, that extra draw sags the rail and the ESP32-S3 brownout detector resets the chip repeatedly → **reboot loop**. There was no power warning anywhere in the docs for this supported hookup.

## Changes

Only hand-maintained docs are touched. The **AMYboard FAQ is auto-generated from Discord**, so it's intentionally left alone.

- **`docs/amyboard/README.md`**
  - *Power Supplies*: note that the I2C/grove input draws ~350 mA from 3.3V.
  - *Quick start - Tulip*: a ⚠️ callout right under "Tulip will power and communicate with the AMYboard!" explaining the boot-loop risk and the two fixes (stronger 1–2 A supply / good cable / no hub, **or** power the AMYboard from its own USB-C).
- **`docs/troubleshooting.md`**
  - Cross-reference from the existing "Tulip won't start properly, black screen" section.
  - New section **"Tulip reboots in a loop after connecting an AMYboard or I2C accessory"** with the mechanism, the `Brownout detector was triggered` log tell, and fixes.

## Notes / scope

- Numbers cited (350 mA, 575 mA, ≥1A) are straight from the repo docs.
- This is the **docs mitigation only**. The bench-measurement follow-up from #1026 (confirm brownout vs. regulator dropout vs. inrush on 1A vs 2A supplies) is intentionally **not** part of this PR, so #1026 stays open for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)