### PR TITLE
docs: add set_display_rotation, hline, vline to accessories page

### DIFF
--- a/docs/amyboard/accessories.md
+++ b/docs/amyboard/accessories.md
@@ -54,7 +54,13 @@ amyboard.display_refresh()
 
 # Draw shapes
 amyboard.display.fill_rect(10, 40, 50, 20, 200)
+amyboard.display.hline(0, 70, 128, 255)   # horizontal line: x, y, width, color
+amyboard.display.vline(64, 0, 128, 255)   # vertical line: x, y, height, color
 amyboard.display_refresh()
+
+# Rotate the OLED (sh1107 only).  One of 0, 90, 180, 270 degrees.
+# The setting is saved and re-applied automatically on every boot.
+amyboard.set_display_rotation(90)
 
 # Show a live waveform visualization
 amyboard.draw_waveform()


### PR DESCRIPTION
Documents three recently added display APIs in `docs/amyboard/accessories.md` (Displays section):

- `amyboard.display.hline(x, y, w, col)` and `amyboard.display.vline(x, y, h, col)` — added to the shape-drawing example with argument comments.
- `amyboard.set_display_rotation(90)` — noted as sh1107-only, accepting 0/90/180/270, persisted and re-applied on boot (wording matches `python.md` and the docstring in `tulip/shared/amyboard-py/amyboard.py`).

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)