### PR TITLE
amyboard: enable WebREPL (REPL over WiFi)

### DIFF
--- a/docs/amyboard/python.md
+++ b/docs/amyboard/python.md
@@ -19,6 +19,29 @@ You'll see the MicroPython `>>>` prompt. You can type Python commands directly.
 
 Open [amyboard.com](https://amyboard.com) -- it includes a Python REPL running in the browser. You can test code online before deploying it to hardware.
 
+### Over WiFi (WebREPL)
+
+AMYboard can also expose its REPL over your WiFi network with MicroPython's **WebREPL**, so you can connect wirelessly from a browser -- no USB cable. Join a network, then start the WebREPL server with a password (up to 9 characters):
+
+```python
+import amyboard, webrepl
+
+amyboard.wifi('your_ssid', 'your_password')  # join WiFi (returns the board's IP)
+webrepl.start(password='amyboard')           # start the server on port 8266
+```
+
+`webrepl.start()` prints the address it's listening on, for example:
+
+```
+WebREPL server started on http://192.168.1.42:8266/
+```
+
+To connect, open the WebREPL client at [micropython.org/webrepl](https://micropython.org/webrepl/), enter `ws://192.168.1.42:8266/` (use your board's IP), click **Connect**, and type the password. You now have a full `>>>` prompt over the network. The same client can also transfer files to and from the board.
+
+To start WebREPL automatically on every boot, add the three lines above (including `amyboard.wifi(...)`) to your `sketch.py` -- see [The sketch.py startup script](#the-sketchpy-startup-script) below.
+
+> **Security:** WebREPL gives anyone on the network with the password full control of your AMYboard. Use it only on trusted networks, and pick a non-trivial password.
+
 ## Playing sounds with AMY
 
 The `amy` module gives you direct access to the synthesizer engine:

--- a/tulip/amyboard/boards/manifest.py
+++ b/tulip/amyboard/boards/manifest.py
@@ -9,7 +9,7 @@ include("$(MPY_DIR)/extmod/asyncio")
 # Useful networking-related packages.
 #require("mip")
 require("ntptime")
-#require("webrepl")
+require("webrepl")  # WebREPL server (REPL over WiFi); _webrepl C module is enabled in mpconfigport.h
 
 # Require some micropython-lib modules.
 # require("aioespnow")


### PR DESCRIPTION
## What

Enable MicroPython **WebREPL** on the AMYboard target so you can get a full Python REPL over WiFi (no USB cable), and document the flow.

- `tulip/amyboard/boards/manifest.py` — uncomment `require("webrepl")`, which freezes the standard micropython-lib `webrepl.py` / `webrepl_setup.py` into firmware.
- `docs/amyboard/python.md` — new **"Over WiFi (WebREPL)"** section under "Connecting to the REPL".

The built-in `_webrepl` C module (`MICROPY_PY_WEBREPL`) and its `websocket` / `network` deps are already enabled in `tulip/amyboard/mpconfigport.h`, so this is purely a manifest + docs change — no C config needed.

**AMYboard target only.** The Tulip `esp32s3` manifest is intentionally left unchanged (its `require("webrepl")` stays commented).

## How to try it

After flashing this firmware:

```python
import amyboard, webrepl
amyboard.wifi('your_ssid', 'your_password')   # join WiFi (returns the board's IP)
webrepl.start(password='amyboard')            # start the server on port 8266
```

`webrepl.start()` prints e.g. `WebREPL server started on http://192.168.1.42:8266/`. Then open the client at https://micropython.org/webrepl/ , enter `ws://<board-ip>:8266/`, **Connect**, and type the password.

## Notes

- WebREPL exposes a full REPL to anyone on the network with the password — the docs include a security note to use it only on trusted networks.
- Not yet built/flashed locally (fresh worktree); the change is a standard `require()` line and the C deps are confirmed enabled, but CI/your hardware test is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)