### PR TITLE
Test: exercise HW CI after full-flash partition reset

### DIFF
--- a/tulip/amyboard/hwci/README.md
+++ b/tulip/amyboard/hwci/README.md
@@ -194,3 +194,5 @@ Gated to same-repo
 PRs (the runner is on a public repo). Stable `/dev` names come from
 [`99-amyboard.rules`](99-amyboard.rules); install it on the Pi (needs sudo) after
 adding a board.
+
+<!-- HWCI end-to-end retest 2026-07-06T2: full pipeline after amy revert + SPIRAM fix + harness contamination fixes. -->


### PR DESCRIPTION
Comment-only change under `tulip/amyboard/hwci/` to trigger the AMYboard PR preview build and the chained HW CI run on both the AMYboard and Tulip bench boards, verifying they pass end-to-end after today's full-image reflash (partition table change).

Safe to close (or merge) once HW CI reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)