### PR TITLE
Update m5_8encoder.py to allow for correct addressing of the 9th LED

### DIFF
--- a/tulip/shared/py/m5_8encoder.py
+++ b/tulip/shared/py/m5_8encoder.py
@@ -70,7 +70,7 @@ def read_switch():
     return struct.unpack("B", val)[0]
 
 def set_led(led: int, color: bytes):
-    if not (0 <= led < ENCODERS):
+    if not (0 <= led < LEDS):
         raise ValueError(
             f"Invalid led number {led} (valid values: 0-{LEDS - 1})"
         )


### PR DESCRIPTION
set_led() was checking to see if the value of 8 was less than the number of ENCODERS(8) instead of the number of LEDS(9). This update will have it check against LEDS(9) to allow for the LED beside the SW switch to be addressed correctly.