### PR TITLE
web: bridge get_synth_commands() to JS callers in both web apps

### DIFF
--- a/tulip/amyboardweb/static/spss.js
+++ b/tulip/amyboardweb/static/spss.js
@@ -520,35 +520,62 @@ function get_wire_commands_for_juno_patch(patch) {
   return wire_commands;
 }
 
+// Canonical JS bridge for AMY's get_synth_commands. The C convenience wrapper
+// exists for CPython (amy/src/pyamy.c) and for MicroPython as
+// tulip.amy_get_synth_commands (modtulip.c) -- but the MicroPython one is compiled
+// out on web (#ifndef __EMSCRIPTEN__) because here micropython does not link AMY;
+// AMY runs in a separate WASM worklet. So we bridge it from JS instead, driving
+// AMY's exported low-level generator yield_synth_commands. Reads back the wirecode
+// commands that reconstruct synth `synth` (1..16) from AMY's current state and
+// returns them as an array of strings (empty if the synth has no state).
+// include_fx (default true) also emits the global FX commands. Throws if AMY's
+// WASM module is not loaded or `synth` is out of range.
+function get_synth_commands(synth, include_fx = true) {
+  const s = Number(synth);
+  if (!Number.isInteger(s) || s < 1 || s > 16) {
+    throw new Error("get_synth_commands: synth must be an integer 1..16.");
+  }
+  if (!amy_module || typeof amy_yield_synth_commands !== "function") {
+    throw new Error("get_synth_commands: AMY WASM module is not loaded.");
+  }
+  const maxMessageLen = 1024;
+  const bufferPtr = amy_module._malloc(maxMessageLen);
+  if (!bufferPtr) {
+    throw new Error("get_synth_commands: failed to allocate AMY message buffer.");
+  }
+  const lines = [];
+  let state = 0;
+  let iterations = 0;
+  const MAX_ITERATIONS = 500;
+  try {
+    do {
+      state = amy_yield_synth_commands(s, bufferPtr, maxMessageLen, !!include_fx, state);
+      const wire = read_c_string_from_heap(bufferPtr, maxMessageLen).trim();
+      if (wire) {
+        lines.push(wire);
+      }
+      if (++iterations >= MAX_ITERATIONS) {
+        console.error("get_synth_commands: bailed after " + MAX_ITERATIONS + " iterations (state=" + state + ")");
+        break;
+      }
+    } while (state != 0);
+  } finally {
+    amy_module._free(bufferPtr);
+  }
+  return lines;
+}
+// spss.js is loaded as a plain <script>, so this is already a global, but be
+// explicit that it is the intended JS entry point for reading synth commands.
+globalThis.get_synth_commands = get_synth_commands;
+
+// Editor helper: get_synth_commands for a UI channel (1..16), but treats an empty
+// result as an error (a configured channel always yields at least one command).
 function get_wire_commands_for_channel(channel) {
   const synth = normalize_synth_channel(channel);
   if (!synth) {
     throw new Error("Invalid channel.");
   }
-  if (!amy_module || typeof amy_yield_synth_commands !== "function") {
-    throw new Error("AMY patch command generator is unavailable.");
-  }
-  const maxMessageLen = 1024;
-  const bufferPtr = amy_module._malloc(maxMessageLen);
-  if (!bufferPtr) {
-    throw new Error("Failed to allocate AMY message buffer.");
-  }
-  const lines = [];
-  let state = 0;
-  const MAX_ITERATIONS = 500;
-  let iterations = 0;
-  do {
-    state = amy_yield_synth_commands(synth, bufferPtr, maxMessageLen, true, state);
-    const wire = read_c_string_from_heap(bufferPtr, maxMessageLen).trim();
-    if (wire) {
-      lines.push(wire);
-    }
-    if (++iterations >= MAX_ITERATIONS) {
-      console.error("get_wire_commands_for_channel: bailed after " + MAX_ITERATIONS + " iterations (state=" + state + ")");
-      break;
-    }
-  } while (state != 0);
-  amy_module._free(bufferPtr);
+  const lines = get_synth_commands(synth, true);
   if (!lines.length) {
     throw new Error("No synth commands were generated for this channel.");
   }

--- a/tulip/web/static/spss.js
+++ b/tulip/web/static/spss.js
@@ -18,6 +18,7 @@ var amy_audioin_toggle = false;
 var editor_height = 200;
 var tulip_height = null; // gets set on launch
 var amy_module = null;
+var amy_yield_synth_commands = null;
 var res_ptr_in = null;
 var res_ptr_out = null;
 
@@ -53,6 +54,9 @@ amyModule().then(async function(am) {
   amy_process_single_midi_byte = am.cwrap(
     'amy_process_single_midi_byte', null, ['number, number']
   );
+  amy_yield_synth_commands = am.cwrap(
+    'yield_synth_commands', 'number', ['number', 'number', 'number', 'boolean', 'number']
+  );
   amy_start_web_no_synths();
   amy_bleep(0); // won't play until live audio starts
   amy_module = am;
@@ -60,6 +64,78 @@ amyModule().then(async function(am) {
   res_ptr_out = amy_module._malloc(2 * 256 * 2); // 2 channels, 256 frames, int16s
 
 });
+
+// Read a NUL-terminated C string out of the AMY WASM heap (used to read back the
+// wirecode strings yielded by yield_synth_commands).
+function read_c_string_from_heap(ptr, maxLen) {
+  if (!amy_module || !amy_module.HEAPU8) {
+    return "";
+  }
+  const heap = amy_module.HEAPU8;
+  const start = Number(ptr);
+  const limit = Math.max(0, Number(maxLen) || 0);
+  if (!Number.isInteger(start) || start <= 0 || limit <= 0) {
+    return "";
+  }
+  const end = Math.min(heap.length, start + limit);
+  let out = "";
+  for (let i = start; i < end; i += 1) {
+    const b = heap[i];
+    if (b === 0) {
+      break;
+    }
+    out += String.fromCharCode(b);
+  }
+  return out;
+}
+
+// Canonical JS bridge for AMY's get_synth_commands. The C convenience wrapper
+// exists for CPython (amy/src/pyamy.c) and for MicroPython as
+// tulip.amy_get_synth_commands (modtulip.c) -- but the MicroPython one is compiled
+// out on web (#ifndef __EMSCRIPTEN__) because here micropython does not link AMY;
+// AMY runs in a separate WASM worklet. So we bridge it from JS instead, driving
+// AMY's exported low-level generator yield_synth_commands. Reads back the wirecode
+// commands that reconstruct synth `synth` (1..16) from AMY's current state and
+// returns them as an array of strings (empty if the synth has no state).
+// include_fx (default true) also emits the global FX commands. Throws if AMY's
+// WASM module is not loaded or `synth` is out of range.
+function get_synth_commands(synth, include_fx = true) {
+  const s = Number(synth);
+  if (!Number.isInteger(s) || s < 1 || s > 16) {
+    throw new Error("get_synth_commands: synth must be an integer 1..16.");
+  }
+  if (!amy_module || typeof amy_yield_synth_commands !== "function") {
+    throw new Error("get_synth_commands: AMY WASM module is not loaded.");
+  }
+  const maxMessageLen = 1024;
+  const bufferPtr = amy_module._malloc(maxMessageLen);
+  if (!bufferPtr) {
+    throw new Error("get_synth_commands: failed to allocate AMY message buffer.");
+  }
+  const lines = [];
+  let state = 0;
+  let iterations = 0;
+  const MAX_ITERATIONS = 500;
+  try {
+    do {
+      state = amy_yield_synth_commands(s, bufferPtr, maxMessageLen, !!include_fx, state);
+      const wire = read_c_string_from_heap(bufferPtr, maxMessageLen).trim();
+      if (wire) {
+        lines.push(wire);
+      }
+      if (++iterations >= MAX_ITERATIONS) {
+        console.error("get_synth_commands: bailed after " + MAX_ITERATIONS + " iterations (state=" + state + ")");
+        break;
+      }
+    } while (state != 0);
+  } finally {
+    amy_module._free(bufferPtr);
+  }
+  return lines;
+}
+// spss.js is loaded as a plain <script>, so this is already a global, but be
+// explicit that it is the intended JS entry point for reading synth commands.
+globalThis.get_synth_commands = get_synth_commands;
 
 // Called from AMY to update Tulip about what tick it is, for the sequencer
 function amy_sequencer_js_hook(tick) {


### PR DESCRIPTION
## What

On web, AMY runs in a separate WASM worklet (`AMY_IS_EXTERNAL`) and the micropython module does **not** link it — so `tulip.amy_get_synth_commands` (`modtulip.c`) sits inside `#ifndef __EMSCRIPTEN__` and is compiled out on web. The convenience `get_synth_commands` only existed for "micropython that links AMY" (desktop/ESP) and for CPython (`amy/src/pyamy.c`).

This bridges the same capability to **JS callers** on web by driving AMY's already-exported low-level generator `yield_synth_commands`. Pure JS in `static/` — no AMY/submodule change.

## Changes

- **`tulip/amyboardweb/static/spss.js`** — adds a canonical global `get_synth_commands(synth, include_fx = true)` returning an array of wirecode strings (JS analogue of pyamy.c's wrapper). The editor-only `get_wire_commands_for_channel` now delegates to it (same error contract; heap-buffer free moved into `try/finally`).
- **`tulip/web/static/spss.js`** — Tulip Web lacked the plumbing, so adds the `yield_synth_commands` cwrap, a `read_c_string_from_heap` helper, and the identical `get_synth_commands`.

Both files are plain `<script>`s, so `get_synth_commands` is a true global (also assigned to `globalThis`).

```js
const cmds  = get_synth_commands(5);        // wirecode strings for synth 5
const noFx  = get_synth_commands(5, false); // omit global FX commands
```

## Verification

- `node --check` passes on both files.
- Isolated logic test with a mock AMY module: generator loop terminates correctly, empty synth → `[]` (matches pyamy/modtulip), `include_fx` passes through, range validation (0 / 17 / 2.5) throws, and malloc/free stay balanced across all paths including throws.
- Reuses the exact cwrap+loop already running in amyboardweb; AMY's `make web` exports `_yield_synth_commands` unconditionally.

Not done: full WASM build / live browser run (static-JS-only change over an already-proven path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)