### PR TITLE
tulip/web: don't fail the build when amy has no amy.aw.js

### DIFF
--- a/tulip/web/build.sh
+++ b/tulip/web/build.sh
@@ -51,7 +51,13 @@ cp vercel.json stage/
 
 cp ../../amy/build/amy.js stage/run/amy-$timestamp.js
 cp ../../amy/build/amy.wasm stage/run/amy-$timestamp.wasm
-cp ../../amy/docs/amy.aw.js stage/run/amy-$timestamp.aw.js
+# emscripten >=4 inlines the AudioWorklet glue into amy.js, so newer amy no longer
+# ships a separate amy.aw.js (and amy.js never references one). Copy it only if an
+# older pinned amy still has it -- otherwise `set -e` aborts the whole build on the
+# missing file. (amyboardweb's dev.py already guards the same copy with os.path.exists.)
+if [ -f ../../amy/docs/amy.aw.js ]; then
+  cp ../../amy/docs/amy.aw.js stage/run/amy-$timestamp.aw.js
+fi
 
 cp build-standard/tulip/obj/micropython.wasm stage/run/tulipcc-$timestamp.wasm
 cp build-standard/tulip/obj/micropython.mjs stage/run/tulipcc-$timestamp.mjs


### PR DESCRIPTION
## Problem

amy dropped the separate `amy.aw.js` / `amy.ww.js` from its web build in [shorepine/amy#775](https://github.com/shorepine/amy/pull/775) — emscripten ≥4 inlines the AudioWorklet/WasmWorker glue directly into `amy.js`, which never references a separate `.aw.js`.

But `tulip/web/build.sh` still hard-copied it:

```
cp ../../amy/docs/amy.aw.js stage/run/amy-$timestamp.aw.js
```

Under `set -e`, once a newer amy is pinned that whole web-preview build aborts with:

```
cp: cannot stat '../../amy/docs/amy.aw.js': No such file or directory
```

This is what's failing the auto-pin PRs the [amy→tulipcc pin workflow](https://github.com/shorepine/amy/blob/main/.github/workflows/tulipcc-pin.yml) opens (e.g. #1053, which pins amy#777).

## Fix

Guard the copy with `[ -f ]` so it's copied only when an *older* pinned amy still ships it — mirroring `tulip/amyboardweb/dev.py`, which already guards the identical copy with `os.path.exists()` (so AMYboard Web never broke; only `tulip/web` did).

No runtime effect: `amy.js` loads the worklet inline either way, and it references `aw.js` zero times in both the old (`ec78cc8`) and new amy. Works for both the old amy `main` still pins and the newer amy the pin PRs carry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)