### PR TITLE
Fix GM drum examples: use patch=258 instead of the old wave=amy.PCM recipe

### DIFF
--- a/AMY_AGENTS.md
+++ b/AMY_AGENTS.md
@@ -59,8 +59,9 @@ Set the tempo with **`sequencer.tempo(bpm)`** (`import sequencer`). The grid is 
 import amy, sequencer
 
 sequencer.tempo(120)
-# GM drum synth: synth_flags=3 = GM note map, note 36 = kick
-amy.send(synth=10, num_voices=1, oscs_per_voice=1, synth_flags=3, wave=amy.PCM, amp=5)
+# GM drum synth: patch=258 is the GM drum kit (note 36 = kick, 38 = snare, 42 = hat...);
+# synth_flags=3 routes notes through the GM note map and ignores note-offs.
+amy.send(synth=10, num_voices=1, synth_flags=3, patch=258, amp=5)
 
 KICK = 36
 step = 0
@@ -73,6 +74,16 @@ def loop():
 
 > Source of truth: `tulip/amyboardweb/sketches/house_generator.py`, `acid_generator.py`
 > (`sequencer.tempo(...)` + 32-steps-per-bar patterns driven by a `loop()` step counter).
+
+> **GM drums need `patch=258`.** To play drums by GM note number (36=kick, 38=snare,
+> 42=closed hat, 46=open hat, 49=crash...) load the drum-kit patch: `amy.send(synth=10,
+> num_voices=N, synth_flags=3, patch=258)`. The note→sample mapping lives in patch 258.
+> The older recipe — `wave=amy.PCM` + `oscs_per_voice=1` with **no** patch — no longer
+> makes sound: bare `wave=amy.PCM` needs an explicit `preset=`, and note numbers alone no
+> longer select a drum sample. (`synth_flags` bit 1 used to be a built-in GM-drum note map;
+> it is now `SYNTH_FLAGS_NOTES_VIA_MIDI`, which only maps notes when a patch like 258 sets
+> up the mapping.) If you just want one raw PCM sample pitched by note, use
+> `wave=amy.PCM, preset=P` instead of a patch.
 
 ---
 

--- a/docs/amyboard/python.md
+++ b/docs/amyboard/python.md
@@ -61,7 +61,7 @@ amy.send(osc=0, vel=0)
 
 ### Using patches
 
-AMY has 256+ built-in patches: 0-127 are Juno-6 analog, 128-255 are DX7 FM, 256 is piano, and 257+ are PCM drum kits.
+AMY has 256+ built-in patches: 0-127 are Juno-6 analog, 128-255 are DX7 FM, 256 is piano, and 257+ are PCM drum kits. Patch 258 is the General MIDI drum kit — load it on a synth with `synth_flags=3` and play GM note numbers (36=kick, 38=snare, 42=hat...) to trigger drums.
 In general, a patch will use multiple oscs.  `synth` is our abstraction to manage multiple oscs at the same time.
 
 ```python
@@ -149,7 +149,7 @@ import amy, amyboard
 
 # Set up my preferred patches
 amy.send(synth=1, patch=0, num_voices=6)      # Channel 1: Juno patch 0, 6-voice poly
-amy.send(synth=10, num_voices=1, oscs_per_voice=1, synth_flags=3)    # Channel 10: Drums (synth_flags magic).
+amy.send(synth=10, num_voices=6, patch=258, synth_flags=3)    # Channel 10: GM drum kit (note 36=kick, ...).
 
 # Set CV out 1 to 0V on startup
 amyboard.cv_out(0.0, channel=0)

--- a/docs/music.md
+++ b/docs/music.md
@@ -35,7 +35,7 @@ If you're using [Tulip Desktop](tulip_desktop.md) or [Tulip Web](https://tulip.c
 
 When you start up your Tulip, it is configured to receive MIDI messages from the MIDI in port (or the USB MIDI port if connected.) You can plug in any MIDI device that sends MIDI out, like a MIDI keyboard or your computer running a sequencer. 
 
-Try to just play notes once you've turned on Tulip, By default, MIDI channel 1 plays a Juno-6 patch. Notes on channel 10 will play PCM patches, roughly aligned with General MIDI drums. 
+Try to just play notes once you've turned on Tulip, By default, MIDI channel 1 plays a Juno-6 patch. Notes on channel 10 will play PCM patches, roughly aligned with General MIDI drums. (Channel 10 is set up for you as the GM drum kit, AMY `patch=258`, so note 36 is the kick, 38 the snare, 42 the closed hat, and so on. If you configure a drum synth by hand, load that patch — `amy.send(synth=10, num_voices=6, synth_flags=3, patch=258)` — rather than a bare `wave=amy.PCM` osc.)
 
 You can adjust patch assignments per channel, or change patches, using our built in `voices` app. You can type `run('voices')` or tap the bottom right launcher menu and tap `Voices`. 
 

--- a/tulip/amyboardweb/sketches/acid_generator.py
+++ b/tulip/amyboardweb/sketches/acid_generator.py
@@ -16,8 +16,9 @@ amyboard.display_refresh()
 # --- Synth setup ---
 
 # Synth 1: TB-303 bass — already configured via knobs
-# Synth 10: 808 drums (GM mapping with synth_flags=3)
-amy.send(synth=10, num_voices=5, oscs_per_voice=1, synth_flags=3, amp=5, wave=amy.PCM)
+# Synth 10: 808 drums. patch=258 is the GM drum kit (maps note 36->kick etc.);
+# synth_flags=3 routes notes through the GM note map and ignores note-offs.
+amy.send(synth=10, num_voices=5, synth_flags=3, amp=5, patch=258)
 
 # A little reverb, plus some chorus for the 303
 amy.send(chorus="0.6,2,0.3")

--- a/tulip/amyboardweb/sketches/house_generator.py
+++ b/tulip/amyboardweb/sketches/house_generator.py
@@ -26,8 +26,9 @@ amy.send(synth=1, osc=0, wave=amy.ALGO, algorithm=5, algo_source=',,4,3,2,1', bp
 # Synth 2: Piano chords (3 voices for triads)
 amy.send(synth=2, patch=256, num_voices=3)
 
-# Synth 10: 808 drums (GM mapping with synth_flags=3)
-amy.send(synth=10, num_voices=4, oscs_per_voice=1, synth_flags=3, amp=5, wave=amy.PCM)
+# Synth 10: 808 drums. patch=258 is the GM drum kit (maps note 36->kick etc.);
+# synth_flags=3 routes notes through the GM note map and ignores note-offs.
+amy.send(synth=10, num_voices=4, synth_flags=3, amp=5, patch=258)
 
 # A little reverb
 amy.send(reverb="0.7,0.5,0.1")


### PR DESCRIPTION
## What

The old recipe for GM/808 drums on channel 10 —

```python
amy.send(synth=10, num_voices=N, oscs_per_voice=1, synth_flags=3, wave=amy.PCM, amp=5)
amy.send(synth=10, note=36, vel=1)   # expected: kick
```

**no longer makes any sound** on current AMY. This updates the examples and docs that still show it to the working form:

```python
amy.send(synth=10, num_voices=N, synth_flags=3, patch=258)
amy.send(synth=10, note=36, vel=1)   # kick (38 snare, 42 hat, 46 open hat, 49 crash, ...)
```

## Why it broke

Two AMY changes:

1. `synth_flags` **bit 1** used to be a built-in GM-drum note→sample map (`SYNTH_FLAGS_MIDI_DRUMS`). That machinery was removed (moved into **patch 258**) and the bit was later repurposed as `SYNTH_FLAGS_NOTES_VIA_MIDI`. So GM note numbers alone no longer select a drum sample.
2. A bare `wave=amy.PCM` osc with **no `preset`** is silent — `pcm_note_on()` requires a preset, and `note=36` doesn't select one.

The drum-kit note→sample mapping now lives in **AMY patch 258** (the same kit `amy_default_synths()` loads on channel 10). Verified by building the AMY Python module and rendering: the old recipe → silence (peak 0.0), `patch=258` → kick (peak 0.36) with the full kit mapped across GM notes.

## Changes

- `tulip/amyboardweb/sketches/acid_generator.py` — synth 10 drum setup → `patch=258`
- `tulip/amyboardweb/sketches/house_generator.py` — synth 10 drum setup → `patch=258`
- `AMY_AGENTS.md` — fixed the four-on-the-floor example + added a note explaining the change
- `docs/amyboard/python.md` — fixed the default-sketch drum line; named patch 258 as the GM kit
- `docs/music.md` — clarified that channel 10 is the GM drum kit (`patch=258`)

The other `wave=amy.PCM` sketches (`wavfile.py`, `sampler.py`) already pass an explicit `preset=`, so they still work and are untouched.

### Note on `_auto_generated_knobs`
`acid_generator.py`'s machine-generated `_auto_generated_knobs` block still contains the old-style synth-10 wirecodes (`i10...w7p1...`). I left it alone since it's marked *"Do not edit — set automatically by the knobs."* It's harmless here: `run_sketch()` applies the knob block **before** importing the sketch, so the top-level `patch=258` call runs last and wins. Regenerating it through the AMYboard Online knob UI would clear the stale lines if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)