### PR TITLE
amyboardweb: fix Start/Stop buttons broken by MIDI clock-sync gating

### DIFF
--- a/tulip/amyboardweb/static/spss.js
+++ b/tulip/amyboardweb/static/spss.js
@@ -5068,36 +5068,26 @@ window.reapply_last_zd_dump = function() {
     }
 };
 
+// Start/stop the sequencer transport. Mirrors set_tempo_from_ui(): in control
+// mode we send a zP python-exec sysex to the board; in simulate mode we run the
+// same python directly in the wasm MicroPython. Both call sequencer.start()/stop()
+// (-> tulip.sequencer_start/stop -> AMY sequencer_midi_start/stop), which works
+// regardless of MIDI clock sync state (tulip.external_midi_sync). We deliberately
+// no longer send raw MIDI Start/Stop (0xFA/0xFC): AMY now ignores those unless the
+// user has enabled external MIDI sync, which is what broke these buttons.
 function control_sequencer_start() {
-    console.log('sequencer start: midiOutputDevice=', midiOutputDevice);
-    if (midiOutputDevice) {
-        try {
-            // Send MIDI Start (0xFA) via the raw MIDIOutput to avoid WebMidi.js filtering.
-            var raw = midiOutputDevice._midiOutput || midiOutputDevice.output;
-            if (raw && typeof raw.send === 'function') {
-                raw.send([0xFA]);
-                console.log('sequencer start: sent 0xFA via raw output');
-            } else if (typeof midiOutputDevice.send === 'function') {
-                midiOutputDevice.send([0xFA]);
-                console.log('sequencer start: sent 0xFA via WebMidi output');
-            }
-        } catch (e) { console.warn('sequencer start failed:', e); }
+    if (amyboard_mode === 'control') {
+        amy_add_log_message('zPimport sequencer; sequencer.start()Z');
+    } else {
+        runCodeBlock('import sequencer; sequencer.start()');
     }
 }
 
 function control_sequencer_stop() {
-    console.log('sequencer stop: midiOutputDevice=', midiOutputDevice);
-    if (midiOutputDevice) {
-        try {
-            var raw = midiOutputDevice._midiOutput || midiOutputDevice.output;
-            if (raw && typeof raw.send === 'function') {
-                raw.send([0xFC]);
-                console.log('sequencer stop: sent 0xFC via raw output');
-            } else if (typeof midiOutputDevice.send === 'function') {
-                midiOutputDevice.send([0xFC]);
-                console.log('sequencer stop: sent 0xFC via WebMidi output');
-            }
-        } catch (e) { console.warn('sequencer stop failed:', e); }
+    if (amyboard_mode === 'control') {
+        amy_add_log_message('zPimport sequencer; sequencer.stop()Z');
+    } else {
+        runCodeBlock('import sequencer; sequencer.stop()');
     }
 }
 

--- a/tulip/shared/py/sequencer.py
+++ b/tulip/shared/py/sequencer.py
@@ -16,6 +16,17 @@ def clear():
     amy.send(reset=amy.RESET_SEQUENCER)
     tulip.seq_remove_callbacks()
 
+# Start/stop the sequencer transport, independent of MIDI clock sync
+# (tulip.external_midi_sync). Sent as an AMY wire command (sequencer_run), so it
+# works identically on firmware and the AMYboard web (wasm) build, where AMY is
+# a separate module reachable only via the wire protocol. Used by the AMYboard
+# Online Start/Stop buttons.
+def start():
+    amy.send(sequencer_run=1)
+
+def stop():
+    amy.send(sequencer_run=0)
+
 class AMYSequenceEvent:
     SEQUENCE_TAG = 0
     def __init__(self, sequence):


### PR DESCRIPTION
## Problem

AMY's recent MIDI clock-sync change made the board ignore incoming MIDI **Start (0xFA)** / **Stop (0xFC)** unless the user has explicitly enabled external sync (`amy_external_midi_sync` / `tulip.external_midi_sync(True)`):

```c
else if(status_byte == 0xFA) { if(external_midi_sync_enabled) sequencer_midi_start(); }
else if(status_byte == 0xFC) { if(external_midi_sync_enabled) sequencer_midi_stop(); }
```

That gating is correct (a connected DAW's transport shouldn't hijack the board uninvited), but it broke the **AMYboard Online editor's Start/Stop buttons**, which were the *only* editor controls driving the sequencer by sending raw `0xFA`/`0xFC`. Every other control (Tempo, restart, factory-reset) goes through the `zP` python-exec sysex path instead.

## Fix

Make Start/Stop use the same mechanism as the Tempo control (`set_tempo_from_ui`), calling a new `sequencer.start()` / `sequencer.stop()`:

- **Control mode** → `zP` python-exec sysex to the board.
- **Simulate mode** → `runCodeBlock(...)` (runs the python directly in the wasm MicroPython).

Both resolve to `tulip.sequencer_start/stop()` → AMY's `sequencer_midi_start/stop()`, which are **not** gated by sync state. The sequencer runs on its internal clock, so this is independent of `external_midi_sync` in both modes.

### Changes (tulipcc only — no AMY change needed)

- **`tulip/shared/modtulip.c`** — add `tulip.sequencer_stop()` (calls `sequencer_midi_stop()`); move both `sequencer_start`/`sequencer_stop` out of the `#ifndef __EMSCRIPTEN__` guard so the AMYboard web (wasm) build exposes them too (required for **simulate** mode — previously they were compiled out of emscripten).
- **`tulip/shared/py/sequencer.py`** — add `start()` / `stop()` wrappers.
- **`tulip/amyboardweb/static/spss.js`** — `control_sequencer_start/stop` branch on `amyboard_mode` like the tempo control, instead of sending raw MIDI.

### Why simulate mode needed the un-gating

In simulate mode `amy_add_message` is the wasm cwrap and AMY's exec hook (`mp_exec_hook`) is a no-op unless `AMYBOARD` is defined (the web build defines only `AMYBOARD_WEB`). So the JS runs the python directly via `runCodeBlock`, which needs `tulip.sequencer_start/stop` present in the wasm `_tulip` module. The underlying `sequencer_midi_start/stop()` are platform-independent in AMY (`src/sequencer.c`), and the wasm sequencer ticks from the audio path (`sequencer_check_and_fill()`), so once `sequencer_running` flips the local preview advances.

## Testing

Relying on CI to build the AMYboard firmware and web app. Behavior to verify after build: Start/Stop drive the sequencer in both **Control** (real board over WebMIDI) and **Simulate** (in-browser) modes, with external MIDI sync left disabled.