### PR TITLE
amyboard: fix SD card writes failing with EIO

### DIFF
--- a/tulip/amyboard/machine_sdcard.c
+++ b/tulip/amyboard/machine_sdcard.c
@@ -391,6 +391,12 @@ static mp_obj_t machine_sdcard_writeblocks(mp_obj_t self_in, mp_obj_t block_num,
     mp_get_buffer_raise(buf, &bufinfo, MP_BUFFER_READ);
     err = sdmmc_write_sectors(&(self->card), bufinfo.buf, mp_obj_get_int(block_num), bufinfo.len / _SECTOR_SIZE(self));
 
+    // The VFS block protocol treats any return other than None (or 0) as an
+    // error, so returning True on success made every write fail with EIO.
+    // Same fix as readblocks above (#1065).
+    if (err == ESP_OK) {
+        return mp_const_none;
+    }
     return mp_obj_new_bool(err == ESP_OK);
 }
 static MP_DEFINE_CONST_FUN_OBJ_3(machine_sdcard_writeblocks_obj, machine_sdcard_writeblocks);


### PR DESCRIPTION
Fixes #1065.

## Root cause

MicroPython's VFS block-device protocol (`mp_vfs_blockdev_call_rw` in `extmod/vfs_blockdev.c`) treats any `writeblocks` return value other than `None` (or an int 0) as an error code. The vendored `tulip/amyboard/machine_sdcard.c` returned `True` on success (as the old upstream driver did), so FatFS saw every sector write as failed and raised `OSError: [Errno 5] EIO` — the sectors never reached the card, which is why Thonny left 0-byte files.

`readblocks` got exactly this fix in March 2025 ("added by BAW mar 5 2025"), which is why reads and `ls` work fine. `writeblocks` never got the matching patch. This applies the same one-liner to the write path.

## Testing

- AMYBOARD firmware builds clean.
- Reproduced the failure path on the HW CI bench board via the raw REPL — but the bench AMYboard has **no SD card inserted** (`machine.SDCard(...).info()` → `ESP_ERR_TIMEOUT`), so the write fix itself needs a board with a card. The PR-preview firmware from this PR can be flashed from `amyboard-pr-<N>.vercel.app` to confirm:

```python
r = open("/sd/test.txt", "w")
r.write("test of AMYboard writing to sd\n")
r.close()
print(open("/sd/test.txt").read())
```

Tulip CC is unaffected (`MICROPY_HW_ENABLE_SDCARD` is 0 on esp32s3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)