### PR TITLE
amyboard-pr-preview: keep amy pinned to the PR through the root container build

### DIFF
--- a/.github/workflows/amyboard-pr-preview.yml
+++ b/.github/workflows/amyboard-pr-preview.yml
@@ -102,8 +102,14 @@ jobs:
 
       # For an AMY PR, point the `amy` submodule at the PR's commit so the firmware
       # is built from THIS PR's AMY code — the whole reason for the dispatch. The
-      # build reads amy sources by path (esp32_common.cmake → ../../amy/src), so
-      # checking out the working tree is all that's needed.
+      # build reads amy sources by path (esp32_common.cmake → ../../amy/src).
+      #
+      # Checking out amy's working tree is NOT enough on its own: the esp-idf
+      # firmware step below runs `git submodule update` inside a root Docker
+      # container, which would reset amy back to the superproject's *recorded*
+      # gitlink (main's pin) — silently building main's amy instead of the PR's.
+      # So we also `git add amy` to record the PR SHA as the gitlink; a later
+      # `git submodule update` then keeps the PR commit.
       - name: Pin amy submodule to the PR SHA (AMY runs only)
         if: steps.ctx.outputs.is_amy == 'true'
         env:
@@ -113,10 +119,12 @@ jobs:
           case "$AMY_SHA" in
             ""|*[!0-9a-fA-F]*) echo "::error::bad amy SHA: '$AMY_SHA'"; exit 1 ;;
           esac
-          cd amy
-          git fetch origin "$AMY_SHA"
-          git checkout --detach "$AMY_SHA"
-          echo "amy pinned to:"; git log -1 --oneline
+          git -C amy fetch origin "$AMY_SHA"
+          git -C amy checkout --detach "$AMY_SHA"
+          echo "amy pinned to:"; git -C amy log -1 --oneline
+          # Record the new gitlink in the superproject index so the container's
+          # `git submodule update` can't revert amy to main's pin.
+          git add amy
 
       # --- Firmware (.bin sets) ---
       # Build AMYBOARD then TULIP4_R11 in ONE esp-idf container: the two targets
@@ -162,6 +170,15 @@ jobs:
             tulip/esp32s3/dist/tulip-firmware-TULIP4_R11.bin
             tulip/esp32s3/dist/tulip-full-TULIP4_R11.bin
             tulip/esp32s3/dist/tulip-sys.bin
+
+      # The esp-idf firmware step above runs in a Docker container as root, so any
+      # file it created or rewrote in the bind-mounted workspace is now owned by
+      # root:root. The web build below runs as the (non-root) runner and, for AMY
+      # PRs, regenerates amy/amy/constants.py via `make web` (the pinned amy.h is
+      # newer than the committed patches.h). That write fails with "Permission
+      # denied" on the root-owned file — so reclaim ownership first.
+      - name: Reclaim workspace ownership after the root container build
+        run: sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE"
 
       # --- Web stage/ (amy + amyboard WASM + static) ---
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Problem

AMY-PR previews ([`repository_dispatch: amy-pr`](.github/workflows/amyboard-pr-preview.yml)) started failing in the **Build amyboardweb stage/** step (e.g. [amy#784](https://github.com/shorepine/amy/pull/784)):

```
/bin/sh: 1: cannot create amy/constants.py: Permission denied
make: *** [Makefile:63: src/patches.h] Error 2
```

### Root cause (verified on the runner)

The esp-idf firmware step runs in a Docker container **as root** with the workspace bind-mounted, and inside it a `git submodule update` runs (it does `git config --global --add safe.directory "*"` first). That **reverts the `amy` submodule from the PR's pinned commit back to the superproject's recorded gitlink (main's pin)** and leaves the reverted files owned by `root:root`.

I confirmed this with a diagnostic run: right after the container, `amy/amy/constants.py` was `root root` and byte-identical to main's pin (2773 bytes), **not** the PR's version (2794 bytes with `NOTE_SOURCE_MAPPED`).

Two consequences:
1. **Correctness (silent):** the preview web editor — and very likely the firmware/HW-CI — were built from **main's amy, not the PR's**. The pin was being undone.
2. **The visible failure:** the reverted files are root-owned, so the non-root web build hit `Permission denied` when `make web` regenerated `amy/amy/constants.py`. This only surfaces when the PR changes a header (`src/amy.h`) without regenerating the committed `src/patches.h`, so `make` considers it stale (amy#784 does exactly this); other AMY PRs stayed green while still building main's amy.

## Fix

- **Record the PR SHA as the superproject gitlink** (`git add amy`) in the pin step, so the container's `git submodule update` keeps the PR commit instead of reverting.
- **Reclaim workspace ownership** after the root container step so the web build can write (defense-in-depth; the container still root-owns other paths like `build/`).

## Verification

Dispatched this workflow for amy#784 (`a07a6ae`) on a branch carrying this fix plus a temporary probe + stop-before-deploy guard:

- After the container: `amy HEAD = a07a6ae` (PR SHA), `constants.py` = **2794 bytes, `runner runner`, `HAS PR MARKER`** — the pin survived and the revert no longer root-owns the tree.
- **`Build amyboardweb stage/` passed.**
- The run was intentionally halted before deploy, so no Vercel deploy / HW-CI / PR comment fired (HW-CI gates on `conclusion == success`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)