### PR TITLE
amyboardweb: fix 'refused to connect' on the Upgrade Firmware tab (COEP scope)

### DIFF
--- a/tulip/amyboardweb/vercel.json
+++ b/tulip/amyboardweb/vercel.json
@@ -23,6 +23,22 @@
       ]
     },
     {
+      "source": "/esptool",
+      "headers": [
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+        { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
+        { "key": "Cross-Origin-Resource-Policy", "value": "cross-origin" }
+      ]
+    },
+    {
+      "source": "/esptool/(.*)",
+      "headers": [
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+        { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
+        { "key": "Cross-Origin-Resource-Policy", "value": "cross-origin" }
+      ]
+    },
+    {
       "source": "/((?!amy-|amyboard-).*)",
       "headers": [
         {


### PR DESCRIPTION
## Problem

On amyboard.com the **Upgrade Firmware** tab in the editor fails to load — the embedded flasher renders as **"www.amyboard.com refused to connect."**

## Root cause — [#1022](https://github.com/shorepine/tulipcc/pull/1022)

[#1022](https://github.com/shorepine/tulipcc/pull/1022) moved cross-origin isolation from the root-scoped `mini-coi` service worker (which isolated the **entire** origin, including `/esptool/`) to per-path Vercel headers scoped to **`/editor` only**, and made `mini-coi.js` bail out once the server already isolates a page.

The editor embeds the flasher with `<iframe src="esptool/index.html">` and the page uses `<base href="/">`, so the iframe resolves to **`/esptool/index.html`** — which no longer receives any COEP header. A `Cross-Origin-Embedder-Policy: require-corp` document **refuses to embed an iframe that isn't itself isolated** (even same-origin), and Chrome renders that block as *"… refused to connect."*

Verified against live `www.amyboard.com`: `/editor/` returns `COEP: require-corp`; `/esptool/index.html` returns no COEP. The bug is **prod/preview-only** — local `webdev.py` sends these headers for *every* path, so `/esptool/` is isolated there and the iframe works.

## Fix

Apply the same `COOP`/`COEP`/`CORP` headers to `/esptool` and `/esptool/(.*)`, mirroring the existing `/editor` rules, so the flasher page is cross-origin isolated and embeddable again.

No esptool code changes are needed: its only cross-origin dependency (crypto-js from jsDelivr) already returns `Cross-Origin-Resource-Policy: cross-origin`, so it still loads under COEP; everything else esptool loads is same-origin.

## Verify

On the `amyboard-pr-<N>.vercel.app` preview: open `/editor/` → **Upgrade Firmware** tab → the Adafruit WebSerial flasher should render (not "refused to connect"). Confirm `curl -I https://amyboard-pr-<N>.vercel.app/esptool/index.html` now includes `cross-origin-embedder-policy: require-corp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)