### PR TITLE
tools: AMYboard World recorder (capture + beep-sync + stitch) + SysEx control API doc

### DIFF
--- a/docs/amyboard/README.md
+++ b/docs/amyboard/README.md
@@ -132,6 +132,7 @@ And all sound will come from the AMYboard.
  - **[Arduino Setup](arduino.md)** -- Using the AMY synth engine in Arduino projects
  - **[Modular Synth Setup](modular.md)** -- CV, gate, and MIDI integration with your modular rig
  - **[Using Python](python.md)** -- Programming AMYboard with MicroPython
+ - **[Control API (MIDI SysEx)](control_api.md)** -- Drive AMYboard from your own scripts: transfer files both ways, dump synth state, run Python, reboot, read errors
  - **[Accessories](accessories.md)** -- Compatible displays, encoders, and other I2C accessories
  - **[Troubleshooting](troubleshooting.md)** -- Common issues and how to fix them
  - **[FAQ](faq.md)** -- Frequently asked questions from the AMYboard community

--- a/docs/amyboard/control_api.md
+++ b/docs/amyboard/control_api.md
@@ -1,0 +1,273 @@
+# Controlling AMYboard over MIDI SysEx
+
+AMYboard exposes a small control protocol over **USB MIDI System Exclusive
+(SysEx)** messages. It's the same protocol the [AMYboard Online editor](https://amyboard.com/editor)
+uses to write sketches to the board, read files back, dump synth state, run
+Python, and reboot. Because it's plain MIDI, you can drive it from any language
+with a MIDI library — this page documents the wire format so you can write your
+own scripts and programs.
+
+> If you just want to write Python on the board interactively, use the REPL /
+> `mpremote` (see [Using Python](python.md)). This control API is for *programs*
+> that talk to the board over MIDI — uploaders, automation, test harnesses, CI.
+
+A complete, importable Python reference implementation lives in the repo at
+[`tools/amyworld_recorder/amyboard_link.py`](https://github.com/shorepine/tulipcc/blob/main/tools/amyworld_recorder/amyboard_link.py).
+
+---
+
+## The envelope
+
+Every control frame is one MIDI SysEx message with AMYboard's manufacturer ID
+`00 03 45`:
+
+```
+F0  00 03 45  <ASCII payload ...>  F7
+```
+
+- `F0` … `F7` are the standard SysEx start/end bytes.
+- `00 03 45` is the manufacturer ID ("SPSS" — Shorepine Synth Systems). The board
+  ignores any SysEx that doesn't start with it.
+- The payload is plain 7-bit ASCII. Binary data (file contents, samples, state
+  dumps) is **base64-encoded** so it stays inside the 7-bit SysEx range.
+
+The board appears as a MIDI port named **`AMYboard`** (input *and* output — the
+same port carries control frames both ways and ordinary note data). Connect to
+both directions of that port.
+
+Ordinary **MIDI channel-voice messages** (note on/off, control change, program
+change, pitch bend) are *not* SysEx — send them as normal MIDI to play the loaded
+synth. See [Playing notes](#playing-notes).
+
+---
+
+## Flow control: wait for the ACK
+
+The board **acknowledges every SysEx control frame it processes** by sending back:
+
+```
+F0 00 03 45 'A' 'K' F7        (i.e. F0 00 03 45 41 4B F7)
+```
+
+The ACK is sent *after* the message is fully handled, not just received. **Send
+one control frame, wait for its `AK`, then send the next.** Keeping a single frame
+in flight is what prevents the board's SysEx ring buffer from overflowing during
+multi-frame transfers. Use a timeout (the web editor uses 5 s) and proceed if no
+ACK arrives, but under normal conditions every frame is acked promptly.
+
+`zB` (reboot) and `zI` (ping) are handled in pure C before the ACK path, so they
+do **not** produce an `AK` — `zI` produces an `OK` reply (below) and `zB` produces
+nothing (the board reboots). Channel-voice MIDI is not acked.
+
+---
+
+## Command reference (host → board)
+
+All payloads below sit inside the `F0 00 03 45 … F7` envelope. A trailing `Z` is
+an end-of-message marker that several commands accept/strip.
+
+| Payload | Meaning |
+|---|---|
+| `zT<path>,<size>Z` | **Begin a file write** to `<path>` (e.g. `/user/current/sketch.py`). `<size>` is the raw byte count. Stops the running sketch, then expects base64 data chunks (next rows). |
+| *(base64)* | **One file/sample data chunk.** During a `zT` (or sample) transfer, send the file bytes in ≤188-byte raw chunks, each base64-encoded, one chunk per SysEx frame, until `<size>` bytes have been delivered. |
+| `zD Z` | **Dump all synth state** back to the host as SysEx (see [Reading state](#reading-amy-state-zd)). |
+| `zD<path>Z` | **Read a file** off the board's filesystem, streamed back as SysEx. |
+| `zA Z` / `zA<path>Z` | **Write current AMY state into a sketch** on disk — updates the `_auto_generated_knobs` block of `/user/current/sketch.py` (or `<path>`). |
+| `zP<python>Z` | **Run a line of Python** on the board. e.g. `zPimport amyboard; amyboard.restart_sketch()Z`. |
+| `zY1Z` / `zY0Z` | **Sequencer transport** — start / stop the step sequencer without MIDI clock. |
+| `zB Z` / `zB0Z` | **Reboot to bootloader** — skip `sketch.py` on next boot (frees the scheduler). USB re-enumerates. |
+| `zB1Z` | **Reboot normally** — run `sketch.py` on next boot. |
+| `zB2Z` | **Reboot to ROM download / flash mode.** |
+| `zIZ` | **Ping** — board replies `OK` (below). |
+| `z<preset>,<len>,<sr>,<note>,<loopstart>,<loopend>Z` | **Load a PCM sample** into a memory preset, followed by raw sample data chunks. `<len>`=0 unloads the preset. (Advanced; see `amy.load_sample`.) |
+| `zF<preset>,<path>,<note>Z` | **Load a PCM preset from a WAV file** already on the board's filesystem. |
+| `zS<preset>,<bus>,<frames>,<note>,<loopstart>,<loopend>Z` / `zOZ` | **Sample audio from a bus** into a preset / **stop** sampling. |
+
+You can also send **raw AMY wire commands** (the text synth protocol, e.g.
+`v0n60l1Z`) by `zP`-running `amy.send(...)`, or — more directly — most AMY control
+is done by sending MIDI notes/CCs and letting the loaded sketch react.
+
+---
+
+## Response reference (board → host)
+
+All replies use the same envelope, with a single-byte **tag** right after the
+manufacturer ID: `F0 00 03 45 <tag> <data...> F7`.
+
+| Tag (ASCII / hex) | Meaning |
+|---|---|
+| `A` `K` (`41 4B`) | **ACK** — the preceding control frame was processed. (Flow control.) |
+| `O` `K` (`4F 4B`) | **Pong** — reply to `zI`; the board is alive and ready. |
+| `X` (`58`) | **Sketch error** — `<data>` is base64 of a Python traceback (with file/line numbers). Sent when a sketch fails to load/run. |
+| `V` (`56`) | **Firmware version** — `<data>` is an ASCII version string (e.g. `20260627-abc1234`). Sent in reply to `amyboard.report_version()`. |
+| `0` (`30`) | **Dump: single frame** — `<data>` is base64 of the *entire* `zD` payload (it all fit in one frame). |
+| `C` (`43`) | **Dump: chunk, more follow** — `<data>` is base64 of one chunk of a multi-frame `zD` dump. |
+| `E` (`45`) | **Dump: final chunk** — last frame of a multi-frame `zD` dump. |
+
+To reassemble a `zD` dump: collect frames until you see a `0` (the only frame) or
+an `E` (the last of several `C` frames), base64-decode each frame's data, and
+concatenate in order.
+
+---
+
+## Recipes
+
+### Write a sketch to the board (`zT`)
+
+This is the "write to sketch" flow the web editor uses.
+
+1. `zT/user/current/sketch.py,<size>Z` — wait for `AK`.
+2. For each ≤188-byte slice of the UTF-8 file bytes: base64-encode it, send it,
+   wait for `AK`. Repeat until all `<size>` bytes are sent.
+3. `zPimport amyboard; amyboard.environment_transfer_done()Z` — restarts the
+   sketch with the new file. (Or `amyboard.restart_sketch()`.)
+
+The receiver base64-decodes each chunk and appends to the file; when `<size>`
+bytes have arrived it closes the file and the transfer is done.
+
+### Read a file from the board (`zD<path>`)
+
+`zD/user/current/sketch.py Z` (no space; shown spaced for clarity) → the board
+streams the file back as `C…C E` (or a single `0`) frames. Decode and concatenate
+each frame's base64 to get the file bytes.
+
+> Filenames whose **last character is `Z`** are not addressable (the trailing `Z`
+> is treated as the end marker). Interior `Z`s (e.g. `/ZIP.py`) are fine.
+
+### Read AMY state (`zD`)
+
+`zDZ` (empty filename) dumps the **full live synth state** — every active
+instrument plus the global effects (reverb / chorus / echo / EQ) — as a series of
+newline-separated **AMY wire-command lines**. Reassemble the frames as above; the
+decoded text is the wire protocol you could replay with `amy.send(...)` to restore
+that exact state. This is what `zA` writes into a sketch's knob block.
+
+### Run Python / restart the sketch (`zP`)
+
+`zP<code>Z` runs one line on the board. Handy ones:
+
+- `zPimport amyboard; amyboard.restart_sketch()Z` — reload & restart `sketch.py`.
+- `zPimport amyboard; amyboard.environment_transfer_done()Z` — restart after a `zT`.
+- `zPimport amyboard; amyboard.factory_reset()Z` — clear `current/` and reload default.
+- `zPimport amyboard; amyboard.report_version()Z` — board replies with a `V` frame.
+- `zPimport sequencer; sequencer.tempo(120)Z` — set tempo.
+
+`zP` code is capped at 255 bytes — keep it to a short statement (imports + a call).
+
+### Reset to a clean slate
+
+Two options, lightest first:
+
+- **Reset the synth only (no reboot):** `zPimport amy; amy.reset()Z`. Clears all
+  oscillators/voices without dropping USB. Fast; the port stays open. Best for
+  scripts that load many sketches back-to-back.
+- **Full reboot:** `zBZ` (skip-sketch bootloader) then poll for the `AMYboard`
+  MIDI port to disappear and re-enumerate, reconnect, optionally `zIZ` until you
+  get `OK`. Guaranteed-clean slate, but the USB device resets so your MIDI
+  handles must be reopened.
+
+### See Python errors
+
+When a sketch fails to load or run, the board pushes the **full traceback** back
+as an `X` frame — base64 of the Python exception with file and line numbers. Watch
+for `X` frames after any `zT`+restart or `zP` that runs sketch code, decode the
+base64, and you have the error without needing the serial console. Example decoded
+payload:
+
+```
+Traceback (most recent call last):
+  File "amyboard.py", line 593, in run_sketch
+  File "/user/current/sketch.py", line 4, in <module>
+NameError: name 'foo' isn't defined
+```
+
+### Save the current state into a sketch (`zA`)
+
+`zAZ` rewrites the `_auto_generated_knobs` section of `/user/current/sketch.py`
+with the board's current AMY state, so a later restart restores it. Pass a path
+(`zA/user/current/other.py Z`) to target a different file.
+
+### Ping (`zI`)
+
+`zIZ` → `F0 00 03 45 'O' 'K' F7`. Use it to confirm the board is connected and
+responsive, e.g. while waiting out a reboot.
+
+### Sequencer transport (`zY`)
+
+`zY1Z` starts the step sequencer, `zY0Z` stops it — lets a host drive playback
+without sending MIDI clock.
+
+### Playing notes
+
+To make the loaded synth sound, send **ordinary MIDI** to the `AMYboard` port (not
+SysEx):
+
+- Note on: `0x90 <note> <velocity>` (status `0x90`–`0x9F` = channels 1–16)
+- Note off: `0x80 <note> 0` (or note-on with velocity 0)
+- Also handled: control change (`0xB0`), program change (`0xC0`), pitch bend
+  (`0xE0`), sustain pedal (CC 64), all-notes-off (CC 123).
+
+Most AMYboard World sketches listen on **channel 1**.
+
+---
+
+## Minimal example (Python + mido)
+
+```python
+import base64, time, threading
+import mido
+
+MFR = [0x00, 0x03, 0x45]
+ack = threading.Event()
+
+def on_msg(m):
+    if m.type == "sysex" and tuple(m.data[:3]) == (0x00, 0x03, 0x45):
+        tag = m.data[3]
+        if tag == 0x41 and m.data[4] == 0x4B:        # 'AK'
+            ack.set()
+        elif tag == 0x58:                             # 'X' error
+            print("sketch error:\n" + base64.b64decode(bytes(m.data[4:])).decode())
+
+inp  = mido.open_input("AMYboard", callback=on_msg)
+outp = mido.open_output("AMYboard")
+
+def send(payload: bytes, timeout=5.0):
+    ack.clear()
+    outp.send(mido.Message("sysex", data=MFR + list(payload)))
+    ack.wait(timeout)
+
+# upload a sketch
+code = b"import amy\nprint('hello from amyboard')\n"
+send(b"zPimport amy; amy.reset()Z")                  # clean slate
+send(("zT/user/current/sketch.py,%dZ" % len(code)).encode())
+for i in range(0, len(code), 188):
+    send(base64.b64encode(code[i:i+188]))
+send(b"zPimport amyboard; amyboard.environment_transfer_done()Z")  # restart
+
+# play a note
+outp.send(mido.Message("note_on",  note=60, velocity=100, channel=0))
+time.sleep(0.5)
+outp.send(mido.Message("note_off", note=60, channel=0))
+```
+
+For a fuller implementation — chunked transfers with per-chunk ACK, error
+collection, reboot/re-enumeration handling, state dump reassembly — see
+[`tools/amyworld_recorder/amyboard_link.py`](https://github.com/shorepine/tulipcc/blob/main/tools/amyworld_recorder/amyboard_link.py).
+
+---
+
+## Where this is implemented (source of truth)
+
+- **Transfer-layer command dispatch** (`zT`, `zD`, `zA`, `zP`, `zY`, `zF`, `zS`,
+  sample load): [`amy/src/parse.c`](https://github.com/shorepine/amy/blob/main/src/parse.c)
+  — `amy_parse_transfer_layer_message()`.
+- **Reboot / ping / SysEx intake** (`zB`, `zI`, the `00 03 45` gate):
+  [`amy/src/amy_midi.c`](https://github.com/shorepine/amy/blob/main/src/amy_midi.c) — `parse_sysex()`.
+- **File receive + base64 + state/file dump framing** (`C`/`E`/`0` markers):
+  [`amy/src/transfer.c`](https://github.com/shorepine/amy/blob/main/src/transfer.c).
+- **The `AK` ACK** (sent after each processed SysEx):
+  [`tulip/shared/modtulip.c`](https://github.com/shorepine/tulipcc/blob/main/tulip/shared/modtulip.c) — `tulip_amy_send_sysex()`.
+- **Sketch run / restart / error reporting (`X` frame) / version (`V` frame):**
+  [`tulip/shared/amyboard-py/amyboard.py`](https://github.com/shorepine/tulipcc/blob/main/tulip/shared/amyboard-py/amyboard.py).
+- **Reference host implementation (browser):**
+  [`tulip/amyboardweb/static/spss.js`](https://github.com/shorepine/tulipcc/blob/main/tulip/amyboardweb/static/spss.js).

--- a/tools/amyworld_recorder/.gitignore
+++ b/tools/amyworld_recorder/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+session_out/
+stitchtest/
+captest/
+*.mp4
+*.mov
+config.json
+__pycache__/

--- a/tools/amyworld_recorder/README.md
+++ b/tools/amyworld_recorder/README.md
@@ -1,0 +1,247 @@
+# AMYboard World recorder
+
+Tools to audition and record **every AMYboard World sketch** for a video: pull each
+sketch from the World API, push it onto a USB-connected AMYboard (the same SysEx
+"write to sketch" flow the web editor uses), record the iPhone (Continuity Camera) +
+a Mac audio input to a per-sketch clip, mark it good / not interesting / not working,
+then stitch the good ones into a montage with title/username/description overlays.
+
+Two scripts:
+
+- **`record.py`** — interactive capture session (one clip per sketch).
+- **`stitch.py`** — build the final montage from the good clips with ffmpeg; also
+  lists the broken sketches and the Python errors they hit.
+
+State lives in `<out>/session.json`, so you can stop any time and resume later —
+already-handled sketches are skipped.
+
+## Setup
+
+```bash
+cd tools/amyworld_recorder
+python3.13 -m venv .venv
+./.venv/bin/pip install -r requirements.txt
+```
+
+`ffmpeg`/`ffprobe` must be on `PATH` (`brew install ffmpeg`).
+
+The `./amyworld` wrapper runs either script with the venv:
+`./amyworld record …`, `./amyworld stitch …` (or call `./.venv/bin/python record.py …`).
+
+## Physical setup
+
+- AMYboard in your eurorack, connected to the Mac over USB (shows up as MIDI port
+  `AMYboard`).
+- iPhone pointed at it, connected via Continuity Camera (appears as an AVFoundation
+  video device).
+- AMYboard audio routed into a Mac audio input device (e.g. `Model 16`, `BlackHole`).
+  Video (iPhone) is captured with ffmpeg; **audio is captured with sounddevice
+  (PortAudio/CoreAudio), not ffmpeg**, then the two are muxed when you mark the
+  clip. This matters: ffmpeg's avfoundation audio input slips samples against the
+  device's USB clock — inaudible in silence but it **clicks on every signal**.
+  PortAudio follows the device clock exactly (measured: 0 glitches vs ~70 per take
+  with ffmpeg). A/V sync is approximate — fine for a synth-module shot; the audio
+  is the take that matters.
+
+  Note: ffmpeg-avfoundation and sounddevice use **different device numbering**, so
+  `audio_device` is matched against the sounddevice list — check `--list-devices`,
+  which prints both.
+- If the audio device is a multi-channel mixer/interface and the AMYboard is on a
+  specific channel pair (e.g. Tascam **Model 16 channels 13/14**), set
+  `audio_channels` (1-indexed) so only those channels are recorded:
+  `"audio_device": "Model 16", "audio_channels": [13, 14]`. Behind the scenes this
+  records the whole device and extracts those channels with an ffmpeg `pan` filter
+  (`pan=stereo|c0=c12|c1=c13`). One channel → dual-mono. Omit to capture the
+  device's default stereo. To find the right pair, capture all channels once and
+  check levels:
+  `ffmpeg -f avfoundation -i "none:Model 16" -t 5 all.wav` then
+  `ffmpeg -i all.wav -af astats=measure_overall=none:measure_perchannel=Peak_level -f null -`.
+
+## 1. Find your devices
+
+```bash
+./amyworld record --list-devices
+```
+
+Note the iPhone video device name and your audio device name. Copy
+`config.example.json` to `config.json` and set `video_device` / `audio_device`
+(name substring or numeric index both work):
+
+```json
+{ "video_device": "iPhone", "audio_device": "Model 16", "out_dir": "session_out" }
+```
+
+## 2. Record
+
+```bash
+./amyworld record --config config.json
+```
+
+For each sketch it downloads the code, starts the clip recording, pushes the sketch to
+the board, and shows:
+
+```
+[12/200] id=570  very_basic_pad_dx7.py  by generator
+  Very basic pad — DX7 strings patch …
+  ● recording -> clips/00570_very_basic_pad_dx7.mov
+  transfer: 4/4 frames acked
+  [g]ood  [n]ot interesting  [x] not working  |  [p]lay pattern  [s]top  [r]e-transfer  [i]nfo  [q]uit & save
+```
+
+Single keypress (no Enter):
+
+| key | action |
+|-----|--------|
+| `p` | play a random performance over MIDI so the synth sounds — walks a diatonic chord progression, alternating an arpeggio phase with a block chord (pattern, chord, pattern, chord…), with a random root/scale/direction/tempo each time |
+| `s` | stop the pattern |
+| `g` | mark **good**, stop recording, save, next |
+| `n` | mark **not interesting**, next |
+| `x` | mark **not working**, next |
+| `r` | re-transfer the sketch to the board |
+| `i` | print the sketch's Python source |
+| `d` | **denylist** this sketch (e.g. it hangs the board) — discards its clip and skips it on every future run |
+| `q` | stop the session (saves everything; this sketch stays pending) |
+
+### Denylist
+
+Some sketches hang or crash the board. Denylisted ids are **never transferred**
+again. The list lives in `<out>/denylist.json` (hand-editable). Manage it without
+the board/camera connected:
+
+```bash
+./amyworld record --deny 574 --deny-reason "hangs the board"   # add id(s): 574 or 574,575
+./amyworld record --list-denied                                # show the denylist
+./amyworld record --undeny 574                                 # remove id(s)
+```
+
+These run and exit. After denylisting, just start recording again as usual — the
+denied sketches are skipped. You can also press `d` during a session to denylist
+the current sketch on the fly.
+
+If a sketch fails to load, the board sends its **full Python traceback back over MIDI**
+and it's shown inline and saved — `x` is suggested automatically.
+
+Useful flags: `--tag official`, `--q reverb`, `--limit 50`, `--redo`,
+`--redo-status not_working` (retry only the broken ones), `--autoplay`,
+`--reset amy|reboot|none` (clean-slate strategy; `amy` resets the synth without a USB
+reboot — the default), `--amy-volume N`.
+
+**OLED between sketches** — by default each sketch load resets the OLED to the
+**AMYboard!!!** boot logo first (`oled_reset: "logo"`), so a previous sketch's
+leftover screen content doesn't carry over and confuse the shot. A sketch that
+draws its own screen still does (the reset happens just before it starts). Use
+`oled_reset: "clear"` to blank it instead, or `"none"` to leave it alone
+(`--oled-reset logo|clear|none`).
+
+**Recording level** — set `amy_volume` (config) or `--amy-volume N` to send
+`amy.send(volume=N)` right after each sketch starts, as a global boost so quiet
+patches record at a usable level. It's applied *after* the sketch's own init so it
+isn't clobbered. On our bench `volume=5` brought a default pad from ≈−24 dBFS to
+≈−15 dBFS on the captured channels. Leave it unset to keep each sketch's native
+level.
+
+### Watchdog (automatic)
+
+Every load ends with an inert liveness ping. If the just-started sketch has a
+runaway `loop()` that hangs the board, the ping gets no ACK → the recorder
+**auto-recovers** (`zB` reboot + factory reset), **denylists** that sketch, marks
+it `not_working`, and moves on — so one bad sketch can't stall an unattended
+session. The transfer also aborts early instead of waiting out a 5 s timeout on
+every frame when the board is unresponsive. Disable the auto-denylist with
+`--no-denylist-on-wedge` (it still recovers, just doesn't denylist).
+
+### Recovering a wedged board (manual)
+
+Some sketches have a runaway `loop()` that eats the CPU, so the board stops
+accepting new sketches (`zP`/`zT` can't get scheduler time). `zB` is handled in
+pure C on the MIDI task, so it reboots the board **even when the loop is hogging
+the scheduler**. To unstick it:
+
+```bash
+./amyworld record --recover            # zB reboot (skips the bad sketch) + factory reset to the default sketch
+./amyworld record --recover --no-factory-reset   # just free it; leave sketch.py as-is
+```
+
+`--recover` reboots skipping the bad sketch, waits for USB to re-enumerate, and
+(by default) overwrites `sketch.py` with the safe default so a later power-cycle
+won't re-run the bad one. Then start recording again as usual. Denylist the
+offender so it isn't reloaded: `./amyworld record --deny <id>`. If `--recover`
+reports the board didn't come back, physically power-cycle (unplug/replug USB).
+
+## 3. Review the broken ones
+
+```bash
+./amyworld stitch broken --session session_out     # ids + captured Python errors
+./amyworld stitch list   --session session_out --status good
+```
+
+## External-video mode (phone films the whole session)
+
+If Continuity capture flickers the OLED (an iPhone shutter/exposure issue that
+can't be fixed through ffmpeg), film the session on the phone with a manual-shutter
+app (~1/60 s) instead, and let the recorder sync it up afterward.
+
+How it works: the recorder captures only the **clean Model 16 audio** per sketch
+(no video) and plays a two-pulse **sync beep** on the AMYboard at each sketch. That
+beep lands in both the clean clip and the phone's audio, so the stitcher finds each
+sketch's exact position in the long phone video by detecting the beeps.
+
+```bash
+# 1. record — pass --external-video (or "capture_video": false in config)
+./amyworld record --config config.json --external-video
+#    → it prompts you to START the phone filming, then run the session as usual.
+#      Keep the phone recording running the WHOLE time; keep the AMYboard audible
+#      to the phone (even roomy audio is fine — it's only used to find the beeps).
+
+# 2. build — point it at your phone video; it syncs by beep and uses the clean audio
+./amyworld stitch sync --session session_out --phone-video ~/Movies/session.mov --out montage.mp4
+```
+
+**Multiple runs / multiple videos.** The session and its beep counter persist, so
+you can stop and resume across several sittings — but start a **fresh phone
+recording for each run** (it's a new video). At stitch time, pass **all** the
+videos **in run order**; each beep lands in exactly one video, so they line up 1:1
+with the recorded beeps:
+
+```bash
+./amyworld stitch sync --session session_out \
+    --phone-video ~/Movies/run1.mov ~/Movies/run2.mov ~/Movies/run3.mov \
+    --out montage.mp4
+```
+
+`sync` prints the beeps found per video and the total vs recorded — if they match,
+alignment is exact; a mismatch means a missed/extra beep shifted things (rare).
+Everything else (overlays, denylist, watchdog, OLED reset, volume) works the same.
+`--tail N` trims N seconds off each clip's end.
+
+## 4. Build the montage (Continuity/on-Mac capture)
+
+```bash
+./amyworld stitch plan   --session session_out      # writes session_out/clips.json
+# edit clips.json: reorder, set "enabled": false to drop one,
+#                  set "in"/"out" (seconds) to trim each clip
+./amyworld stitch render --session session_out --out montage.mp4
+```
+
+`plan` lists every **good** clip in capture order, pre-filling each `in` point with the
+moment you first hit `p` (so the silent transfer head is skipped). Reorder / disable /
+trim freely, then `render`.
+
+Render flags: `--portrait` (1080×1920), `--width/--height`, `--fps`, `--title-size`,
+`--meta-size`, `--title-seconds N` (show the overlay only for the first N seconds),
+`--font /path/to.ttf`.
+
+## How the transfer works
+
+Verified against the tree (`spss.js`, `modtulip.c`, `amy/src/transfer.c`,
+`amyboard.py`). All control frames are MIDI SysEx `F0 00 03 45 … F7`:
+
+- `zT<path>,<size>Z` then base64 chunks (≤188 raw bytes each) → writes
+  `/user/current/sketch.py`; `zP import amyboard; amyboard.environment_transfer_done()Z`
+  restarts the sketch.
+- The board ACKs every SysEx (`F0 00 03 45 'A' 'K' F7`); we wait for each ACK before
+  sending the next frame (one in flight), exactly like the web editor.
+- Sketch load errors come back as `F0 00 03 45 'X' <base64 traceback> F7`.
+- Patterns play via ordinary MIDI note on/off on channel 1.
+
+`amyboard_link.py` is a standalone, importable client for all of this.

--- a/tools/amyworld_recorder/amyboard_link.py
+++ b/tools/amyworld_recorder/amyboard_link.py
@@ -1,0 +1,329 @@
+"""AMYboard USB-MIDI link.
+
+Replicates the AMYboard Web "write to sketch" SysEx protocol so we can push an
+AMYboard World sketch onto a physically connected board over USB MIDI, exactly
+the way the web editor's `_send_text_file_to_amyboard()` does.
+
+Protocol (verified against the tree):
+  - tulip/amyboardweb/static/spss.js  (sysex_write_amy_message, _send_text_file_to_amyboard)
+  - tulip/shared/modtulip.c           (tulip_amy_send_sysex -> the 'AK' ACK)
+  - amy/src/transfer.c, amy/src/parse.c (zT file receive + base64 decode)
+  - tulip/shared/amyboard-py/amyboard.py (environment_transfer_done, _report_sketch_error)
+
+All control frames are MIDI SysEx framed F0 <mfr> <ascii payload> F7, mfr = 00 03 45.
+
+  Host -> board payloads:
+    zBZ                      reboot into "skip sketch" bootloader (USB re-enumerates)
+    zT<path>,<size>Z         begin a file transfer; size = raw byte count
+    <base64>                 one file chunk (<=188 raw bytes, base64-encoded), repeated
+    zP<python>Z              run one line of python on the board
+
+  Board -> host frames:
+    F0 00 03 45 'A' 'K' F7   ACK, sent after the board finishes processing each sysex
+    F0 00 03 45 'X' <b64> F7 sketch load error: base64 of a python traceback
+    F0 00 03 45 'V' <ascii>  firmware version string
+
+The board ACKs every sysex it processes, so we send one frame and wait for its ACK
+before sending the next (single message in flight) — this is what keeps the board's
+sysex ring buffer from overflowing. Standard MIDI note on/off are channel-voice
+messages (not sysex), are not ACKed, and make the loaded synth play.
+"""
+
+import base64
+import threading
+import time
+
+import mido
+
+MFR = [0x00, 0x03, 0x45]
+MFR_T = (0x00, 0x03, 0x45)
+CHUNK_BYTES = 188          # AMYBOARD_TRANSFER_CHUNK_BYTES in spss.js
+ACK_TIMEOUT = 5.0          # spss.js waits 5s for the ACK then proceeds anyway
+DEFAULT_PORT_MATCH = "amyboard"
+SKETCH_PATH = "/user/current/sketch.py"
+
+TAG_ACK = 0x41      # 'A' (followed by 'K')
+TAG_ERROR = 0x58    # 'X'
+TAG_VERSION = 0x56  # 'V'
+
+
+def find_port(names, match):
+    """Return the first port name containing `match` (case-insensitive)."""
+    match = match.lower()
+    for n in names:
+        if match in n.lower():
+            return n
+    return None
+
+
+class SketchError(Exception):
+    pass
+
+
+class AMYboardLink:
+    def __init__(self, port_match=DEFAULT_PORT_MATCH, verbose=True):
+        self.port_match = port_match
+        self.verbose = verbose
+        self.inport = None
+        self.outport = None
+        self._ack = threading.Event()
+        self._lock = threading.Lock()
+        self.errors = []      # decoded sketch-error tracebacks since last clear
+        self.version = None
+        self.in_name = None
+        self.out_name = None
+
+    # -- connection ---------------------------------------------------------
+    def open(self):
+        self.in_name = find_port(mido.get_input_names(), self.port_match)
+        self.out_name = find_port(mido.get_output_names(), self.port_match)
+        if not self.in_name or not self.out_name:
+            raise RuntimeError(
+                "Could not find an AMYboard MIDI port (match=%r).\n  inputs:  %s\n  outputs: %s"
+                % (self.port_match, mido.get_input_names(), mido.get_output_names()))
+        self.outport = mido.open_output(self.out_name)
+        self.inport = mido.open_input(self.in_name, callback=self._on_message)
+        self._log("connected: in=%r out=%r" % (self.in_name, self.out_name))
+        return self
+
+    def close(self):
+        for p in (self.inport, self.outport):
+            try:
+                if p:
+                    p.close()
+            except Exception:
+                pass
+        self.inport = self.outport = None
+
+    def __enter__(self):
+        return self.open()
+
+    def __exit__(self, *a):
+        self.close()
+
+    # -- incoming sysex -----------------------------------------------------
+    def _on_message(self, msg):
+        if msg.type != "sysex":
+            return
+        data = msg.data  # tuple of the bytes between F0 and F7
+        if len(data) < 4 or tuple(data[:3]) != MFR_T:
+            return
+        tag = data[3]
+        if tag == TAG_ACK and len(data) >= 5 and data[4] == 0x4B:
+            self._ack.set()
+        elif tag == TAG_ERROR:
+            try:
+                text = base64.b64decode(bytes(data[4:])).decode("utf-8", "replace").strip()
+            except Exception:
+                text = "<undecodable sketch error frame>"
+            self.errors.append(text)
+            self._log("  ⚠ sketch error frame received (%d bytes)" % len(text))
+        elif tag == TAG_VERSION:
+            self.version = bytes(data[4:]).decode("ascii", "replace").strip()
+
+    # -- outgoing -----------------------------------------------------------
+    def _send_sysex(self, payload):
+        """Send one raw sysex frame; payload is a bytes/list of 7-bit values."""
+        self.outport.send(mido.Message("sysex", data=MFR + list(payload)))
+
+    def send_and_ack(self, payload, timeout=ACK_TIMEOUT):
+        """Send one sysex frame and wait for the board's ACK. Returns True if acked."""
+        with self._lock:
+            self._ack.clear()
+            self._send_sysex(payload)
+            got = self._ack.wait(timeout)
+        return got
+
+    def send_python(self, code, timeout=ACK_TIMEOUT):
+        """Run one line of python on the board via zP. Returns True if acked."""
+        return self.send_and_ack(b"zP" + code.encode("utf-8") + b"Z", timeout=timeout)
+
+    def ping(self, timeout=2.5):
+        """Inert liveness check. A runaway sketch loop() starves the MicroPython
+        scheduler, so this zP won't get ACKed when the board is wedged."""
+        return self.send_and_ack(b"zPpassZ", timeout=timeout)
+
+    # -- high level ---------------------------------------------------------
+    def reset_amy(self):
+        """Clear all AMY oscillators for a clean slate (no USB re-enumeration)."""
+        return self.send_python("import amy; amy.reset()")
+
+    def reboot_bootloader(self):
+        """Send zB: reboot into skip-sketch mode. The board's USB re-enumerates;
+        no ACK comes back. Follow with wait_for_ready()."""
+        self._send_sysex(b"zBZ")
+
+    def recover(self, factory_reset=True, timeout=20):
+        """Unstick a board wedged by a runaway sketch loop(). zB is handled in
+        pure C on the MIDI task, so it reboots even when loop() is hogging the
+        MicroPython scheduler and normal zP/zT can't get through. Reboots skipping
+        the bad sketch, waits for re-enumeration, then (optionally) factory_resets
+        so a later power-cycle won't re-run the bad sketch.py. Returns True if the
+        board came back."""
+        self.reboot_bootloader()
+        ok = self.wait_for_ready(timeout=timeout)
+        if ok and factory_reset:
+            self.send_python("import amyboard; amyboard.factory_reset()")
+        return ok
+
+    def wait_for_ready(self, timeout=12.0):
+        """After a zB reboot, wait for the AMYboard MIDI port to drop and come
+        back, then reconnect. Returns True on success."""
+        self.close()
+        deadline = time.time() + timeout
+        # wait for it to disappear (best effort, short)
+        t = time.time() + 3.0
+        while time.time() < t:
+            if not find_port(mido.get_output_names(), self.port_match):
+                break
+            time.sleep(0.2)
+        # wait for it to come back
+        while time.time() < deadline:
+            if find_port(mido.get_output_names(), self.port_match) and \
+               find_port(mido.get_input_names(), self.port_match):
+                time.sleep(1.0)  # settle
+                try:
+                    self.open()
+                    return True
+                except Exception:
+                    pass
+            time.sleep(0.3)
+        return False
+
+    def transfer_file(self, text, path=SKETCH_PATH, progress=None, max_consecutive_timeouts=3):
+        """Send a text file to the board (zT header + base64 chunks). Returns
+        (chunks_sent, chunks_acked). Aborts early if the board stops ACKing for
+        `max_consecutive_timeouts` frames in a row (it's wedged) — otherwise a
+        hung board would make every frame wait out its full 5 s timeout."""
+        data = text.encode("utf-8")
+        size = len(data)
+        header = "zT%s,%dZ" % (path, size)
+        ok = self.send_and_ack(header.encode("utf-8"))
+        acked = 1 if ok else 0
+        sent = 1
+        consecutive = 0 if ok else 1
+        n_chunks = (size + CHUNK_BYTES - 1) // CHUNK_BYTES
+        for i in range(n_chunks):
+            if consecutive >= max_consecutive_timeouts:
+                break  # board not responding — abort rather than wait out every frame
+            chunk = data[i * CHUNK_BYTES:(i + 1) * CHUNK_BYTES]
+            b64 = base64.b64encode(chunk)
+            ok = self.send_and_ack(b64)
+            sent += 1
+            if ok:
+                acked += 1
+                consecutive = 0
+            else:
+                consecutive += 1
+            if progress:
+                progress(i + 1, n_chunks)
+        return sent, acked
+
+    def environment_transfer_done(self):
+        """Tell the board the sketch.py transfer is complete and (re)start it."""
+        return self.send_python("import amyboard; amyboard.environment_transfer_done()")
+
+    def restart_sketch(self):
+        return self.send_python("import amyboard; amyboard.restart_sketch()")
+
+    def set_volume(self, volume):
+        """Set AMY's global output volume (amy.send(volume=...))."""
+        return self.send_python("import amy; amy.send(volume=%g)" % float(volume))
+
+    # sync marker: two short high sine pulses, played on a spare AMY oscillator
+    # (so it sounds the same regardless of the loaded sketch's patch). Used to
+    # locate each sketch inside an externally-recorded phone video.
+    BEEP_FREQ = 3520
+    BEEP_OSC = 62
+
+    def beep(self, pulses=2, ms=100, gap_ms=80):
+        for i in range(pulses):
+            self.send_python("import amy; amy.send(osc=%d,wave=0,freq=%d,amp=1,vel=1)"
+                             % (self.BEEP_OSC, self.BEEP_FREQ))
+            time.sleep(ms / 1000.0)
+            self.send_python("import amy; amy.send(osc=%d,vel=0)" % self.BEEP_OSC)
+            if i < pulses - 1:
+                time.sleep(gap_ms / 1000.0)
+
+    def reset_display(self, mode="logo"):
+        """Reset the OLED between sketches so the previous sketch's leftover
+        screen contents don't persist.
+          'logo'  -> re-init the display and show the AMYboard!!! boot logo
+          'clear' -> blank the screen
+          'none'  -> do nothing
+        """
+        if mode == "logo":
+            # init_display() makes a fresh (blank) framebuffer and draws the logo.
+            return self.send_python("import amyboard; amyboard.init_display()")
+        if mode == "clear":
+            return self.send_python("import amyboard as A; A.display.clear() if A.display else None")
+        return None
+
+    def load_sketch(self, text, reset="amy", error_wait=1.5, progress=None, volume=None,
+                    display_reset="logo", liveness_timeout=2.5):
+        """Push a sketch and start it, mirroring the web World-import flow.
+
+        reset: 'amy'    -> amy.reset() first (clean slate, no re-enumeration; default)
+               'reboot' -> full zB reboot + wait_for_ready (guaranteed clean slate)
+               'none'   -> just transfer over whatever is running
+        volume: if set, send amy.send(volume=...) AFTER the sketch restarts (so the
+                sketch's own init can't clobber it) — a global recording-level boost.
+        display_reset: reset the OLED just BEFORE the sketch restarts so leftover
+                screen content doesn't carry over ('logo' | 'clear' | 'none').
+        Returns a dict: {acked, sent, ready, errors:[traceback,...], wedged}.
+        Sketch-load errors arrive asynchronously after the restart, so we wait
+        `error_wait` seconds and collect any 'X' frames. `wedged` is True if the
+        just-started sketch hung the board (no response to a liveness ping) — the
+        caller should recover() and denylist it.
+        """
+        self.clear_errors()
+        ready = True
+        if reset == "reboot":
+            self.reboot_bootloader()
+            ready = self.wait_for_ready()
+            if not ready or not self.outport:
+                return {"sent": 0, "acked": 0, "ready": False,
+                        "errors": ["board did not re-enumerate after reboot; "
+                                   "reconnect USB or use --reset amy"]}
+        elif reset == "amy":
+            self.reset_amy()
+        sent, acked = self.transfer_file(text, progress=progress)
+        if display_reset and display_reset != "none":
+            # before the restart: the new sketch can still draw over it
+            self.reset_display(display_reset)
+        self.environment_transfer_done()
+        if volume is not None:
+            self.set_volume(volume)
+        time.sleep(error_wait)
+        errs = self.drain_errors()
+        # watchdog: if the sketch we just started has a runaway loop(), it starves
+        # the scheduler and this inert ping won't be ACKed.
+        wedged = not self.ping(timeout=liveness_timeout)
+        return {"sent": sent, "acked": acked, "ready": ready, "errors": errs, "wedged": wedged}
+
+    # -- notes (make the synth play) ----------------------------------------
+    def note_on(self, note, velocity=100, channel=0):
+        self.outport.send(mido.Message("note_on", note=note, velocity=velocity, channel=channel))
+
+    def note_off(self, note, channel=0):
+        self.outport.send(mido.Message("note_off", note=note, velocity=0, channel=channel))
+
+    def all_notes_off(self, channel=0):
+        # CC 123 = all notes off; also blast explicit note_offs as a fallback.
+        try:
+            self.outport.send(mido.Message("control_change", control=123, value=0, channel=channel))
+        except Exception:
+            pass
+
+    # -- errors -------------------------------------------------------------
+    def clear_errors(self):
+        self.errors = []
+        self.version = None
+
+    def drain_errors(self):
+        errs, self.errors = self.errors, []
+        return errs
+
+    def _log(self, msg):
+        if self.verbose:
+            print(msg)

--- a/tools/amyworld_recorder/amyworld
+++ b/tools/amyworld_recorder/amyworld
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Convenience wrapper: runs the recorder tools with the bundled venv so you
+# don't have to activate it. Usage:
+#   ./amyworld record  --list-devices
+#   ./amyworld record  --config config.json
+#   ./amyworld stitch  plan --session session_out
+#   ./amyworld stitch  render --session session_out --out montage.mp4
+set -euo pipefail
+here="$(cd "$(dirname "$0")" && pwd)"
+py="$here/.venv/bin/python"
+if [ ! -x "$py" ]; then
+  echo "venv missing — create it with:"
+  echo "  python3.13 -m venv $here/.venv && $here/.venv/bin/pip install -r $here/requirements.txt"
+  exit 1
+fi
+tool="${1:-}"; shift || true
+case "$tool" in
+  record) exec "$py" "$here/record.py" "$@" ;;
+  stitch) exec "$py" "$here/stitch.py" "$@" ;;
+  *) echo "usage: amyworld {record|stitch} [args...]"; exit 1 ;;
+esac

--- a/tools/amyworld_recorder/beepsync.py
+++ b/tools/amyworld_recorder/beepsync.py
@@ -1,0 +1,90 @@
+"""Detect the AMYboard sync-beep markers in an audio track.
+
+The recorder plays a two-pulse sine marker (see AMYboardLink.beep) at each
+sketch. This finds those markers in an externally-recorded video's audio so the
+stitcher can locate each sketch on the phone timeline. Detection keys on both the
+marker frequency (a Goertzel magnitude at BEEP_FREQ) and the two-pulse *timing*,
+so ordinary bright synth content doesn't false-trigger.
+"""
+
+import numpy as np
+
+BEEP_FREQ = 3520.0
+
+
+def _goertzel_env(x, sr, freq, hop):
+    """Magnitude of `freq` over non-overlapping `hop`-sample windows."""
+    n = len(x) // hop
+    if n == 0:
+        return np.zeros(0)
+    x = x[:n * hop].reshape(n, hop).astype(np.float64)
+    t = np.arange(hop) / sr
+    ref = np.exp(-2j * np.pi * freq * t)
+    return np.abs(x @ ref) / hop
+
+
+def detect_beeps(audio, sr, freq=BEEP_FREQ, pulse_ms=100, gap_ms=80,
+                 hop_ms=10, rel_thresh=0.35):
+    """Return marker start times (seconds). `audio` is a mono float/int array.
+
+    A marker = two ~pulse_ms bursts of `freq` energy separated by ~gap_ms of
+    quiet. We find bursts (contiguous above-threshold runs) then keep pairs whose
+    durations and spacing match the marker shape."""
+    a = np.asarray(audio, dtype=np.float64)
+    if a.size == 0:
+        return []
+    hop = max(1, int(sr * hop_ms / 1000.0))
+    env = _goertzel_env(a, sr, freq, hop)
+    if env.size == 0:
+        return []
+    # robust threshold: fraction of the loud-marker level (95th pct is ~marker)
+    hi = np.percentile(env, 99)
+    if hi <= 0:
+        return []
+    thr = hi * rel_thresh
+    above = env > thr
+
+    # contiguous above-threshold runs -> bursts (start_frame, end_frame)
+    bursts = []
+    i = 0
+    while i < len(above):
+        if above[i]:
+            j = i
+            while j < len(above) and above[j]:
+                j += 1
+            bursts.append((i, j))
+            i = j
+        else:
+            i += 1
+
+    def sec(frame):
+        return frame * hop / sr
+
+    pulse_s = pulse_ms / 1000.0
+    gap_s = gap_ms / 1000.0
+    markers = []
+    used = -1
+    for k in range(len(bursts) - 1):
+        if k <= used:
+            continue
+        b0, e0 = bursts[k]
+        b1, e1 = bursts[k + 1]
+        d0, d1 = sec(e0) - sec(b0), sec(e1) - sec(b1)
+        gap = sec(b1) - sec(e0)
+        # each burst roughly a pulse, and the gap roughly the marker gap
+        if (0.4 * pulse_s < d0 < 2.5 * pulse_s and
+                0.4 * pulse_s < d1 < 2.5 * pulse_s and
+                0.2 * gap_s < gap < 3.0 * gap_s):
+            markers.append(sec(b0))
+            used = k + 1
+    return markers
+
+
+def load_audio_mono(path, sr=8000):
+    """Decode any media file's audio to a mono numpy array at `sr` via ffmpeg."""
+    import subprocess
+    p = subprocess.run(
+        ["ffmpeg", "-v", "error", "-i", path, "-map", "0:a:0",
+         "-ac", "1", "-ar", str(sr), "-f", "s16le", "-"],
+        capture_output=True)
+    return np.frombuffer(p.stdout, dtype=np.int16).astype(np.float64), sr

--- a/tools/amyworld_recorder/capture.py
+++ b/tools/amyworld_recorder/capture.py
@@ -1,0 +1,316 @@
+"""Per-clip A/V capture.
+
+Video (iPhone / Continuity Camera) is captured with ffmpeg's avfoundation input.
+Audio is captured with sounddevice (PortAudio/CoreAudio), NOT ffmpeg — ffmpeg's
+avfoundation audio input slips samples against the device's USB clock, which is
+inaudible in silence but clicks on every signal. PortAudio follows the device
+clock exactly (verified: 0 discontinuities vs ~70 for ffmpeg on the same signal).
+The two are muxed into one clip when the take is marked.
+
+Video and audio devices are matched by name at run time (their indices can move),
+but note ffmpeg-avfoundation and sounddevice each have their OWN device numbering.
+"""
+
+import os
+import queue
+import re
+import subprocess
+import threading
+import time
+import wave
+
+import numpy as np
+import sounddevice as sd
+
+
+def list_avfoundation_devices():
+    """Return (video, audio) dicts mapping index -> name."""
+    p = subprocess.run(
+        ["ffmpeg", "-hide_banner", "-f", "avfoundation", "-list_devices", "true", "-i", ""],
+        capture_output=True, text=True)
+    out = p.stderr
+    video, audio, section = {}, {}, None
+    for line in out.splitlines():
+        if "AVFoundation video devices" in line:
+            section = video
+            continue
+        if "AVFoundation audio devices" in line:
+            section = audio
+            continue
+        m = re.search(r"\]\s*\[(\d+)\]\s+(.*)$", line)
+        if m and section is not None:
+            section[int(m.group(1))] = m.group(2).strip()
+    return video, audio
+
+
+def resolve_device(devices, want):
+    """Resolve `want` (an int index, a numeric string, or a name substring) to an
+    avfoundation index using the {index:name} map `devices`."""
+    if want is None:
+        return None
+    s = str(want)
+    if s.isdigit() and int(s) in devices:
+        return int(s)
+    low = s.lower()
+    for idx, name in devices.items():
+        if low in name.lower():
+            return idx
+    return None
+
+
+def find_iphone(video_devices):
+    """Best-effort auto-detect of a Continuity Camera video device."""
+    for pat in ("iphone", "continuity", "desk view"):
+        for idx, name in video_devices.items():
+            if pat in name.lower():
+                return idx
+    return None
+
+
+def _rm(p):
+    try:
+        if p and os.path.exists(p):
+            os.remove(p)
+    except OSError:
+        pass
+
+
+# --------------------------------------------------------------------------
+# audio devices + capture (sounddevice / PortAudio / CoreAudio)
+# --------------------------------------------------------------------------
+def list_sd_audio_devices():
+    """Return {index: name} of sounddevice INPUT devices."""
+    out = {}
+    for i, d in enumerate(sd.query_devices()):
+        if d.get("max_input_channels", 0) > 0:
+            out[i] = d["name"]
+    return out
+
+
+def resolve_sd_audio(want):
+    """Resolve `want` (int index, numeric string, or name substring) to a
+    sounddevice input-device index."""
+    if want is None:
+        return None
+    devs = list_sd_audio_devices()
+    s = str(want)
+    if s.isdigit() and int(s) in devs:
+        return int(s)
+    low = s.lower()
+    for idx, name in devs.items():
+        if low in name.lower():
+            return idx
+    return None
+
+
+class SdAudioRecorder:
+    """Records `channels` (1-indexed device channels, e.g. [13, 14]) from a
+    sounddevice input device to a PCM WAV file, until stop(). The audio callback
+    only enqueues frames; a writer thread does the file I/O so the realtime
+    callback never blocks."""
+
+    def __init__(self, device_idx, channels=None, samplerate=48000):
+        self.device_idx = device_idx
+        self.want = [c - 1 for c in channels] if channels else [0, 1]  # 0-based
+        self.open_ch = max(self.want) + 1   # PortAudio opens channels 1..open_ch
+        self.samplerate = samplerate
+        self.stream = None
+        self.wav = None
+        self._q = queue.Queue()
+        self._stop = threading.Event()
+        self._writer = None
+        self.xruns = 0
+
+    def start(self, path):
+        self.wav = wave.open(path, "wb")
+        self.wav.setnchannels(len(self.want))
+        self.wav.setsampwidth(2)      # int16
+        self.wav.setframerate(self.samplerate)
+
+        def cb(indata, frames, time_info, status):
+            if status:
+                self.xruns += 1
+            self._q.put(indata[:, self.want].copy())
+
+        self.stream = sd.InputStream(
+            device=self.device_idx, channels=self.open_ch,
+            samplerate=self.samplerate, dtype="int16", latency="high", callback=cb)
+        self._writer = threading.Thread(target=self._drain, daemon=True)
+        self._writer.start()
+        self.stream.start()
+
+    def _drain(self):
+        while not self._stop.is_set() or not self._q.empty():
+            try:
+                block = self._q.get(timeout=0.2)
+            except queue.Empty:
+                continue
+            self.wav.writeframesraw(block.tobytes())
+
+    def stop(self):
+        if self.stream:
+            try:
+                self.stream.stop()
+                self.stream.close()
+            except Exception:
+                pass
+            self.stream = None
+        self._stop.set()
+        if self._writer:
+            self._writer.join(timeout=5)
+            self._writer = None
+        if self.wav:
+            self.wav.close()
+            self.wav = None
+
+
+class ClipRecorder:
+    def __init__(self, video_idx, audio_idx, framerate=30, video_size=None,
+                 log_dir=None, vbitrate="8M", audio_channels=None):
+        self.video_idx = video_idx
+        self.audio_idx = audio_idx
+        self.audio_channels = audio_channels  # 1-indexed list, e.g. [13, 14]
+        self.framerate = framerate
+        self.video_size = video_size  # e.g. "1280x720"; None = device default
+        self.log_dir = log_dir
+        self.vbitrate = vbitrate
+        self.path = None
+        self.started_at = None
+        # Video is captured by ffmpeg (avfoundation); audio by sounddevice
+        # (PortAudio). They are muxed at stop(). ffmpeg's avfoundation AUDIO
+        # input slips samples vs the device clock (clicks on signal), so audio
+        # must NOT go through ffmpeg — see module docstring. video_idx is an
+        # ffmpeg-avfoundation index; audio_idx is a sounddevice index.
+        self.vproc = None
+        self.arec = None
+        self._vlog = None
+        self._vtmp = self._atmp = None
+
+    def _video_cmd(self, out):
+        cmd = ["ffmpeg", "-hide_banner", "-y", "-thread_queue_size", "1024",
+               "-f", "avfoundation", "-framerate", str(self.framerate)]
+        if self.video_size:
+            cmd += ["-video_size", self.video_size]
+        cmd += ["-i", "%d:none" % self.video_idx,
+                "-c:v", "h264_videotoolbox", "-b:v", self.vbitrate,
+                "-pix_fmt", "yuv420p", out]
+        return cmd
+
+    def _open_log(self, name):
+        if not self.log_dir:
+            return None, subprocess.DEVNULL
+        os.makedirs(self.log_dir, exist_ok=True)
+        p = os.path.join(self.log_dir, name)
+        f = open(p, "wb")
+        return f, f
+
+    def start(self, path):
+        os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+        self.path = path
+        base = os.path.basename(path)
+        # Start audio first (it's the take that matters), then video right after.
+        if self.audio_idx is not None:
+            self._atmp = path + ".audio.wav"
+            self.arec = SdAudioRecorder(self.audio_idx, channels=self.audio_channels)
+            try:
+                self.arec.start(self._atmp)
+            except Exception as e:
+                self.arec = None
+                raise RuntimeError("audio capture failed to start on device %r: %s"
+                                   % (self.audio_idx, e))
+        self.started_at = time.time()
+        # video_idx None == audio-only mode (video comes from an external camera
+        # recorded separately; we just capture the clean audio here).
+        if self.video_idx is not None:
+            self._vtmp = path + ".video.mp4"
+            self._vlog, vsink = self._open_log(base + ".video.log")
+            self.vproc = subprocess.Popen(self._video_cmd(self._vtmp),
+                                          stdin=subprocess.PIPE, stdout=vsink, stderr=vsink)
+            time.sleep(0.6)  # liveness: if video ffmpeg dies, device/permission is wrong
+            if self.vproc.poll() is not None:
+                if self.arec:
+                    self.arec.stop()
+                raise RuntimeError(
+                    "video ffmpeg exited immediately (rc=%s). Check device index/permission; see %s"
+                    % (self.vproc.returncode, self.log_dir or "stderr"))
+        return self
+
+    def elapsed(self):
+        return time.time() - self.started_at if self.started_at else 0.0
+
+    @staticmethod
+    def _quit(proc):
+        if not proc:
+            return
+        if proc.poll() is None:
+            try:
+                proc.stdin.write(b"q")
+                proc.stdin.flush()
+            except Exception:
+                pass
+            try:
+                proc.wait(timeout=8)
+            except subprocess.TimeoutExpired:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=4)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+
+    def stop(self, discard=False):
+        """Stop both recordings, mux video+audio into one clip, return its path
+        (or None if discarded)."""
+        if self.arec:
+            self.arec.stop()
+        self._quit(self.vproc)
+        try:
+            if self._vlog:
+                self._vlog.close()
+        except Exception:
+            pass
+        self._vlog = None
+        path = self.path
+        vtmp, atmp = self._vtmp, self._atmp
+        self.arec = None
+        self.vproc = None
+
+        if discard:
+            for t in (vtmp, atmp, path):
+                _rm(t)
+            return None
+
+        # audio-only mode (no video device): the clip IS the clean audio.
+        if self.video_idx is None:
+            if atmp and os.path.exists(atmp):
+                enc = ["ffmpeg", "-hide_banner", "-y", "-i", atmp,
+                       "-c:a", "aac", "-b:a", "256k", "-ar", "48000", "-ac", "2",
+                       "-movflags", "+faststart", path]
+                rc = subprocess.run(enc, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode
+                if rc == 0:
+                    _rm(atmp)
+                    return path
+                os.replace(atmp, path)  # fall back to raw wav under the clip name
+                return path
+            return None
+
+        if atmp and os.path.exists(atmp) and vtmp and os.path.exists(vtmp):
+            # Mux: copy video, encode the clean PCM audio to AAC. -shortest trims
+            # any small length difference from the two independent clocks.
+            mux = ["ffmpeg", "-hide_banner", "-y", "-i", vtmp, "-i", atmp,
+                   "-map", "0:v:0", "-map", "1:a:0", "-c:v", "copy",
+                   "-c:a", "aac", "-b:a", "256k", "-ar", "48000", "-ac", "2",
+                   "-shortest", "-movflags", "+faststart", path]
+            rc = subprocess.run(mux, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode
+            if rc == 0:
+                _rm(vtmp)
+                _rm(atmp)
+                return path
+            # mux failed — fall back to the video-only file so the take isn't lost
+            if os.path.exists(vtmp):
+                os.replace(vtmp, path)
+            _rm(atmp)
+            return path
+        # video-only (no audio device configured)
+        if vtmp and os.path.exists(vtmp):
+            os.replace(vtmp, path)
+        return path if path and os.path.exists(path) else None

--- a/tools/amyworld_recorder/config.example.json
+++ b/tools/amyworld_recorder/config.example.json
@@ -1,0 +1,24 @@
+{
+  "api_base": "https://tulipcc-production.up.railway.app",
+  "out_dir": "session_out",
+
+  "capture_video": true,
+  "video_device": "iPhone",
+  "audio_device": "Model 16",
+  "audio_channels": [13, 14],
+
+  "midi_match": "amyboard",
+  "reset": "amy",
+  "oled_reset": "logo",
+  "denylist_on_wedge": true,
+  "amy_volume": 2,
+  "channel": 0,
+
+  "limit": 1000,
+  "tag": "",
+  "q": "",
+
+  "framerate": 30,
+  "video_size": null,
+  "autoplay": false
+}

--- a/tools/amyworld_recorder/patterns.py
+++ b/tools/amyworld_recorder/patterns.py
@@ -1,0 +1,160 @@
+"""Random musical patterns to audition a loaded AMYboard sketch.
+
+A PatternPlayer runs in its own thread and sends MIDI note on/off to the board
+(channel 1 by default — what the World sketches listen on) until stopped. It walks
+a short diatonic chord progression and, for each chord, plays an **arpeggio phase**
+followed by a **block-chord phase** — so you hear pattern, chord, pattern, chord…
+Each performance picks a random root, scale, arp direction, tempo and progression.
+"""
+
+import random
+import threading
+
+SCALES = {
+    "major":          [0, 2, 4, 5, 7, 9, 11],
+    "minor":          [0, 2, 3, 5, 7, 8, 10],
+    "dorian":         [0, 2, 3, 5, 7, 9, 10],
+    "phrygian":       [0, 1, 3, 5, 7, 8, 10],
+    "lydian":         [0, 2, 4, 6, 7, 9, 11],
+    "mixolydian":     [0, 2, 4, 5, 7, 9, 10],
+    "harmonic_minor": [0, 2, 3, 5, 7, 8, 11],
+}
+
+# Arp direction within the arpeggio phase.
+STYLES = ["up", "down", "updown", "random_walk"]
+
+# Chord progressions as 0-indexed scale degrees (I=0, ii=1, … vi=5).
+PROGRESSIONS = [
+    [0, 4, 5, 3],   # I  V  vi IV
+    [0, 5, 3, 4],   # I  vi IV V
+    [5, 3, 0, 4],   # vi IV I  V
+    [0, 3, 4, 0],   # I  IV V  I
+    [0, 4, 1, 4],   # I  V  ii V
+    [0, 3, 0, 4],
+]
+
+NOTE_NAMES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+
+
+def note_name(midi):
+    return "%s%d" % (NOTE_NAMES[midi % 12], midi // 12 - 1)
+
+
+class Pattern:
+    def __init__(self, root, scale, style, bpm, octaves, velocity, progression):
+        self.root = root
+        self.scale = scale
+        self.style = style
+        self.bpm = bpm
+        self.octaves = octaves
+        self.velocity = velocity
+        self.progression = progression
+
+    def describe(self):
+        return "%s %s · arp+chords (%s) · %d BPM" % (
+            note_name(self.root), self.scale, self.style, self.bpm)
+
+    def as_dict(self):
+        return {"root": self.root, "root_name": note_name(self.root), "scale": self.scale,
+                "style": self.style, "bpm": self.bpm, "octaves": self.octaves,
+                "progression": self.progression}
+
+
+def random_pattern():
+    root = random.randint(48, 62)  # C3..D4
+    scale = random.choice(list(SCALES))
+    style = random.choice(STYLES)
+    bpm = random.choice([72, 84, 96, 110, 120, 132])
+    octaves = random.choice([1, 1, 2])
+    velocity = random.randint(85, 112)
+    progression = random.choice(PROGRESSIONS)
+    return Pattern(root, scale, style, bpm, octaves, velocity, progression)
+
+
+class PatternPlayer(threading.Thread):
+    """Plays `pattern` on `link` forever (in a thread) until stop()."""
+
+    def __init__(self, link, pattern, channel=0):
+        super().__init__(daemon=True)
+        self.link = link
+        self.pattern = pattern
+        self.channel = channel
+        self._stop = threading.Event()
+        self._sounding = []  # notes currently on
+
+    def stop(self):
+        self._stop.set()
+
+    def _wait(self, seconds):
+        self._stop.wait(seconds)  # wakes early on stop
+
+    def _on(self, note, vel=None):
+        self.link.note_on(note, vel or self.pattern.velocity, self.channel)
+        self._sounding.append(note)
+
+    def _off(self, note):
+        self.link.note_off(note, self.channel)
+        if note in self._sounding:
+            self._sounding.remove(note)
+
+    def _all_off(self):
+        for n in list(self._sounding):
+            self._off(n)
+        self.link.all_notes_off(self.channel)
+
+    def _diatonic_chord(self, degree, size=3):
+        """Build an in-key chord by stacking scale thirds from `degree`."""
+        steps = SCALES[self.pattern.scale]
+        n = len(steps)
+        out = []
+        for k in range(size):
+            idx = degree + 2 * k
+            out.append(self.pattern.root + 12 * (idx // n) + steps[idx % n])
+        return out
+
+    def run(self):
+        p = self.pattern
+        beat = 60.0 / p.bpm
+        try:
+            while not self._stop.is_set():
+                for degree in p.progression:
+                    if self._stop.is_set():
+                        break
+                    chord = self._diatonic_chord(degree, size=random.choice([3, 3, 4]))
+                    self._arp_phase(chord, beat)      # pattern
+                    if self._stop.is_set():
+                        break
+                    self._chord_phase(chord, beat)    # chord
+        finally:
+            self._all_off()
+
+    def _arp_phase(self, chord, beat, eighths=8):
+        """One bar of eighth-note arpeggio over the chord tones."""
+        p = self.pattern
+        notes = list(chord) + [chord[0] + 12]  # add the octave on top
+        if p.octaves >= 2:
+            notes = notes + [n + 12 for n in chord]
+        if p.style == "down":
+            notes = list(reversed(notes))
+        elif p.style == "updown":
+            notes = notes + list(reversed(notes[1:-1]))
+        step = beat / 2.0
+        gate = step * 0.85
+        for i in range(eighths):
+            if self._stop.is_set():
+                return
+            n = random.choice(notes) if p.style == "random_walk" else notes[i % len(notes)]
+            self._on(n, p.velocity + random.randint(-8, 8))
+            self._wait(gate)
+            self._off(n)
+            self._wait(step - gate)
+
+    def _chord_phase(self, chord, beat, beats=2):
+        """Hold the block chord for a couple of beats."""
+        hold = beat * beats
+        for n in chord:
+            self._on(n, self.pattern.velocity)
+        self._wait(hold * 0.92)
+        for n in chord:
+            self._off(n)
+        self._wait(hold * 0.08)

--- a/tools/amyworld_recorder/record.py
+++ b/tools/amyworld_recorder/record.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python3
+"""Interactive AMYboard World capture session.
+
+For each AMYboard World sketch: download it, push it onto a USB-connected
+AMYboard (same SysEx "write to sketch" flow as the web editor), start an ffmpeg
+recording of the iPhone (Continuity Camera) + a Mac audio input, then let you
+audition it and mark it good / not interesting / not working. State is saved so a
+later run skips what you've already done.
+
+Run `./amyworld record --list-devices` first to see your camera/audio indices
+(or `./.venv/bin/python record.py --list-devices`).
+"""
+
+import argparse
+import json
+import os
+import sys
+import termios
+import time
+import tty
+
+import capture
+import patterns
+import worldapi
+from amyboard_link import AMYboardLink
+from session import Session
+
+
+# ----------------------------------------------------------------------------
+# single-key input
+# ----------------------------------------------------------------------------
+def getch():
+    """Read one keypress (no Enter). Falls back to line input if not a tty."""
+    if not sys.stdin.isatty():
+        line = sys.stdin.readline()
+        return line[:1] if line else "q"
+    fd = sys.stdin.fileno()
+    old = termios.tcgetattr(fd)
+    try:
+        tty.setcbreak(fd)
+        ch = sys.stdin.read(1)
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old)
+    return ch
+
+
+# ----------------------------------------------------------------------------
+# config
+# ----------------------------------------------------------------------------
+DEFAULTS = {
+    "api_base": worldapi.DEFAULT_BASE,
+    "out_dir": "session_out",
+    "capture_video": True,   # False = external-video mode (phone films continuously; we sync by beep)
+    "video_device": None,    # name substring or index; None = auto-detect iPhone
+    "audio_device": None,    # name substring or index; None = no audio
+    "audio_channels": None,  # 1-indexed device channels to record, e.g. [13, 14]
+    "midi_match": "amyboard",
+    "framerate": 30,
+    "video_size": None,
+    "reset": "amy",          # amy | reboot | none
+    "oled_reset": "logo",    # reset OLED between sketches: logo | clear | none
+    "denylist_on_wedge": True,  # auto-denylist a sketch that hangs the board (watchdog)
+    "amy_volume": None,      # if set, amy.send(volume=N) after each sketch starts (recording boost)
+    "channel": 0,            # MIDI channel (0 == channel 1)
+    "limit": 1000,           # World currently has ~296 latest-per-user sketches; this gets them all
+    "tag": "",
+    "q": "",
+    "autoplay": False,
+}
+
+
+def load_config(path):
+    cfg = dict(DEFAULTS)
+    if path and os.path.exists(path):
+        with open(path) as f:
+            cfg.update(json.load(f))
+    return cfg
+
+
+# ----------------------------------------------------------------------------
+# device setup
+# ----------------------------------------------------------------------------
+def print_devices():
+    video, _ = capture.list_avfoundation_devices()
+    print("Video devices (ffmpeg avfoundation):")
+    for i, n in sorted(video.items()):
+        print("  [%d] %s" % (i, n))
+    print("Audio input devices (sounddevice / CoreAudio):")
+    for i, n in sorted(capture.list_sd_audio_devices().items()):
+        print("  [%d] %s" % (i, n))
+    import mido
+    print("MIDI inputs: ", mido.get_input_names())
+    print("MIDI outputs:", mido.get_output_names())
+
+
+def resolve_devices(cfg):
+    # video via ffmpeg/avfoundation; audio via sounddevice (DIFFERENT numbering)
+    vidx = None
+    if cfg["capture_video"]:
+        video, _ = capture.list_avfoundation_devices()
+        vidx = capture.resolve_device(video, cfg["video_device"]) if cfg["video_device"] else capture.find_iphone(video)
+        if vidx is None:
+            raise SystemExit(
+                "Could not resolve a video device. Connect your iPhone (Continuity Camera) "
+                "or pass --video-device <name|index>. Run --list-devices to see options.")
+    aidx = capture.resolve_sd_audio(cfg["audio_device"]) if cfg["audio_device"] else None
+    if cfg["audio_device"] and aidx is None:
+        raise SystemExit("Could not resolve audio device %r (see --list-devices)." % cfg["audio_device"])
+    aname = capture.list_sd_audio_devices().get(aidx, "?") if aidx is not None else None
+    vdesc = ("[%d] %s" % (vidx, capture.list_avfoundation_devices()[0].get(vidx, "?"))
+             if vidx is not None else "(external — phone films the whole session)")
+    print("Recording video %s  +  audio %s" % (
+        vdesc, ("[%d] %s" % (aidx, aname)) if aidx is not None else "(none)"))
+    return vidx, aidx
+
+
+# ----------------------------------------------------------------------------
+# one sketch
+# ----------------------------------------------------------------------------
+MENU = ("  [g]ood  [n]ot interesting  [x] not working  [d]enylist  |  "
+        "[p]lay pattern  [s]top  [r]e-transfer  [i]nfo  [q]uit & save")
+
+
+def handle_sketch(item, link, rec_factory, sess, cfg, index, total):
+    title = str(item.get("filename", "")).rsplit(".", 1)[0]
+    desc = item.get("description", "") or item.get("content", "")
+    print("\n" + "=" * 72)
+    print("[%d/%d] id=%s  %s  by %s" % (index, total, item["id"], item.get("filename"),
+                                        worldapi.display_username(item.get("username"))))
+    if desc:
+        print("  " + desc)
+    if item.get("tags"):
+        print("  tags: " + ", ".join(item["tags"]))
+
+    # download
+    try:
+        text = worldapi.download_sketch(item, cfg["api_base"])
+    except Exception as e:
+        print("  ! download failed: %s — marking not working" % e)
+        sess.record(item, "not_working", errors=["download failed: %s" % e])
+        return "next"
+
+    # start recording (audio-only .m4a in external-video mode, else muxed .mov)
+    clip_name = "%05d_%s.%s" % (item["id"], _safe(title), "mov" if cfg["capture_video"] else "m4a")
+    clip_path = os.path.join(cfg["out_dir"], "clips", clip_name)
+    recorder = None
+    started = 0.0
+
+    def start_recording():
+        nonlocal recorder, started
+        recorder = rec_factory()
+        started = time.time()
+        try:
+            recorder.start(clip_path)
+            print("  ● recording -> %s" % os.path.relpath(clip_path))
+        except Exception as e:
+            print("  ! recording failed to start: %s" % e)
+            recorder = None
+
+    def prog(i, n):
+        sys.stdout.write("\r  transferring %d/%d chunks" % (i, n))
+        sys.stdout.flush()
+
+    def do_load():
+        print("  pushing sketch (reset=%s%s)..." % (
+            cfg["reset"], ", volume=%g" % cfg["amy_volume"] if cfg["amy_volume"] else ""))
+        r = link.load_sketch(text, reset=cfg["reset"], progress=prog,
+                             volume=cfg["amy_volume"], display_reset=cfg["oled_reset"])
+        sys.stdout.write("\r" + " " * 40 + "\r")
+        print("  transfer: %d/%d frames acked%s" % (
+            r["acked"], r["sent"], "" if r["ready"] else "  (board did not re-enumerate cleanly)"))
+        return r
+
+    start_recording()
+    result = do_load()
+
+    # Watchdog with correct attribution. If the transfer barely ACKed (<=1), the
+    # board was ALREADY wedged when this load began — i.e. a PREVIOUS sketch's
+    # delayed hang, not this one's fault — so recover and retry this sketch once on
+    # the clean board. If instead it loaded and then went unresponsive, this sketch
+    # is the culprit; denylist it. (A hang that only shows up mid-audition is caught
+    # by the post-mark check below.)
+    retried = False
+    while result.get("wedged"):
+        if recorder:
+            recorder.stop(discard=True)
+        pre_existing = result.get("acked", 0) <= 1
+        print("  ⛔ board wedged (%s) — recovering..." %
+              ("already hung before this sketch" if pre_existing else "this sketch hung on load"))
+        if not link.recover(factory_reset=True):
+            print("  ✗ board did not recover — power-cycle USB and re-run.")
+            sess.record(item, "not_working", errors=["wedged the board; recovery failed"])
+            return "quit"
+        print("  ✓ board recovered.")
+        if pre_existing and not retried:
+            print("  (a previous sketch hung the board, not this one — retrying it)")
+            retried = True
+            start_recording()
+            result = do_load()
+            continue
+        if cfg.get("denylist_on_wedge", True):
+            sess.deny(item, reason="wedged the board (CPU hang)")
+            print("  ⛔ denylisted id=%s — it won't be loaded again." % item["id"])
+        sess.record(item, "not_working", errors=["wedged the board (CPU hang; no traceback)"])
+        return "next"
+
+    # external-video mode: play a sync beep now (in the clean clip + the phone
+    # video's audio) so the stitcher can locate this sketch on the phone timeline.
+    beep_index = None
+    if not cfg["capture_video"]:
+        beep_index = sess.next_beep_index(item["id"])
+        link.beep()
+        print("  ♪ sync beep #%d" % beep_index)
+
+    suggested_status = None
+    if result["errors"]:
+        print("  ⚠ SKETCH ERROR (suggest [x] not working):")
+        for tb in result["errors"]:
+            print(_indent(tb, "      "))
+        suggested_status = "not_working"
+
+    # audition loop
+    player = [None]
+    audition_in = [None]
+
+    def start_pattern():
+        stop_pattern()
+        pat = patterns.random_pattern()
+        if audition_in[0] is None and recorder:
+            audition_in[0] = max(0.0, recorder.elapsed() - 0.3)
+        player[0] = patterns.PatternPlayer(link, pat, channel=cfg["channel"])
+        player[0].start()
+        print("  ♪ %s" % pat.describe())
+        return pat
+
+    def stop_pattern():
+        if player[0]:
+            player[0].stop()
+            player[0].join(timeout=2)
+            player[0] = None
+            link.all_notes_off(cfg["channel"])
+
+    last_pattern = [None]
+    if cfg["autoplay"]:
+        last_pattern[0] = start_pattern()
+
+    print(MENU)
+    if suggested_status:
+        print("  > suggested: x")
+    while True:
+        ch = getch().lower()
+        if ch == "p":
+            last_pattern[0] = start_pattern()
+        elif ch == "s":
+            stop_pattern()
+            print("  ♪ stopped")
+        elif ch == "i":
+            print(_indent(text, "    ")[:1500])
+        elif ch == "r":
+            print("  re-transferring...")
+            result = link.load_sketch(text, reset=cfg["reset"], progress=prog, volume=cfg["amy_volume"], display_reset=cfg["oled_reset"])
+            sys.stdout.write("\r" + " " * 40 + "\r")
+            if result["errors"]:
+                print("  ⚠ sketch error on re-transfer")
+                for tb in result["errors"]:
+                    print(_indent(tb, "      "))
+        elif ch in ("g", "n", "x"):
+            status = {"g": "good", "n": "not_interesting", "x": "not_working"}[ch]
+            stop_pattern()
+            clip = recorder.stop() if recorder else None
+            sess.record(item, status, clip=clip,
+                        errors=result["errors"] or None,
+                        pattern=(last_pattern[0].as_dict() if last_pattern[0] else None),
+                        started_at=started, ended_at=time.time(),
+                        audition_in=audition_in[0], beep_index=beep_index,
+                        transfer={"acked": result["acked"], "sent": result["sent"]})
+            print("  → %s" % status)
+            # delayed-hang check: some sketches only wedge the board mid-audition
+            # (e.g. once MIDI/heavy processing kicks in). Catch it HERE so it's
+            # blamed on this sketch, not the next one — and so the next sketch
+            # loads on a clean board. The clip is kept (it recorded fine).
+            if not link.ping(timeout=2.5):
+                print("  ⛔ board wedged during this sketch (delayed hang) — recovering (clip kept).")
+                if link.recover(factory_reset=True):
+                    print("  ✓ board recovered.")
+                if cfg.get("denylist_on_wedge", True):
+                    sess.deny(item, reason="wedged the board (delayed hang during audition)")
+                    print("  ⛔ denylisted id=%s so it won't be loaded again." % item["id"])
+            return "next"
+        elif ch == "d":
+            stop_pattern()
+            if recorder:
+                recorder.stop(discard=True)
+            sess.deny(item, reason="denied during session")
+            print("  ⛔ denylisted id=%s — will be skipped on every future run." % item["id"])
+            return "next"
+        elif ch == "q":
+            stop_pattern()
+            if recorder:
+                recorder.stop()
+            print("  stopping for now (this sketch stays pending).")
+            return "quit"
+        else:
+            print(MENU)
+
+
+def _safe(name):
+    return "".join(c if c.isalnum() or c in "-_" else "_" for c in name)[:48]
+
+
+def _indent(text, pad):
+    return "\n".join(pad + line for line in str(text).splitlines())
+
+
+# ----------------------------------------------------------------------------
+# main
+# ----------------------------------------------------------------------------
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--config", help="path to a JSON config file")
+    ap.add_argument("--list-devices", action="store_true", help="list camera/audio/MIDI devices and exit")
+    ap.add_argument("--out", dest="out_dir", help="output directory (default session_out)")
+    ap.add_argument("--api-base")
+    ap.add_argument("--video-device", help="iPhone video device name substring or index")
+    ap.add_argument("--audio-device", help="Mac audio input device name substring or index")
+    ap.add_argument("--audio-channels", help="1-indexed device channels to record, e.g. 13,14")
+    ap.add_argument("--external-video", action="store_true",
+                    help="don't capture video; you film the whole session on the phone and we sync by beep")
+    ap.add_argument("--midi-match", help="MIDI port name substring (default amyboard)")
+    ap.add_argument("--reset", choices=["amy", "reboot", "none"], help="clean-slate strategy between sketches")
+    ap.add_argument("--oled-reset", choices=["logo", "clear", "none"], help="reset the OLED between sketches (default logo)")
+    ap.add_argument("--amy-volume", type=float, help="amy.send(volume=N) after each sketch starts (recording level boost; e.g. 5)")
+    ap.add_argument("--limit", type=int)
+    ap.add_argument("--tag", help="only this World tag (e.g. official)")
+    ap.add_argument("--q", help="World search query")
+    ap.add_argument("--framerate", type=int)
+    ap.add_argument("--video-size", help="capture size e.g. 1280x720")
+    ap.add_argument("--autoplay", action="store_true", help="auto-start a pattern after each transfer")
+    ap.add_argument("--redo", action="store_true", help="don't skip already-handled sketches")
+    ap.add_argument("--redo-status", help="only re-do sketches with this status (e.g. not_working)")
+    ap.add_argument("--deny", help="add sketch id(s) to the denylist (comma list), e.g. 574; they're skipped forever")
+    ap.add_argument("--undeny", help="remove sketch id(s) from the denylist (comma list)")
+    ap.add_argument("--list-denied", action="store_true", help="show the denylist and exit")
+    ap.add_argument("--recover", action="store_true",
+                    help="unstick a board wedged by a runaway sketch (zB reboot + factory reset) and exit")
+    ap.add_argument("--no-factory-reset", action="store_true",
+                    help="with --recover, just free the board; don't overwrite sketch.py with the default")
+    ap.add_argument("--no-denylist-on-wedge", action="store_true",
+                    help="if a sketch hangs the board, recover but don't auto-denylist it")
+    ap.add_argument("--deny-reason", default="manually denied", help="reason stored with --deny")
+    args = ap.parse_args()
+
+    if args.list_devices:
+        print_devices()
+        return
+
+    cfg = load_config(args.config)
+    for k in ("out_dir", "api_base", "video_device", "audio_device", "midi_match",
+              "reset", "oled_reset", "limit", "tag", "q", "framerate", "video_size"):
+        v = getattr(args, k, None)
+        if v is not None:
+            cfg[k] = v
+    if args.autoplay:
+        cfg["autoplay"] = True
+    if args.audio_channels:
+        cfg["audio_channels"] = [int(x) for x in args.audio_channels.replace(" ", "").split(",")]
+    if args.amy_volume is not None:
+        cfg["amy_volume"] = args.amy_volume
+    if args.no_denylist_on_wedge:
+        cfg["denylist_on_wedge"] = False
+    if args.external_video:
+        cfg["capture_video"] = False
+
+    # --- recover a wedged board (run & exit; no camera needed) -------------
+    if args.recover:
+        link = AMYboardLink(cfg["midi_match"]).open()
+        print("sending zB reboot (pure-C; bypasses a hung sketch loop)...")
+        ok = link.recover(factory_reset=not args.no_factory_reset)
+        link.close()
+        if ok:
+            print("✓ board recovered%s." % ("" if args.no_factory_reset
+                                            else " and reset to the default sketch"))
+        else:
+            print("✗ board did not come back — power-cycle it (unplug/replug USB), then retry.")
+        return
+
+    sess = Session(cfg["out_dir"])
+
+    # --- denylist management (run & exit; no board/camera needed) ----------
+    if args.deny or args.undeny or args.list_denied:
+        if args.undeny:
+            for sid in args.undeny.replace(" ", "").split(","):
+                print(("removed %s from denylist" % sid) if sess.undeny(sid) else ("%s not on denylist" % sid))
+        if args.deny:
+            # enrich with metadata from the API listing when we can
+            by_id = {}
+            try:
+                by_id = {str(it["id"]): it for it in
+                         worldapi.list_sketches(cfg["api_base"], limit=cfg["limit"])}
+            except Exception:
+                pass
+            for sid in args.deny.replace(" ", "").split(","):
+                item = by_id.get(sid, {"id": int(sid) if sid.isdigit() else sid})
+                d = sess.deny(item, reason=args.deny_reason)
+                print("⛔ denylisted id=%s %s" % (sid, d.get("filename", "")))
+        if args.list_denied or args.deny or args.undeny:
+            print("\ndenylist (%d) — %s:" % (len(sess.denylist), sess.denylist_path))
+            for sid, d in sorted(sess.denylist.items(), key=lambda kv: int(kv[0])):
+                print("  id=%-5s %-30s by %-14s — %s" % (
+                    sid, d.get("filename", ""), d.get("username", ""), d.get("reason", "")))
+        return
+
+    print("session: %s" % sess.path)
+    c = sess.counts()
+    print("so far: good=%d  not_interesting=%d  not_working=%d  pending=%d  | denylisted=%d" % (
+        c["good"], c["not_interesting"], c["not_working"], c["pending"], len(sess.denylist)))
+
+    print("fetching sketch list...")
+    items = worldapi.list_sketches(cfg["api_base"], limit=cfg["limit"], tag=cfg["tag"], q=cfg["q"])
+    print("got %d sketches" % len(items))
+
+    # filter to what we still need to do (denylisted are always skipped)
+    todo = []
+    for it in items:
+        if sess.is_denied(it["id"]):
+            continue
+        if args.redo_status:
+            if sess.status(it["id"]) == args.redo_status:
+                todo.append(it)
+        elif args.redo or not sess.is_done(it["id"]):
+            todo.append(it)
+    if not todo:
+        print("nothing to do — all fetched sketches are already handled or denylisted (use --redo to repeat).")
+        return
+    print("%d sketches to record this run (skipping %d denylisted).\n" % (len(todo), len(sess.denylist)))
+
+    vidx, aidx = resolve_devices(cfg)
+
+    if cfg["audio_channels"]:
+        print("audio channels: %s (extracted from the device)" % cfg["audio_channels"])
+
+    def rec_factory():
+        return capture.ClipRecorder(vidx, aidx, framerate=cfg["framerate"],
+                                    video_size=cfg["video_size"],
+                                    audio_channels=cfg["audio_channels"],
+                                    log_dir=os.path.join(cfg["out_dir"], "logs"))
+
+    if not cfg["capture_video"]:
+        print("\n" + "!" * 72)
+        print("EXTERNAL-VIDEO MODE: start your phone filming NOW and let it run for the")
+        print("WHOLE session (don't stop/restart it). A sync beep plays at each sketch so")
+        print("the stitcher can line the video up. Keep the AMYboard audible to the phone.")
+        print("!" * 72)
+        try:
+            input("Press Enter once the phone is recording... ")
+        except EOFError:
+            pass
+
+    with AMYboardLink(cfg["midi_match"]) as link:
+        for i, item in enumerate(todo, 1):
+            action = handle_sketch(item, link, rec_factory, sess, cfg, i, len(todo))
+            if action == "quit":
+                break
+
+    c = sess.counts()
+    print("\ndone. good=%d  not_interesting=%d  not_working=%d  pending=%d" % (
+        c["good"], c["not_interesting"], c["not_working"], c["pending"]))
+    if cfg["capture_video"]:
+        print("next: ./amyworld stitch plan --session %s" % cfg["out_dir"])
+    else:
+        print("next: ./amyworld stitch sync --session %s --phone-video <your_video.mov> --out montage.mp4"
+              % cfg["out_dir"])
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/amyworld_recorder/requirements.txt
+++ b/tools/amyworld_recorder/requirements.txt
@@ -1,0 +1,5 @@
+mido>=1.3
+python-rtmidi>=1.5
+requests>=2.31
+sounddevice>=0.4
+numpy>=1.24

--- a/tools/amyworld_recorder/session.py
+++ b/tools/amyworld_recorder/session.py
@@ -1,0 +1,140 @@
+"""Session state for a recording run.
+
+Stored as <out_dir>/session.json. Tracks the disposition of every sketch we've
+touched so a later run can skip the ones already handled, and so the stitcher
+knows which clips are good and what text to overlay.
+"""
+
+import json
+import os
+import time
+
+import worldapi
+
+# Statuses that count as "handled" — skipped on the next run unless --redo.
+DONE = {"good", "not_interesting", "not_working"}
+ALL_STATUSES = DONE | {"pending"}
+
+
+class Session:
+    def __init__(self, out_dir):
+        self.out_dir = out_dir
+        self.path = os.path.join(out_dir, "session.json")
+        self.denylist_path = os.path.join(out_dir, "denylist.json")
+        self.data = {"created_at": time.time(), "sketches": {}}
+        self.denylist = {}  # {str(id): {reason, filename, username, added_at}}
+        os.makedirs(out_dir, exist_ok=True)
+        if os.path.exists(self.path):
+            self.load()
+        if os.path.exists(self.denylist_path):
+            with open(self.denylist_path) as f:
+                self.denylist = json.load(f)
+
+    def load(self):
+        with open(self.path) as f:
+            self.data = json.load(f)
+        self.data.setdefault("sketches", {})
+
+    def save(self):
+        tmp = self.path + ".tmp"
+        with open(tmp, "w") as f:
+            json.dump(self.data, f, indent=2)
+        os.replace(tmp, self.path)
+
+    # -- queries ------------------------------------------------------------
+    def get(self, sketch_id):
+        return self.data["sketches"].get(str(sketch_id))
+
+    def status(self, sketch_id):
+        rec = self.get(sketch_id)
+        return rec["status"] if rec else None
+
+    def is_done(self, sketch_id):
+        return self.status(sketch_id) in DONE
+
+    def next_beep_index(self, sketch_id):
+        """Record a sync beep for `sketch_id` and return its index. The Nth beep
+        found in the phone recording maps to self.data['beeps'][N] (external-video
+        mode) — so beeps stay aligned to sketches regardless of how each was
+        finally marked."""
+        beeps = self.data.setdefault("beeps", [])
+        idx = len(beeps)
+        beeps.append(str(sketch_id))
+        self.save()
+        return idx
+
+    # -- denylist (sketches to never load again, e.g. they hang the board) ---
+    def is_denied(self, sketch_id):
+        return str(sketch_id) in self.denylist
+
+    def deny(self, item, reason=""):
+        """Add a sketch to the persistent denylist; it's skipped on every run."""
+        sid = str(item["id"])
+        self.denylist[sid] = {
+            "id": item["id"],
+            "filename": item.get("filename", ""),
+            "username": worldapi.display_username(item.get("username", "")),
+            "reason": reason,
+            "added_at": time.time(),
+        }
+        self._save_denylist()
+        return self.denylist[sid]
+
+    def undeny(self, sketch_id):
+        if str(sketch_id) in self.denylist:
+            del self.denylist[str(sketch_id)]
+            self._save_denylist()
+            return True
+        return False
+
+    def _save_denylist(self):
+        tmp = self.denylist_path + ".tmp"
+        with open(tmp, "w") as f:
+            json.dump(self.denylist, f, indent=2)
+        os.replace(tmp, self.denylist_path)
+
+    def by_status(self, status):
+        return [r for r in self.data["sketches"].values() if r.get("status") == status]
+
+    def counts(self):
+        c = {s: 0 for s in ALL_STATUSES}
+        for r in self.data["sketches"].values():
+            c[r.get("status", "pending")] = c.get(r.get("status", "pending"), 0) + 1
+        return c
+
+    # -- writes -------------------------------------------------------------
+    def record(self, item, status, clip=None, errors=None, pattern=None,
+               started_at=None, ended_at=None, audition_in=None, transfer=None,
+               beep_index=None):
+        """Upsert the result for one sketch."""
+        sid = str(item["id"])
+        rec = self.data["sketches"].get(sid, {})
+        rec.update({
+            "id": item["id"],
+            "filename": item.get("filename", ""),
+            "title": str(item.get("filename", "")).rsplit(".", 1)[0],
+            "username": worldapi.display_username(item.get("username", "")),
+            "description": item.get("description", "") or item.get("content", ""),
+            "tags": item.get("tags", []),
+            "status": status,
+            "updated_at": time.time(),
+        })
+        if clip is not None:
+            rec["clip"] = clip
+        if errors is not None:
+            rec["errors"] = errors
+        if pattern is not None:
+            rec["pattern"] = pattern
+        if started_at is not None:
+            rec["started_at"] = started_at
+        if ended_at is not None:
+            rec["ended_at"] = ended_at
+        if audition_in is not None:
+            rec["audition_in"] = audition_in
+        if transfer is not None:
+            rec["transfer"] = transfer
+        if beep_index is not None:
+            rec["beep_index"] = beep_index
+        self.data["sketches"][sid] = rec
+        self.save()
+        return rec

--- a/tools/amyworld_recorder/stitch.py
+++ b/tools/amyworld_recorder/stitch.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Build the final montage from a recording session, with ffmpeg.
+
+Run via the wrapper (uses the bundled venv): `./amyworld stitch <cmd> …`
+(or directly: `./.venv/bin/python stitch.py <cmd> …`).
+
+Workflow:
+  1. ./amyworld stitch plan   --session session_out          # writes clips.json
+  2. (edit clips.json: reorder, set enabled:false, set in/out trim seconds)
+  3. ./amyworld stitch render --session session_out --out montage.mp4
+
+Other commands:
+  ./amyworld stitch list   --session session_out [--status good]
+  ./amyworld stitch broken --session session_out             # show errors for failed sketches
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+
+from session import Session
+from worldapi import display_username
+
+FONT_CANDIDATES = [
+    "/System/Library/Fonts/Supplemental/Arial Bold.ttf",
+    "/System/Library/Fonts/Supplemental/Arial.ttf",
+    "/System/Library/Fonts/Helvetica.ttc",
+    "/System/Library/Fonts/SFNS.ttf",
+]
+
+
+def find_font():
+    for f in FONT_CANDIDATES:
+        if os.path.exists(f):
+            return f
+    return None
+
+
+def ffprobe_has_audio(path):
+    try:
+        out = subprocess.run(
+            ["ffprobe", "-v", "error", "-select_streams", "a",
+             "-show_entries", "stream=index", "-of", "csv=p=0", path],
+            capture_output=True, text=True).stdout.strip()
+        return bool(out)
+    except Exception:
+        return False
+
+
+def ffprobe_duration(path):
+    try:
+        out = subprocess.run(
+            ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+             "-of", "csv=p=0", path], capture_output=True, text=True).stdout.strip()
+        return float(out)
+    except Exception:
+        return 0.0
+
+
+# ---------------------------------------------------------------------------
+# plan
+# ---------------------------------------------------------------------------
+def cmd_plan(args):
+    sess = Session(args.session)
+    good = sess.by_status("good")
+    good.sort(key=lambda r: r.get("updated_at", 0))
+    clips = []
+    for r in good:
+        clip = r.get("clip")
+        if not clip or not os.path.exists(clip):
+            print("  ! skipping id=%s (clip missing: %s)" % (r["id"], clip))
+            continue
+        clips.append({
+            "id": r["id"],
+            "title": r.get("title", ""),
+            "username": display_username(r.get("username", "")),
+            "description": r.get("description", ""),
+            "clip": clip,
+            "enabled": True,
+            "in": round(r.get("audition_in") or 0.0, 2),
+            "out": None,  # null = to end
+        })
+    out = args.list or os.path.join(args.session, "clips.json")
+    with open(out, "w") as f:
+        json.dump({"clips": clips}, f, indent=2)
+    print("wrote %d good clips to %s" % (len(clips), out))
+    print("edit it (reorder / enabled:false / in/out trim), then: ./amyworld stitch render --session %s" % args.session)
+
+
+# ---------------------------------------------------------------------------
+# render
+# ---------------------------------------------------------------------------
+def cmd_render(args):
+    listpath = args.list or os.path.join(args.session, "clips.json")
+    if not os.path.exists(listpath):
+        raise SystemExit("no clip list at %s — run `stitch.py plan` first." % listpath)
+    with open(listpath) as f:
+        clips = [c for c in json.load(f)["clips"] if c.get("enabled", True)]
+    if not clips:
+        raise SystemExit("no enabled clips in %s" % listpath)
+
+    font = args.font or find_font()
+    if not font:
+        print("warning: no font found; text overlays disabled.", file=sys.stderr)
+
+    W, H = (1080, 1920) if args.portrait else (args.width, args.height)
+    workdir = tempfile.mkdtemp(prefix="amyworld_stitch_")
+    segments = []
+    print("rendering %d clips at %dx%d -> %s" % (len(clips), W, H, args.out))
+    for i, c in enumerate(clips):
+        # Segments carry LOSSLESS PCM audio. We must not encode AAC per segment:
+        # AAC's ~2100-sample encoder priming/padding would leave a click + timing
+        # wobble at every clip join once concatenated. Instead we copy the gapless
+        # PCM through the concat demuxer and encode AAC exactly once, below.
+        seg = os.path.join(workdir, "seg_%03d.mov" % i)
+        _render_segment(c, seg, W, H, font, args)
+        segments.append(seg)
+        print("  [%d/%d] %s" % (i + 1, len(clips), c.get("title")))
+
+    _concat_segments(segments, workdir, args.out)
+    print("done -> %s" % args.out)
+
+
+def _concat_segments(segments, workdir, out):
+    """Concat PCM-audio segments, encoding AAC exactly once (no per-segment AAC
+    boundaries), video stream-copied."""
+    listfile = os.path.join(workdir, "concat.txt")
+    with open(listfile, "w") as f:
+        for s in segments:
+            f.write("file '%s'\n" % s)
+    subprocess.run(["ffmpeg", "-hide_banner", "-y", "-f", "concat", "-safe", "0",
+                    "-i", listfile, "-c:v", "copy",
+                    "-c:a", "aac", "-b:a", "256k", "-ar", "48000", "-ac", "2",
+                    "-movflags", "+faststart", out], check=True)
+
+
+# ---------------------------------------------------------------------------
+# sync: build the montage from an externally-recorded phone video, locating each
+# sketch by its sync beep and using the clean Model 16 audio the Mac recorded.
+# ---------------------------------------------------------------------------
+def cmd_sync(args):
+    import beepsync
+    sess = Session(args.session)
+    beeps = sess.data.get("beeps", [])
+    if not beeps:
+        raise SystemExit("no sync beeps recorded — record the session with --external-video first.")
+
+    # One phone video per run; the beep counter climbs across runs. Detect beeps
+    # in each video (given in RUN ORDER) and lay them end to end — that flat list
+    # lines up 1:1 with the recorded beeps, so each sketch is found in the right
+    # video at the right time.
+    flat = []  # (video_path, local_time) in recorded order
+    for v in args.phone_video:
+        pa, sr = beepsync.load_audio_mono(v, sr=8000)
+        if pa.size == 0:
+            raise SystemExit("no decodable audio in %s — can't find the beeps." % v)
+        bts = beepsync.detect_beeps(pa, sr)
+        print("  %-40s %d beeps" % (os.path.basename(v), len(bts)))
+        flat.extend((v, t) for t in bts)
+    print("total beeps across %d video(s): %d;  recorded: %d" % (len(args.phone_video), len(flat), len(beeps)))
+    if len(flat) != len(beeps):
+        print("  ! count mismatch: alignment proceeds by index, so a missed/extra beep shifts")
+        print("    everything after it. Give the videos in RUN ORDER; check the result.")
+    n = min(len(flat), len(beeps))
+
+    # good sketches, in beep order
+    good = []
+    for i in range(n):
+        rec = sess.get(beeps[i])
+        if rec and rec.get("status") == "good" and rec.get("clip") and os.path.exists(rec["clip"]):
+            good.append((i, rec))
+    if not good:
+        raise SystemExit("no good clips with audio to stitch (checked %d beeps)." % n)
+
+    font = args.font or find_font()
+    W, H = (1080, 1920) if args.portrait else (args.width, args.height)
+    workdir = tempfile.mkdtemp(prefix="amyworld_sync_")
+    segments = []
+    print("rendering %d good clips synced to the phone video ..." % len(good))
+    for k, (bi, rec) in enumerate(good):
+        clip = rec["clip"]
+        # locate the beep inside the clean clip so we can align it to the phone beep
+        ca, csr = beepsync.load_audio_mono(clip, sr=8000)
+        cb = beepsync.detect_beeps(ca, csr)
+        clip_beep = cb[0] if cb else 0.0
+        lead = 0.4                       # start just past the ~0.28s double-beep
+        a_ss = clip_beep + lead
+        clip_dur = ffprobe_duration(clip)
+        seg_dur = max(0.2, clip_dur - a_ss - max(0.0, args.tail))
+        video, beep_t = flat[bi]             # which phone video, and where in it
+        phone_ss = beep_t + lead             # beep-to-beep alignment
+        seg = os.path.join(workdir, "seg_%03d.mov" % k)
+        _render_synced_segment(rec, video, phone_ss, seg_dur, clip, a_ss, seg, W, H, font, args)
+        segments.append(seg)
+        print("  [%d/%d] %-28s %s@%.1fs  %.1fs%s" % (
+            k + 1, len(good), rec.get("title", "")[:28], os.path.basename(video), phone_ss, seg_dur,
+            "" if cb else "  (no beep found in clip — used start)"))
+
+    _concat_segments(segments, workdir, args.out)
+    print("done -> %s" % args.out)
+
+
+def _render_synced_segment(rec, phone_video, phone_ss, dur, audio_path, audio_ss, out, W, H, font, args):
+    clip = {"title": rec.get("title", ""), "username": display_username(rec.get("username", "")),
+            "description": rec.get("description", "")}
+    vf = ("scale=%d:%d:force_original_aspect_ratio=decrease,"
+          "pad=%d:%d:(ow-iw)/2:(oh-ih)/2,setsar=1,fps=%d" % (W, H, W, H, args.fps))
+    for filt in _overlay_filters(clip, out, W, H, font, args, 0.0):
+        vf += "," + filt
+    cmd = ["ffmpeg", "-hide_banner", "-y",
+           "-ss", "%.3f" % phone_ss, "-i", phone_video,      # video from phone
+           "-ss", "%.3f" % audio_ss, "-i", audio_path,       # clean Model 16 audio
+           "-t", "%.3f" % dur,
+           "-map", "0:v:0", "-map", "1:a:0", "-vf", vf,
+           "-c:v", "libx264", "-preset", "medium", "-crf", "18", "-pix_fmt", "yuv420p",
+           "-c:a", "pcm_s16le", "-ar", "48000", "-ac", "2", "-r", str(args.fps), out]
+    subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def _overlay_filters(clip, out, W, H, font, args, ss):
+    """A lower-third: one translucent panel (drawbox) with the title + 'by user'
+    + wrapped description stacked as one drawtext per line. Each line is its own
+    drawtext (no embedded newlines) because ffmpeg 8's harfbuzz shaping renders
+    an embedded \\n as a tofu glyph. Text comes from files to avoid escaping."""
+    if not font:
+        return []
+    pad, gap, margin_x = 26, 12, 64
+
+    lines = []  # (text, size)
+    if clip.get("title"):
+        lines.append((clip["title"], args.title_size))
+    if clip.get("username"):
+        lines.append(("by %s" % clip["username"], args.meta_size))
+
+    # Wrap the description to the real frame width (drawtext doesn't wrap), then
+    # show as many lines as fit in a panel up to overlay_max_frac of the height;
+    # ellipsize only if it's longer than that.
+    usable_w = W - 2 * margin_x
+    wrap_w = max(20, int(usable_w / (args.meta_size * 0.60)))  # ~chars per line
+    desc_lines = textwrap.wrap(clip.get("description", "") or "", width=wrap_w)
+    desc_h = int(args.meta_size * 1.32) + gap
+    used_h = pad * 2 + sum(int(sz * 1.32) + gap for _, sz in lines)
+    budget = args.overlay_max_frac * H
+    max_desc = max(1, int((budget - used_h) / desc_h))
+    if len(desc_lines) > max_desc:
+        desc_lines = desc_lines[:max_desc]
+        desc_lines[-1] = desc_lines[-1].rstrip()[:wrap_w - 1] + "…"  # ellipsis
+    for dl in desc_lines:
+        lines.append((dl, args.meta_size))
+    if not lines:
+        return []
+
+    heights = [int(sz * 1.32) for _, sz in lines]
+    panel_h = sum(heights) + gap * (len(lines) - 1) + pad * 2
+    y0 = H - args.bottom_margin - panel_h
+    enable = (":enable='lt(t-%g\\,%g)'" % (ss, args.title_seconds)) if args.title_seconds else ""
+
+    filters = ["drawbox=x=0:y=%d:w=%d:h=%d:color=black@0.5:t=fill%s" % (y0, W, panel_h, enable)]
+    y = y0 + pad
+    for i, (txt, sz) in enumerate(lines):
+        tf = os.path.join(os.path.dirname(out),
+                          "%s.l%d.txt" % (os.path.basename(out), i))
+        with open(tf, "w") as f:
+            f.write(txt)
+        filters.append(
+            "drawtext=fontfile=%s:textfile=%s:fontsize=%d:fontcolor=white:"
+            "x=%d:y=%d:shadowcolor=black@0.8:shadowx=2:shadowy=2%s"
+            % (font, tf, sz, margin_x, y, enable))
+        y += heights[i] + gap
+    return filters
+
+
+def _render_segment(clip, out, W, H, font, args):
+    path = clip["clip"]
+    ss = float(clip.get("in") or 0.0)
+    to = clip.get("out")
+    seek = ["-ss", str(ss)]
+    trim = ["-to", str(float(to))] if to else []
+    has_audio = ffprobe_has_audio(path)
+
+    vf = ("scale=%d:%d:force_original_aspect_ratio=decrease,"
+          "pad=%d:%d:(ow-iw)/2:(oh-ih)/2,setsar=1,fps=%d"
+          % (W, H, W, H, args.fps))
+    for filt in _overlay_filters(clip, out, W, H, font, args, ss):
+        vf += "," + filt
+
+    cmd = ["ffmpeg", "-hide_banner", "-y"] + seek + ["-i", path] + trim
+    if not has_audio:
+        cmd += ["-f", "lavfi", "-i", "anullsrc=channel_layout=stereo:sample_rate=48000"]
+    cmd += ["-vf", vf, "-map", "0:v:0", "-map", ("1:a:0" if not has_audio else "0:a:0?")]
+    # PCM audio so the join is gapless; AAC is encoded once at concat time.
+    cmd += ["-c:v", "libx264", "-preset", "medium", "-crf", "18", "-pix_fmt", "yuv420p",
+            "-c:a", "pcm_s16le", "-ar", "48000", "-ac", "2",
+            "-shortest", "-r", str(args.fps), out]
+    subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+# ---------------------------------------------------------------------------
+# list / broken
+# ---------------------------------------------------------------------------
+def cmd_list(args):
+    sess = Session(args.session)
+    recs = sess.by_status(args.status) if args.status else list(sess.data["sketches"].values())
+    recs.sort(key=lambda r: r.get("updated_at", 0))
+    for r in recs:
+        print("%-14s id=%-5s %-32s by %-14s %s" % (
+            r.get("status"), r["id"], r.get("filename", "")[:32],
+            display_username(r.get("username", "")), os.path.basename(r.get("clip") or "")))
+    print("\n%d shown" % len(recs))
+
+
+def cmd_broken(args):
+    sess = Session(args.session)
+    recs = sess.by_status("not_working")
+    if not recs:
+        print("no sketches marked not_working.")
+        return
+    for r in recs:
+        print("=" * 72)
+        print("id=%s  %s  by %s" % (r["id"], r.get("filename"), display_username(r.get("username"))))
+        for tb in (r.get("errors") or ["(no captured python error — likely silent / no sound)"]):
+            print("\n".join("    " + ln for ln in str(tb).splitlines()))
+    print("\n%d broken" % len(recs))
+
+
+# ---------------------------------------------------------------------------
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("plan", help="write clips.json from good sketches")
+    p.add_argument("--session", required=True)
+    p.add_argument("--list", help="output path (default <session>/clips.json)")
+    p.set_defaults(func=cmd_plan)
+
+    p = sub.add_parser("render", help="render the montage from clips.json")
+    p.add_argument("--session", required=True)
+    p.add_argument("--list", help="clip list (default <session>/clips.json)")
+    p.add_argument("--out", default="montage.mp4")
+    p.add_argument("--font")
+    p.add_argument("--width", type=int, default=1920)
+    p.add_argument("--height", type=int, default=1080)
+    p.add_argument("--portrait", action="store_true", help="1080x1920 vertical")
+    p.add_argument("--fps", type=int, default=30)
+    p.add_argument("--title-size", type=int, default=64)
+    p.add_argument("--meta-size", type=int, default=38)
+    p.add_argument("--bottom-margin", type=int, default=80)
+    p.add_argument("--overlay-max-frac", type=float, default=0.6,
+                   help="max fraction of frame height the title/description panel may use (default 0.6)")
+    p.add_argument("--title-seconds", type=float, default=0.0,
+                   help="show overlays only for the first N seconds (0 = whole clip)")
+    p.set_defaults(func=cmd_render)
+
+    p = sub.add_parser("sync", help="build the montage from an external phone video, synced by beep")
+    p.add_argument("--session", required=True)
+    p.add_argument("--phone-video", required=True, nargs="+",
+                   help="the phone video(s), one per run, IN RUN ORDER (e.g. run1.mov run2.mov)")
+    p.add_argument("--out", default="montage.mp4")
+    p.add_argument("--tail", type=float, default=0.0, help="trim N seconds off each clip's end")
+    p.add_argument("--font")
+    p.add_argument("--width", type=int, default=1920)
+    p.add_argument("--height", type=int, default=1080)
+    p.add_argument("--portrait", action="store_true", help="1080x1920 vertical")
+    p.add_argument("--fps", type=int, default=30)
+    p.add_argument("--title-size", type=int, default=64)
+    p.add_argument("--meta-size", type=int, default=38)
+    p.add_argument("--bottom-margin", type=int, default=80)
+    p.add_argument("--overlay-max-frac", type=float, default=0.6,
+                   help="max fraction of frame height the title/description panel may use (default 0.6)")
+    p.add_argument("--title-seconds", type=float, default=0.0,
+                   help="show overlays only for the first N seconds (0 = whole clip)")
+    p.set_defaults(func=cmd_sync)
+
+    p = sub.add_parser("list", help="list recorded sketches")
+    p.add_argument("--session", required=True)
+    p.add_argument("--status", help="good | not_interesting | not_working | pending")
+    p.set_defaults(func=cmd_list)
+
+    p = sub.add_parser("broken", help="show not_working sketches and their python errors")
+    p.add_argument("--session", required=True)
+    p.set_defaults(func=cmd_broken)
+
+    args = ap.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/amyworld_recorder/worldapi.py
+++ b/tools/amyworld_recorder/worldapi.py
@@ -1,0 +1,49 @@
+"""Thin client for the AMYboard World sketch API (read-only, public).
+
+Backed by tulip/server/amyboardworld_db_api.py; production base is
+https://tulipcc-production.up.railway.app
+"""
+
+import requests
+
+DEFAULT_BASE = "https://tulipcc-production.up.railway.app"
+
+# How internal World usernames are credited to viewers. The 'generator' account
+# holds sketches made from community-entered text prompts — that's real
+# authorship — so we credit them as "anonymous" rather than exposing the backend
+# account name.
+USERNAME_ALIASES = {"generator": "anonymous"}
+
+
+def display_username(name):
+    """Map an internal World username to how it should be shown to viewers."""
+    if not name:
+        return name
+    return USERNAME_ALIASES.get(name.strip().lower(), name)
+
+
+def list_sketches(base=DEFAULT_BASE, limit=100, tag="", q="", username="",
+                  item_type="environment", latest_per_user_env=True, timeout=30):
+    params = {"limit": limit, "item_type": item_type,
+              "latest_per_user_env": "true" if latest_per_user_env else "false"}
+    if tag:
+        params["tag"] = tag
+    if q:
+        params["q"] = q
+    if username:
+        params["username"] = username
+    r = requests.get(base + "/api/amyboardworld/files", params=params, timeout=timeout)
+    r.raise_for_status()
+    items = r.json().get("items", [])
+    # only real environment .py sketches
+    return [it for it in items if str(it.get("filename", "")).endswith(".py")]
+
+
+def download_sketch(item, base=DEFAULT_BASE, timeout=30):
+    """Return the sketch's python source text for a list item."""
+    url = item.get("download_url") or ("/api/amyboardworld/files/%s/download" % item["id"])
+    if not url.startswith("http"):
+        url = base + url
+    r = requests.get(url, timeout=timeout)
+    r.raise_for_status()
+    return r.text


### PR DESCRIPTION
## What

A self-contained tool, `tools/amyworld_recorder/`, to audition and record **every AMYboard World sketch** for a video, plus a new doc for the AMYboard MIDI SysEx control protocol.

### The recorder
For each World sketch: pull it from the World API → push it to a USB-connected AMYboard over the same SysEx *write-to-sketch* flow the web editor uses → audition it (random arp+chord patterns) → mark **good / not interesting / not working / denylist** → record clean audio → stitch the good ones into a captioned montage.

Highlights, most of them learned the hard way on real hardware:
- **`amyboard_link.py`** — a reusable Python client for the AMYboard SysEx protocol (transfer, run-python, reboot, error frames, notes).
- **Clean audio via sounddevice/PortAudio**, not ffmpeg — ffmpeg's avfoundation audio input slips samples against the device's USB clock (inaudible in silence, clicks on signal); PortAudio follows it exactly. Extracts a chosen channel pair (e.g. Model 16 ch 13/14).
- **Watchdog**: detects a sketch that hangs the board — on load *or* mid-audition — recovers with a pure-C `zB` reboot, and denylists it, with correct attribution (a delayed hang is blamed on the sketch that caused it, not the next one).
- **OLED reset** to the boot logo between sketches; optional `amy.send(volume=…)` boost.
- **Gapless montage**: PCM segments + a single AAC encode, with title/username/description overlays.

### Two capture modes
1. **On-Mac** (Continuity/iPhone video muxed per clip) → `stitch plan` / `stitch render`.
2. **External-video** (`--external-video`) — the phone films the whole session (works around an iPhone shutter/exposure flicker on the OLED that can't be fixed through ffmpeg). A two-pulse **sync beep** plays at each sketch; `stitch sync` detects the beeps in the phone video(s), locates each sketch, and muxes in the **clean Model 16 audio**. Supports **multiple videos** across resumed runs.

### Doc
`docs/amyboard/control_api.md` — documents the AMYboard MIDI SysEx control protocol (file transfer both directions, state dump, run-python, reboot, ACK/error/version frames) for anyone writing their own tools. Linked from the AMYboard docs index.

## Notes
- Self-contained under `tools/`; no changes to firmware or build. Setup is a venv + `requirements.txt` (README included). Not wired into CI.
- `.gitignore` keeps the venv, per-user `config.json`, `session_out/`, and media out of git; `config.example.json` is the template.
- No submodule/pin changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)