### PR TITLE
server: auto-tag shared sketch generations with the hardware they use

### DIFF
--- a/tulip/amyboardweb/static/spss.js
+++ b/tulip/amyboardweb/static/spss.js
@@ -65,6 +65,11 @@ var amyboard_world_files = [];
 var amyboard_world_loading_index = null;
 var amyboard_world_selected_tag = "";
 var amyboard_world_tag_palette = {};
+// Tag pills shown in the AMYboard World filter UI. #generated is a shortcut
+// for username=generator (see refresh_amyboard_world_files); the hardware
+// tags (#display, #encoder) are applied automatically by the server when a
+// shared generation is published.
+var AMYBOARD_WORLD_PILL_TAGS = ["featured", "official", "generated", "display", "encoder"];
 var selected_environment_file = null;
 var pending_environment_editor_load = false;
 var environment_editor_dirty = false;
@@ -2903,7 +2908,7 @@ function get_world_tag_query() {
 }
 
 function randomize_world_tag_palette() {
-    var tags = ["featured", "official", "generated"];
+    var tags = AMYBOARD_WORLD_PILL_TAGS;
     var classes = [
         "bg-primary",
         "bg-success",
@@ -2931,7 +2936,7 @@ function render_world_tag_pills() {
     if (!Object.keys(amyboard_world_tag_palette).length) {
         randomize_world_tag_palette();
     }
-    var tags = ["featured", "official", "generated"];
+    var tags = AMYBOARD_WORLD_PILL_TAGS;
     var html = "";
     for (var i = 0; i < tags.length; i++) {
         var tag = tags[i];

--- a/tulip/server/amyboardworld_db_api.md
+++ b/tulip/server/amyboardworld_db_api.md
@@ -37,7 +37,7 @@ AMYboard World file API (existing):
 - `DELETE /api/amyboardworld/files/{id}` (admin)
 - `POST /api/admin/amyboardworld/retag_hardware?dry_run=true|false&username=generator`
   (admin) — recompute the auto hardware tags (`#display`, `#encoder`,
-  `#quad-encoder`, `#8encoder`, `#8angle`) of every live `.py` sketch by
+  `#quad-encoder`, `#8encoder`, `#8angle`, `#cv`, `#audio-in`) of every live `.py` sketch by
   `username` from its stored source, preserving non-hardware tags. Sketches
   published from shared generations get these tags automatically; this
   endpoint backfills/refreshes them (idempotent).

--- a/tulip/server/amyboardworld_db_api.md
+++ b/tulip/server/amyboardworld_db_api.md
@@ -35,6 +35,12 @@ AMYboard World file API (existing):
 - `GET /api/amyboardworld/files/{id}/download`
 - `PATCH /api/amyboardworld/files/{id}/tags` (admin)
 - `DELETE /api/amyboardworld/files/{id}` (admin)
+- `POST /api/admin/amyboardworld/retag_hardware?dry_run=true|false&username=generator`
+  (admin) — recompute the auto hardware tags (`#display`, `#encoder`,
+  `#quad-encoder`, `#8encoder`, `#8angle`) of every live `.py` sketch by
+  `username` from its stored source, preserving non-hardware tags. Sketches
+  published from shared generations get these tags automatically; this
+  endpoint backfills/refreshes them (idempotent).
 
 Tulip World file API (new):
 

--- a/tulip/server/amyboardworld_db_api.py
+++ b/tulip/server/amyboardworld_db_api.py
@@ -458,9 +458,11 @@ def _insert_file_row(
     created_at_ms: int | None = None,
     item_type: str = "environment",
     client_ip: str = "",
+    tags: list[str] | None = None,
 ) -> int:
     ts_ms = _normalize_created_at_ms(created_at_ms)
     digest = hashlib.sha256(contents).hexdigest()
+    tags_json = json.dumps(_parse_tags(tags or []))
     with _open_db() as conn:
         # Use item_type column only for the environments table.
         if table == "environments":
@@ -469,7 +471,7 @@ def _insert_file_row(
                 INSERT INTO {table}(username, filename, description, tags_json, created_at_ms, size_bytes, sha256, blob_path, item_type, client_ip)
                 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
-                (username, filename, description, "[]", ts_ms, len(contents), digest, "", item_type, client_ip),
+                (username, filename, description, tags_json, ts_ms, len(contents), digest, "", item_type, client_ip),
             )
         else:
             cur = conn.execute(
@@ -477,7 +479,7 @@ def _insert_file_row(
                 INSERT INTO {table}(username, filename, description, tags_json, created_at_ms, size_bytes, sha256, blob_path, client_ip)
                 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
-                (username, filename, description, "[]", ts_ms, len(contents), digest, "", client_ip),
+                (username, filename, description, tags_json, ts_ms, len(contents), digest, "", client_ip),
             )
         item_id = int(cur.lastrowid)
         safe_filename = f"{item_id:09d}-{filename}"
@@ -1151,6 +1153,58 @@ def publish_shared_generations(
     return {"ok": True, "dry_run": dry_run, "pending": len(items), "published": published, "items": items}
 
 
+@app.post("/api/admin/amyboardworld/retag_hardware", dependencies=[Depends(_require_admin)])
+def retag_hardware(
+    dry_run: bool = Query(default=True),
+    username: str = Query(default=GENERATOR_USERNAME),
+) -> dict[str, Any]:
+    """Backfill: recompute the hardware tags (#display, #encoder, #quad-encoder,
+    #8encoder, #8angle) of every live .py sketch by `username` (default: the
+    generator user) from its stored source, preserving all non-hardware tags.
+    Idempotent — rerunning after a detector change converges on the new tags."""
+    username_s = (username or "").strip().lower()
+    if not username_s:
+        raise HTTPException(status_code=400, detail="username required")
+    with _open_db() as conn:
+        rows = conn.execute(
+            """
+            SELECT id, filename, blob_path, tags_json FROM environments
+            WHERE lower(username) = ? AND deleted_at_ms IS NULL
+              AND lower(filename) LIKE '%.py'
+            ORDER BY id ASC
+            """,
+            (username_s,),
+        ).fetchall()
+
+    items: list[dict[str, Any]] = []
+    changed = 0
+    for r in rows:
+        item_id = int(r["id"])
+        entry: dict[str, Any] = {"id": item_id, "filename": str(r["filename"])}
+        try:
+            code = Path(str(r["blob_path"])).read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            entry["error"] = "blob unreadable"
+            items.append(entry)
+            continue
+        old_tags = _parse_tags(r["tags_json"])
+        new_tags = _merge_hardware_tags(old_tags, _hardware_tags_for_sketch(code))
+        if new_tags == old_tags:
+            continue  # already correct — keep the report to actual changes
+        entry["tags"] = new_tags
+        entry["was"] = old_tags
+        if not dry_run:
+            with _open_db() as conn:
+                conn.execute(
+                    "UPDATE environments SET tags_json = ? WHERE id = ? AND deleted_at_ms IS NULL",
+                    (json.dumps(new_tags), item_id),
+                )
+                conn.commit()
+        changed += 1
+        items.append(entry)
+    return {"ok": True, "dry_run": dry_run, "scanned": len(rows), "changed": changed, "items": items}
+
+
 # ---------------------------------------------------------------------------
 # AMYboard sketch generation via the Claude API
 # ---------------------------------------------------------------------------
@@ -1455,6 +1509,86 @@ def _unique_generator_filename(base: str, gen_id: int) -> str:
     return f"gen-{gen_id}.py"
 
 
+# --- Hardware tags ----------------------------------------------------------
+# Published generator sketches are auto-tagged with the hardware accessories
+# they use, so the World UI can filter by accessory (#display, #encoder, ...).
+# Detection is a static scan of the comment-stripped source: deterministic,
+# free, and reusable for backfilling already-published sketches (see
+# /api/admin/amyboardworld/retag_hardware).
+
+HW_TAG_DISPLAY = "display"
+HW_TAG_ENCODER = "encoder"
+HW_TAG_QUAD_ENCODER = "quad-encoder"       # Adafruit Quad Rotary Encoder (4)
+HW_TAG_8ENCODER = "8encoder"               # M5Stack Unit 8Encoder (8)
+HW_TAG_8ANGLE = "8angle"                   # M5Stack Unit 8Angle
+HARDWARE_TAGS = (HW_TAG_DISPLAY, HW_TAG_ENCODER, HW_TAG_QUAD_ENCODER, HW_TAG_8ENCODER, HW_TAG_8ANGLE)
+
+# The 128x128 OLED: direct drawing calls plus the amyboard helpers that draw.
+_HW_DISPLAY_RE = re.compile(
+    r"\binit_display\s*\(|\bdisplay_refresh\s*\("
+    r"|\bdisplay\s*\.\s*(?:text|fill|fill_rect|rect|line|hline|vline|pixel|scroll|show|refresh|clear|message)\b"
+    r"|\bmonitor_encoders\s*\(|\bdraw_waveform\s*\(|\bshow_midi_ccs\s*\(|\bpatch_selector\s*\(|\bPatchSelector\s*\("
+)
+# Any rotary-encoder accessory: the unified amyboard.encoder() API, the legacy
+# seesaw helpers, the legacy m5_8encoder module, and the helpers built on them.
+_HW_ENCODER_RE = re.compile(
+    r"\bencoder\s*\(|\bamyboard\s*\.\s*Encoder\s*\(|\bread_encoder\s*\(|\bread_buttons\s*\(|\binit_buttons\s*\("
+    r"|\bset_neopixel\s*\(|\binit_neopixels\s*\(|\bshow_neopixels\s*\(|\bm5_8encoder\b"
+    r"|\bmonitor_encoders\s*\(|\bpatch_selector\s*\(|\bPatchSelector\s*\("
+)
+# Evidence a sketch is written for the 8-encoder unit specifically: the legacy
+# module, forcing type="m5stack", the m5stack-only toggle switch, touching an
+# encoder index above 3, or iterating/checking for more than 4 encoders.
+_HW_8ENCODER_RE = re.compile(
+    r"\bm5_8encoder\b|['\"]m5stack['\"]|\.switch\s*\(\s*\)"
+    r"|\.(?:read|button|led|reset)\s*\(\s*[4-7]\b"
+    r"|\bencoders\s*(?:==|>=)\s*[5-8]\b"
+    r"|\brange\s*\(\s*8\s*\)"
+)
+# Evidence a sketch is written for 4 encoders: forcing the quad type, the quad
+# seesaw address, touching an encoder index above 0, or iterating/checking 4.
+_HW_QUAD_ENCODER_RE = re.compile(
+    r"['\"]adafruit_quad['\"]|\bseesaw_dev\s*=\s*0x49\b"
+    r"|\.(?:read|button|led|reset)\s*\(\s*[1-3]\b"
+    r"|\bencoders\s*(?:==|>=)\s*4\b"
+    r"|\brange\s*\(\s*4\s*\)"
+)
+_HW_8ANGLE_RE = re.compile(r"\bm58angle\b")
+
+
+def _strip_python_comments(code: str) -> str:
+    """Drop '#'-to-end-of-line so words in comments (e.g. '# needs a display')
+    can't trip hardware detection. A '#' inside a string literal also truncates
+    that line, which only ever removes string content — the API-call names the
+    detectors match always appear before any string argument."""
+    return "\n".join(line.split("#", 1)[0] for line in (code or "").splitlines())
+
+
+def _hardware_tags_for_sketch(code: str) -> list[str]:
+    """The hardware tags (subset of HARDWARE_TAGS) a sketch's source earns."""
+    src = _strip_python_comments(code)
+    tags: list[str] = []
+    if _HW_DISPLAY_RE.search(src):
+        tags.append(HW_TAG_DISPLAY)
+    if _HW_ENCODER_RE.search(src):
+        tags.append(HW_TAG_ENCODER)
+        # Count-specific tags are additive with #encoder and mutually
+        # exclusive with each other; 8-encoder evidence wins.
+        if _HW_8ENCODER_RE.search(src):
+            tags.append(HW_TAG_8ENCODER)
+        elif _HW_QUAD_ENCODER_RE.search(src):
+            tags.append(HW_TAG_QUAD_ENCODER)
+    if _HW_8ANGLE_RE.search(src):
+        tags.append(HW_TAG_8ANGLE)
+    return tags
+
+
+def _merge_hardware_tags(existing: list[str], hw_tags: list[str]) -> list[str]:
+    """Replace the hardware tags in an existing tag list with hw_tags, keeping
+    every non-hardware tag (featured, official, ...) in place. Idempotent."""
+    return [t for t in existing if t not in HARDWARE_TAGS] + list(hw_tags)
+
+
 def _publish_shared_generation(
     gen_id: int,
     code: str,
@@ -1480,6 +1614,7 @@ def _publish_shared_generation(
         created_at_ms=created_at_ms,
         item_type="environment",
         client_ip=client_ip,
+        tags=_hardware_tags_for_sketch(code),
     )
     with _open_db() as conn:
         conn.execute("UPDATE generations SET uploaded_file_id = ? WHERE id = ?", (item_id, gen_id))

--- a/tulip/server/amyboardworld_db_api.py
+++ b/tulip/server/amyboardworld_db_api.py
@@ -1521,7 +1521,12 @@ HW_TAG_ENCODER = "encoder"
 HW_TAG_QUAD_ENCODER = "quad-encoder"       # Adafruit Quad Rotary Encoder (4)
 HW_TAG_8ENCODER = "8encoder"               # M5Stack Unit 8Encoder (8)
 HW_TAG_8ANGLE = "8angle"                   # M5Stack Unit 8Angle
-HARDWARE_TAGS = (HW_TAG_DISPLAY, HW_TAG_ENCODER, HW_TAG_QUAD_ENCODER, HW_TAG_8ENCODER, HW_TAG_8ANGLE)
+HW_TAG_CV = "cv"                           # CV1/CV2 jacks (in or out)
+HW_TAG_AUDIO_IN = "audio-in"               # line/SPDIF audio input
+HARDWARE_TAGS = (
+    HW_TAG_DISPLAY, HW_TAG_ENCODER, HW_TAG_QUAD_ENCODER, HW_TAG_8ENCODER,
+    HW_TAG_8ANGLE, HW_TAG_CV, HW_TAG_AUDIO_IN,
+)
 
 # The 128x128 OLED: direct drawing calls plus the amyboard helpers that draw.
 _HW_DISPLAY_RE = re.compile(
@@ -1554,6 +1559,12 @@ _HW_QUAD_ENCODER_RE = re.compile(
     r"|\brange\s*\(\s*4\s*\)"
 )
 _HW_8ANGLE_RE = re.compile(r"\bm58angle\b")
+# The CV1/CV2 jacks, either direction: the amyboard helpers, or routing the
+# ext0/ext1 control sources (CV inputs) into a parameter dict.
+_HW_CV_RE = re.compile(r"\bcv_in\s*\(|\bcv_out\s*\(|\bset_cv_out\s*\(|['\"]ext[01]['\"]")
+# Line/SPDIF audio input: the AUDIO_IN oscillator waves, or sampling from the
+# audio-in bus (bus=2) with amy.start_sample(...).
+_HW_AUDIO_IN_RE = re.compile(r"\bAUDIO_IN[01]\b|\bstart_sample\s*\([^)\n]*\bbus\s*=\s*2\b")
 
 
 def _strip_python_comments(code: str) -> str:
@@ -1580,6 +1591,10 @@ def _hardware_tags_for_sketch(code: str) -> list[str]:
             tags.append(HW_TAG_QUAD_ENCODER)
     if _HW_8ANGLE_RE.search(src):
         tags.append(HW_TAG_8ANGLE)
+    if _HW_CV_RE.search(src):
+        tags.append(HW_TAG_CV)
+    if _HW_AUDIO_IN_RE.search(src):
+        tags.append(HW_TAG_AUDIO_IN)
     return tags
 
 

--- a/tulip/server/test_hardware_tags.py
+++ b/tulip/server/test_hardware_tags.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Tests for the hardware-tag detector that auto-tags published generator
+sketches (#display, #encoder, #quad-encoder, #8encoder, #8angle). Pure local
+string checks — no network, DB, or Anthropic API key required.
+Run: python3 tulip/server/test_hardware_tags.py
+(requires the server deps: fastapi, pydantic, requests)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import amyboardworld_db_api as m  # noqa: E402
+
+_failures = 0
+
+
+def check(name: str, cond: bool) -> None:
+    global _failures
+    status = "ok  " if cond else "FAIL"
+    if not cond:
+        _failures += 1
+    print(f"[{status}] {name}")
+
+
+def tags(code: str) -> list[str]:
+    return m._hardware_tags_for_sketch(code)
+
+
+# --- nothing hardware-y ---
+check("plain synth sketch has no tags", tags("import amy\namy.send(synth=1, patch=256)\ndef loop():\n    pass\n") == [])
+check("empty code has no tags", tags("") == [])
+check("comment mentions don't count", tags("# use the display and encoder for this\nimport amy\ndef loop():\n    pass\n") == [])
+check("description line doesn't count", tags("# DESCRIPTION: encoder controls the display brightness\nimport amy\ndef loop():\n    pass\n") == [])
+
+# --- display ---
+check("init_display", tags("import amyboard\namyboard.init_display()\namyboard.display.text('hi',0,0,255)\namyboard.display_refresh()") == ["display"])
+check("display.fill_rect", tags("import amyboard\namyboard.display.fill_rect(0,0,10,10,255)\namyboard.display.show()") == ["display"])
+check("draw_waveform helper", tags("import amyboard\ndef loop():\n    amyboard.draw_waveform()") == ["display"])
+
+# --- encoder (unified API) ---
+check("amyboard.encoder()", tags("import amyboard\nenc = amyboard.encoder()\ndef loop():\n    v = enc.read(0)") == ["encoder"])
+check("legacy read_encoder", tags("import amyboard\ndef loop():\n    v = amyboard.read_encoder()") == ["encoder"])
+check("legacy m5_8encoder module", "8encoder" in tags("import m5_8encoder\ndef loop():\n    pass"))
+
+# --- encoder count evidence ---
+check("index 1-3 means quad", tags("import amyboard\nenc = amyboard.encoder()\ndef loop():\n    a = enc.read(0)\n    b = enc.read(3)") == ["encoder", "quad-encoder"])
+check("range(4) loop means quad", tags("import amyboard\nenc = amyboard.encoder()\ndef loop():\n    for i in range(4):\n        enc.read(i)") == ["encoder", "quad-encoder"])
+check("forced adafruit_quad means quad", tags("import amyboard\nenc = amyboard.encoder(type='adafruit_quad')\ndef loop():\n    pass") == ["encoder", "quad-encoder"])
+check("index 4-7 means 8encoder", tags("import amyboard\nenc = amyboard.encoder()\ndef loop():\n    enc.led(7, 255, 0, 0)") == ["encoder", "8encoder"])
+check("range(8) loop means 8encoder", tags("import amyboard\nenc = amyboard.encoder()\ndef loop():\n    for i in range(8):\n        enc.read(i)") == ["encoder", "8encoder"])
+check("forced m5stack means 8encoder", tags("import amyboard\nenc = amyboard.encoder(type=\"m5stack\")\ndef loop():\n    pass") == ["encoder", "8encoder"])
+check("switch() means 8encoder", tags("import amyboard\nenc = amyboard.encoder()\ndef loop():\n    if enc.switch():\n        pass") == ["encoder", "8encoder"])
+check("8 evidence beats 4 evidence", tags("import amyboard\nenc = amyboard.encoder()\ndef loop():\n    enc.read(2)\n    enc.read(6)") == ["encoder", "8encoder"])
+check("adaptive enc.encoders loop stays plain #encoder", tags("import amyboard\nenc = amyboard.encoder()\ndef loop():\n    for i in range(enc.encoders):\n        enc.read(i)") == ["encoder"])
+
+# --- 8angle ---
+check("m58angle module", tags("import m58angle\ndef loop():\n    v = m58angle.get(0)") == ["8angle"])
+
+# --- combinations ---
+check("display + encoder", tags("import amyboard\namyboard.init_display()\nenc = amyboard.encoder()\ndef loop():\n    amyboard.display.text(str(enc.read(0)),0,0,255)\n    amyboard.display.show()") == ["display", "encoder"])
+check("patch_selector implies display + encoder", tags("import amyboard\namyboard.patch_selector()\ndef loop():\n    pass") == ["display", "encoder"])
+
+# --- against the bundled example sketches ---
+SKETCHES = Path(__file__).resolve().parents[1] / "amyboardweb" / "sketches"
+
+
+def sketch_tags(name: str) -> list[str]:
+    return tags((SKETCHES / name).read_text(encoding="utf-8"))
+
+
+check("preset_selector.py -> display + encoder", sketch_tags("preset_selector.py") == ["display", "encoder"])
+check("acid_generator.py -> display", sketch_tags("acid_generator.py") == ["display"])
+check("woodpiano.py -> display", sketch_tags("woodpiano.py") == ["display"])
+check("arp.py -> no hardware tags", sketch_tags("arp.py") == [])
+check("cvfilter.py -> no hardware tags", sketch_tags("cvfilter.py") == [])
+
+# --- merge preserves non-hardware tags ---
+check("merge keeps featured", m._merge_hardware_tags(["featured", "display"], ["encoder"]) == ["featured", "encoder"])
+check("merge removes stale hw tags", m._merge_hardware_tags(["display", "encoder", "8encoder"], []) == [])
+check("merge is idempotent", m._merge_hardware_tags(["featured", "display"], ["display"]) == ["featured", "display"])
+
+# --- every hardware tag passes the API tag validator ---
+for t in m.HARDWARE_TAGS:
+    check(f"tag '{t}' is valid per TAG_RE", bool(m.TAG_RE.match(t)))
+
+print()
+if _failures:
+    print(f"{_failures} FAILURES")
+    sys.exit(1)
+print("all ok")

--- a/tulip/server/test_hardware_tags.py
+++ b/tulip/server/test_hardware_tags.py
@@ -57,6 +57,18 @@ check("adaptive enc.encoders loop stays plain #encoder", tags("import amyboard\n
 # --- 8angle ---
 check("m58angle module", tags("import m58angle\ndef loop():\n    v = m58angle.get(0)") == ["8angle"])
 
+# --- cv ---
+check("cv_in", tags("import amy, amyboard\ndef loop():\n    r = amyboard.cv_in(1)") == ["cv"])
+check("cv_out", tags("import amy, amyboard\ndef loop():\n    amyboard.cv_out(5.0, channel=0)") == ["cv"])
+check("set_cv_out", tags("import amy, amyboard\namyboard.set_cv_out(0, synth=2)\ndef loop():\n    pass") == ["cv"])
+check("ext0 modulation routing", tags("import amy\namy.send(synth=1, filter_freq={'const': 300, 'ext0': 0.25})\ndef loop():\n    pass") == ["cv"])
+check("ext1 modulation routing", tags('import amy\namy.send(synth=1, amp={"const": 1, "ext1": 0.5})\ndef loop():\n    pass') == ["cv"])
+
+# --- audio-in ---
+check("AUDIO_IN0 wave", tags("import amy\namy.send(synth=18, osc=0, wave=amy.AUDIO_IN0, amp=10)\ndef loop():\n    pass") == ["audio-in"])
+check("start_sample from audio-in bus", tags("import amy\namy.start_sample(preset=30, max_frames=44100, bus=2, midinote=60)\ndef loop():\n    pass") == ["audio-in"])
+check("start_sample from another bus is not audio-in", tags("import amy\namy.start_sample(preset=30, max_frames=44100, bus=0, midinote=60)\ndef loop():\n    pass") == [])
+
 # --- combinations ---
 check("display + encoder", tags("import amyboard\namyboard.init_display()\nenc = amyboard.encoder()\ndef loop():\n    amyboard.display.text(str(enc.read(0)),0,0,255)\n    amyboard.display.show()") == ["display", "encoder"])
 check("patch_selector implies display + encoder", tags("import amyboard\namyboard.patch_selector()\ndef loop():\n    pass") == ["display", "encoder"])
@@ -73,7 +85,11 @@ check("preset_selector.py -> display + encoder", sketch_tags("preset_selector.py
 check("acid_generator.py -> display", sketch_tags("acid_generator.py") == ["display"])
 check("woodpiano.py -> display", sketch_tags("woodpiano.py") == ["display"])
 check("arp.py -> no hardware tags", sketch_tags("arp.py") == [])
-check("cvfilter.py -> no hardware tags", sketch_tags("cvfilter.py") == [])
+check("cvfilter.py -> cv", sketch_tags("cvfilter.py") == ["cv"])
+check("midi2cv.py -> cv", sketch_tags("midi2cv.py") == ["cv"])
+check("audiopassthru.py -> audio-in", sketch_tags("audiopassthru.py") == ["audio-in"])
+check("filter_audio_in.py -> cv + audio-in", sketch_tags("filter_audio_in.py") == ["cv", "audio-in"])
+check("sampler.py -> audio-in", sketch_tags("sampler.py") == ["audio-in"])
 
 # --- merge preserves non-hardware tags ---
 check("merge keeps featured", m._merge_hardware_tags(["featured", "display"], ["encoder"]) == ["featured", "encoder"])


### PR DESCRIPTION
## Summary
- Sketches published to AMYboard World from consented ("share") generations are now automatically tagged with the hardware they use: `#display`, `#encoder`, plus `#quad-encoder` (written for 4 encoders) / `#8encoder` (written for 8), `#8angle` (M5Stack 8Angle unit), `#cv` (CV1/CV2 jacks in either direction, incl. ext0/ext1 modulation routing), and `#audio-in` (line/SPDIF input via AUDIO_IN waves or start_sample bus=2).
- Detection is a deterministic static scan of the comment-stripped sketch source (`_hardware_tags_for_sketch`), covering the unified `amyboard.encoder()` API, the legacy seesaw/`m5_8encoder` helpers, display drawing calls, and the display/encoder helper apps (`patch_selector`, `monitor_encoders`, `draw_waveform`, `show_midi_ccs`).
- New idempotent admin endpoint `POST /api/admin/amyboardworld/retag_hardware?dry_run=&username=` recomputes hardware tags for existing sketches (default: the `generator` user) from their stored blobs, preserving non-hardware tags like `#featured`.
- The AMYboard World tag-filter UI gains `#display` and `#encoder` pills (single shared tag list in `spss.js`).

## Testing
- New `tulip/server/test_hardware_tags.py` (same style as `test_reference_tools.py`): 47 checks covering each tag, encoder-count evidence, comment stripping, merges, TAG_RE validity, and spot checks against the bundled example sketches — all pass.
- `test_reference_tools.py` still passes.
- Local end-to-end against a scratch DB: publish-with-tags, dry-run + live retag, idempotency, `?tag=display` filtering, and admin-auth rejection all verified via FastAPI TestClient.
- Dry run of the detector against all 269 live production generator sketches (public API): 126 would gain tags — 104 `#display`, 81 `#encoder`, 51 `#cv`, 12 `#8encoder`, 8 `#audio-in`, 4 `#quad-encoder`, 1 `#8angle` — with spot checks confirming accuracy.
- `node --check` on `spss.js`.

After merge + Railway deploy, run the backfill:
`curl -X POST ".../api/admin/amyboardworld/retag_hardware?dry_run=false" -H "X-Admin-Token: ..."`

🤖 Generated with [Claude Code](https://claude.com/claude-code)