### PR TITLE
amyboard: runtime MIDI OUT TRS Type A/B switch

### DIFF
--- a/docs/amyboard/python.md
+++ b/docs/amyboard/python.md
@@ -262,6 +262,22 @@ amy.send(osc=0, note=60, vel=0, sequence="24,48,2")   # note off at tick 24 of e
 
 `amy.AMY_MIDI` always sends on MIDI channel 1, and notes that arrived over MIDI in are not echoed back out. See the [AMY MIDI docs](https://github.com/shorepine/amy/blob/main/docs/midi.md#sending-midi-out) for the full details.
 
+#### MIDI out TRS type (A vs B)
+
+The MIDI out jack is a 3.5mm TRS connector, and there are two incompatible wiring standards for these: **Type A** (the official MIDI-spec standard, used by most modern gear) and **Type B** (older, used by some early Arturia/Novation/Akai devices). They swap the TRS tip and ring, so if your external device isn't receiving MIDI, it likely expects the other type. AMYboard defaults to **Type A**; only MIDI out is affected — MIDI in works with either type.
+
+Switch it at runtime with `amyboard.set_midi_type()` (no reboot needed; AMY keeps running):
+
+```python
+import amyboard
+
+amyboard.set_midi_type('B')   # switch MIDI out to Type B
+amyboard.set_midi_type('A')   # back to Type A (the default)
+amyboard.midi_type()          # -> 'A' or 'B', whichever is currently active
+```
+
+This is not persisted across reboots — AMYboard always comes up as Type A.
+
 ### Syncing to MIDI clock
 
 AMYboard's sequencer runs on its own internal clock by default. You can instead **follow** an external MIDI clock — slaving AMYboard to a DAW or drum machine — or **send** MIDI clock out to drive other gear from AMYboard.

--- a/tulip/shared/amy_connector.c
+++ b/tulip/shared/amy_connector.c
@@ -17,6 +17,13 @@
 #include "esp_system.h"
 #include "esp_attr.h"
 #endif
+#ifdef AMYBOARD
+// For amyboard_set_midi_out(): re-point the MIDI UART's TX line at runtime.
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "driver/uart.h"
+#include "driver/gpio.h"
+#endif
 uint8_t * external_map;
 
 #ifdef AMY_IS_EXTERNAL
@@ -421,6 +428,27 @@ void run_amy(uint8_t midi_out_pin) {
     for(uint16_t i=0;i<amy_config.max_oscs;i++) external_map[i] = 0;
     for(uint8_t i=0;i<MAX_CV_SYNTHS;i++) cv_synth_map[i] = 0;
 }
+
+#ifdef AMYBOARD
+// Switch the MIDI OUT TRS standard at runtime (Type A = pin 14, Type B = pin 15)
+// without restarting AMY. AMY transmits MIDI via uart_write_bytes(UART_NUM_1, ...) —
+// keyed on the UART number, not the GPIO — so moving the UART's TX line to the other
+// TRS leg is all that's needed. midi_uart is 1 on AMYboard (amy's esp_get_uart(1) ==
+// UART_NUM_1). Only MIDI OUT differs by type; MIDI IN works for both, so RX (MIDI_IN_PIN)
+// is left unchanged.
+void amyboard_set_midi_out(uint8_t midi_out_pin) {
+    const uint8_t other_pin = (midi_out_pin == MIDI_OUT_PIN_A) ? MIDI_OUT_PIN_B : MIDI_OUT_PIN_A;
+    // Let any in-flight MIDI byte finish before moving the TX line.
+    uart_wait_tx_done(UART_NUM_1, pdMS_TO_TICKS(20));
+    // Re-route the UART's TX to the requested TRS data leg.
+    uart_set_pin(UART_NUM_1, midi_out_pin, MIDI_IN_PIN, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
+    // Disconnect the now-unused leg from the UART and hold it high (MIDI idle/source).
+    // Driving it as a plain GPIO output stops it from mirroring the TX signal.
+    gpio_reset_pin(other_pin);
+    gpio_set_direction(other_pin, GPIO_MODE_OUTPUT);
+    gpio_set_level(other_pin, 1);
+}
+#endif
 
 #elif defined TULIP_DESKTOP
 

--- a/tulip/shared/amyboard-py/amyboard.py
+++ b/tulip/shared/amyboard-py/amyboard.py
@@ -436,20 +436,50 @@ def mount_sd():
     except OSError:
         pass # it's ok!
 
+# Which MIDI OUT TRS standard is live. The two standards swap the TRS tip/ring,
+# so on AMYboard "Type A" vs "Type B" is simply which GPIO carries MIDI OUT (UART TX):
+#   Type A -> pin 14 (GPIO15 held high)
+#   Type B -> pin 15 (GPIO14 held high)
+# Only MIDI OUT differs by type; MIDI IN works for both. Default is Type A.
+_MIDI_OUT_PINS = {'A': 14, 'B': 15}
+_midi_type = 'A'
+
+
+def _normalize_midi_type(type):
+    type = str(type).upper()
+    if type not in _MIDI_OUT_PINS:
+        raise ValueError("MIDI type must be 'A' or 'B'")
+    return type
+
+
 def init_midi(type='A'):
+    # Boot-time MIDI OUT setup, called by start_amy() before AMY starts. Holds the
+    # unused (source) TRS leg high and returns the data pin for amy to bind its UART TX
+    # to. For switching at runtime once AMY is running, use set_midi_type() instead.
     from machine import Pin
-    # set up MIDI, default to type A
-    # only have to set up MIDI OUT. MIDI IN will work either way
-    if(type=='A'):
-        # Type A: GPIO15 held high, MIDI OUT pin is 14
-        pin = Pin(15, Pin.OUT)
-        pin.value(1)
-        return 14
-    else:
-        # Type B: GPIO14 held high, MIDI OUT pin is 15
-        pin = Pin(14, Pin.OUT)  
-        pin.value(1)
-        return 15
+    global _midi_type
+    type = _normalize_midi_type(type)
+    out_pin = _MIDI_OUT_PINS[type]
+    other_pin = _MIDI_OUT_PINS['B' if type == 'A' else 'A']
+    Pin(other_pin, Pin.OUT).value(1)  # hold the non-data leg high (MIDI idle/source)
+    _midi_type = type
+    return out_pin
+
+
+def set_midi_type(type):
+    # Switch the MIDI OUT TRS standard ('A' or 'B') at runtime, without restarting AMY.
+    # AMY keeps running; only the UART TX line moves to the other leg. No persistence —
+    # this resets to the default (Type A) on reboot.
+    global _midi_type
+    type = _normalize_midi_type(type)
+    tulip.amyboard_set_midi_out(_MIDI_OUT_PINS[type])
+    _midi_type = type
+    return type
+
+
+def midi_type():
+    # The MIDI OUT TRS standard currently in use ('A' or 'B').
+    return _midi_type
 
 
 def start_amy():

--- a/tulip/shared/modtulip.c
+++ b/tulip/shared/modtulip.c
@@ -607,6 +607,17 @@ STATIC mp_obj_t tulip_amyboard_start(size_t n_args, const mp_obj_t *args) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(tulip_amyboard_start_obj, 1, 1, tulip_amyboard_start);
 
+#if defined(AMYBOARD)
+// Switch the MIDI OUT TRS standard live (Type A = pin 14, Type B = pin 15). See
+// amyboard.set_midi_type() — AMY keeps running; only the UART TX line moves.
+extern void amyboard_set_midi_out(uint8_t);
+STATIC mp_obj_t tulip_amyboard_set_midi_out(mp_obj_t pin_obj) {
+    amyboard_set_midi_out((uint8_t)mp_obj_get_int(pin_obj));
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(tulip_amyboard_set_midi_out_obj, tulip_amyboard_set_midi_out);
+#endif
+
 
 STATIC mp_obj_t tulip_bootloader_mode(void) {
 #if defined(AMYBOARD) && defined(ESP_PLATFORM)
@@ -1699,6 +1710,7 @@ STATIC const mp_rom_map_elem_t tulip_module_globals_table[] = {
 #ifdef AMYBOARD
     { MP_ROM_QSTR(MP_QSTR_amyboard_send), MP_ROM_PTR(&tulip_amyboard_send_obj) },
     { MP_ROM_QSTR(MP_QSTR_amyboard_start), MP_ROM_PTR(&tulip_amyboard_start_obj) },
+    { MP_ROM_QSTR(MP_QSTR_amyboard_set_midi_out), MP_ROM_PTR(&tulip_amyboard_set_midi_out_obj) },
     { MP_ROM_QSTR(MP_QSTR_bootloader_mode), MP_ROM_PTR(&tulip_bootloader_mode_obj) },
 #else
     #ifndef AMYBOARD_WEB


### PR DESCRIPTION
## What

Adds a runtime way to switch the AMYboard MIDI **OUT** between TRS **Type A** and **Type B**, from Python, without a reboot and without restarting AMY:

```python
import amyboard
amyboard.set_midi_type('B')   # switch MIDI OUT to Type B
amyboard.set_midi_type('A')   # back to Type A (the boot default)
amyboard.midi_type()          # -> 'A' or 'B', whichever is live
```

Not persisted — AMYboard always boots as Type A (no NVS).

## Why

The MIDI OUT 3.5mm TRS jack has two incompatible wiring standards: **Type A** (the MIDI-spec default, most modern gear) and **Type B** (older Arturia/Novation/Akai, etc.). They swap the TRS tip/ring. Previously `init_midi()` set this once at boot (default A) with no way to change it live — if your external device expected the other type, you had no recourse short of editing firmware.

## How

On AMYboard, "Type A vs B" is simply which GPIO carries MIDI OUT: **Type A = pin 14, Type B = pin 15** (the unused leg is held high at MIDI idle). AMY transmits MIDI via `uart_write_bytes(UART_NUM_1, ...)` — keyed on the **UART number, not the pin** — so switching type is just re-pointing that UART's TX line with `uart_set_pin()`. No `amy_start()` re-run (which would have leaked `external_map` and restarted audio). Only MIDI OUT is affected; MIDI IN (pin 21) works with either type and is untouched.

## Changes

- `tulip/shared/amy_connector.c` — `amyboard_set_midi_out(pin)` (AMYBOARD-only): `uart_set_pin()` on `UART_NUM_1` + hold the now-unused TRS leg high.
- `tulip/shared/modtulip.c` — `tulip.amyboard_set_midi_out(pin)` MicroPython binding.
- `tulip/shared/amyboard-py/amyboard.py` — `set_midi_type('A'|'B')` + `midi_type()`; `init_midi()` refactored to share one pin map. Boot path (`start_amy` → `init_midi()`, default A) unchanged.
- `docs/amyboard/python.md` — documented under "Sending MIDI out".

No AMY submodule changes.

## Verification

- ✅ Compiles + links into AMYboard firmware — full `idf.py -DMICROPY_BOARD=AMYBOARD build`, exit 0, no warnings on touched files. Built against the pinned AMY commit `ec78cc8b`, where `midi_uart=1` → `UART_NUM_1` is confirmed.
- ⏳ Hardware electrical verification (OUT signal actually moves 14↔15, both directions drive a real MIDI device) — pending HW CI / bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)