### PR TITLE
amyboard: single MIDI OUT init sequence — boot now goes through set_midi_type()

### DIFF
--- a/docs/amyboard/troubleshooting.md
+++ b/docs/amyboard/troubleshooting.md
@@ -93,7 +93,7 @@ We've fixed a lot of USB issues recently, so [upgrade to the latest firmware](fi
  - AMYboard defaults to Type A MIDI. If your gear uses Type B:
    ```python
    import amyboard
-   amyboard.init_midi(type='B')
+   amyboard.set_midi_type('B')
    ```
  - Add this to your `sketch.py` to make it permanent.
 

--- a/tulip/amyboard/pins.h
+++ b/tulip/amyboard/pins.h
@@ -29,8 +29,6 @@
 #define SPI0_SCK 12
 #define SPI0_MISO 13
 
-#define CV_IN1 16
-#define CV_IN2 15
 
 
 

--- a/tulip/shared/amy_connector.c
+++ b/tulip/shared/amy_connector.c
@@ -460,12 +460,14 @@ void run_amy(uint8_t midi_out_pin) {
 }
 
 #ifdef AMYBOARD
-// Switch the MIDI OUT TRS standard at runtime (Type A = pin 14, Type B = pin 15)
-// without restarting AMY. AMY transmits MIDI via uart_write_bytes(UART_NUM_1, ...) —
-// keyed on the UART number, not the GPIO — so moving the UART's TX line to the other
-// TRS leg is all that's needed. midi_uart is 1 on AMYboard (amy's esp_get_uart(1) ==
-// UART_NUM_1). Only MIDI OUT differs by type; MIDI IN works for both, so RX (MIDI_IN_PIN)
-// is left unchanged.
+// Set the MIDI OUT TRS standard (Type A = pin 14, Type B = pin 15). This is the single
+// MIDI OUT pin-init sequence: amyboard.set_midi_type() calls it both at boot (from
+// start_amy(), right after amy_start()) and at runtime, without restarting AMY. AMY
+// transmits MIDI via uart_write_bytes(UART_NUM_1, ...) — keyed on the UART number, not
+// the GPIO — so moving the UART's TX line to the other TRS leg is all that's needed.
+// midi_uart is 1 on AMYboard (amy's esp_get_uart(1) == UART_NUM_1). Only MIDI OUT
+// differs by type; MIDI IN works for both, so RX (MIDI_IN_PIN) is left unchanged.
+// Requires AMY's UART driver to be installed (amy_start() does this synchronously).
 void amyboard_set_midi_out(uint8_t midi_out_pin) {
     const uint8_t other_pin = (midi_out_pin == MIDI_OUT_PIN_A) ? MIDI_OUT_PIN_B : MIDI_OUT_PIN_A;
     // Let any in-flight MIDI byte finish before moving the TX line.

--- a/tulip/shared/amyboard-py/amyboard.py
+++ b/tulip/shared/amyboard-py/amyboard.py
@@ -537,23 +537,16 @@ def _normalize_midi_type(type):
 
 
 def init_midi(type='A'):
-    # Boot-time MIDI OUT setup, called by start_amy() before AMY starts. Holds the
-    # unused (source) TRS leg high and returns the data pin for amy to bind its UART TX
-    # to. For switching at runtime once AMY is running, use set_midi_type() instead.
-    from machine import Pin
-    global _midi_type
-    type = _normalize_midi_type(type)
-    out_pin = _MIDI_OUT_PINS[type]
-    other_pin = _MIDI_OUT_PINS['B' if type == 'A' else 'A']
-    Pin(other_pin, Pin.OUT).value(1)  # hold the non-data leg high (MIDI idle/source)
-    _midi_type = type
-    return out_pin
+    # Deprecated alias for set_midi_type(), kept for older sketches and docs.
+    return set_midi_type(type)
 
 
 def set_midi_type(type):
-    # Switch the MIDI OUT TRS standard ('A' or 'B') at runtime, without restarting AMY.
-    # AMY keeps running; only the UART TX line moves to the other leg. No persistence —
-    # this resets to the default (Type A) on reboot.
+    # Set the MIDI OUT TRS standard ('A' or 'B'). This is the single MIDI OUT init
+    # sequence — start_amy() calls it at boot and sketches call it at runtime — backed
+    # by amyboard_set_midi_out() in amy_connector.c, which points the UART TX line at
+    # the data leg and holds the unused leg high (MIDI idle/source). AMY keeps running.
+    # No persistence — this resets to the default (Type A) on reboot.
     global _midi_type
     type = _normalize_midi_type(type)
     tulip.amyboard_set_midi_out(_MIDI_OUT_PINS[type])
@@ -568,8 +561,11 @@ def midi_type():
 
 def start_amy():
     init_pcm9211()
-    midi_out_pin = init_midi()
-    tulip.amyboard_start(midi_out_pin)
+    # AMY binds its MIDI UART TX to this pin at start; set_midi_type() right after is
+    # the single MIDI OUT init sequence (it also holds the unused TRS leg high). It
+    # needs AMY's UART driver, which amy_start() installs, so it must come second.
+    tulip.amyboard_start(_MIDI_OUT_PINS[_midi_type])
+    set_midi_type(_midi_type)
     # Boot defaults so the board makes sound before (or without) a sketch:
     # the amyboard patch on channel 1 and GM drums (kit 0, TR-808) on channel
     # 10. Sketch startup re-applies these via _apply_knobs_text.


### PR DESCRIPTION
Dan flagged that switching MIDI OUT between TRS Type A and Type B needs to also hold the *other* leg high, and worried the recent runtime-switch change had two separate init routines. The hold-high was in fact present in both paths, but he was right that the logic lived in two places: `init_midi()` in Python (boot) and `amyboard_set_midi_out()` in C (runtime) each had their own copy of the pin logic — a recipe for drift.

This unifies them: `amyboard_set_midi_out()` in `amy_connector.c` is now the **only** routine that touches the MIDI OUT pins.

- `start_amy()` calls `set_midi_type()` right after `tulip.amyboard_start()`. This is safe because `amy_start()` installs the MIDI UART driver synchronously (`run_midi()` in amy's `api.c`), so the driver is ready by the time the Python call returns.
- `init_midi()` is reduced to a deprecated alias for `set_midi_type()`, kept for older sketches.
- `docs/amyboard/troubleshooting.md` updated — it recommended `init_midi(type='B')` at runtime, which never actually moved the UART TX line; it now recommends `set_midi_type('B')`.

## Hardware verification

Flashed to a local AMYboard and inspected the GPIO matrix over the REPL:

| state | GPIO14 | GPIO15 |
|---|---|---|
| boot (Type A) | U1TXD (matrix signal 15) | GPIO output, held high |
| `set_midi_type('B')` | GPIO output, held high | U1TXD |
| `set_midi_type('A')` | U1TXD | GPIO output, held high |

Board boots normally through the new path and `amyboard.midi_type()` reports correctly throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)