### PR TITLE
Rolling 'tulip' release becomes releases/latest; dated full bins; Tulip Desktop CI

### DIFF
--- a/.github/workflows/amyboard-release.yml
+++ b/.github/workflows/amyboard-release.yml
@@ -4,17 +4,20 @@ name: AMYboard release
 # preview site + firmware (amyboard-pr-<N>.vercel.app) and HW CI before merge,
 # each main commit is treated as releasable:
 #
-#   - firmware -> the rolling 'amyboard' GitHub release, kept NON-latest so it
-#                 never displaces releases/latest (the monthly combined Tulip
-#                 release that tulip.upgrade() + Tulip downloads depend on).
+#   - firmware -> the rolling 'amyboard' GitHub release, kept NON-latest (the
+#                 rolling 'tulip' release owns the LATEST mark / releases/latest).
 #                 amyboard.com's web flasher reads releases/download/amyboard;
 #                 on-device amyboard.upgrade() reads releases/tags/amyboard
 #                 (see get_latest_release() in tulip/shared/py/tulip.py).
+#                 The firmware + sys bins are also MIRRORED onto the rolling
+#                 'tulip' release: legacy AMYboards (monthly-release firmware,
+#                 <= v-jun-2026) OTA from releases/latest and need to find
+#                 amyboard-* assets there.
 #   - web      -> amyboardweb/stage/ deployed --prod to the 'amyboard' Vercel
 #                 project (amyboard.com).
 #
-# Tulip is NOT released here — it stays on the monthly release.sh cadence and
-# keeps releases/latest. This replaces the old 'dev' channel (rolling 'dev'
+# Tulip firmware is NOT built here — it has its own continuous release
+# (tulip-release.yml). This replaces the old 'dev' channel (rolling 'dev'
 # prerelease + amyboard-dev.vercel.app), which PR previews made redundant.
 
 on:
@@ -69,13 +72,15 @@ jobs:
             tulip/amyboard/dist/amyboard-sys.bin
 
       - name: Publish to the rolling 'amyboard' release (kept non-latest)
+        # Gated on main so a workflow_dispatch from a branch is a safe dry-run.
+        if: github.ref == 'refs/heads/main'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          # Create the rolling release once, explicitly NOT 'latest' so it never
-          # displaces the monthly combined Tulip release at releases/latest (which
-          # tulip.upgrade() + Tulip downloads depend on).
+          # Create the rolling release once, explicitly NOT 'latest': the rolling
+          # 'tulip' release owns the LATEST mark (releases/latest), which legacy
+          # pre-jun-2026 devices OTA from.
           if ! gh release view amyboard >/dev/null 2>&1; then
             gh release create amyboard \
               --latest=false \
@@ -83,13 +88,37 @@ jobs:
               --title "AMYboard (rolling release)" \
               --notes "Rolling AMYboard release built from main. Flashed by amyboard.com and on-device amyboard.upgrade(). Updated on every push to main; not a tagged version."
           fi
+          # Stable asset names — consumed by amyboard.com's flasher and
+          # amyboard.upgrade(). Do not rename.
           gh release upload --clobber amyboard \
             tulip/amyboard/dist/amyboard-firmware-AMYBOARD.bin \
             tulip/amyboard/dist/amyboard-full-AMYBOARD.bin \
             tulip/amyboard/dist/amyboard-sys.bin
+          # Date-coded copy of the full image for manufacturing ("which build is
+          # this file?"). One dated copy lives on the release at a time; older
+          # date codes are pruned. Same-day rebuilds clobber the same name.
+          DATE_CODE="$(date -u +%Y%m%d)"
+          cp tulip/amyboard/dist/amyboard-full-AMYBOARD.bin \
+             "tulip/amyboard/dist/amyboard-full-AMYBOARD-${DATE_CODE}.bin"
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/amyboard" --jq '.assets[].name' \
+            | { grep -E '^amyboard-full-AMYBOARD-[0-9]{8}\.bin$' || true; } \
+            | { grep -v "${DATE_CODE}" || true; } \
+            | while read -r stale; do gh release delete-asset amyboard "$stale" --yes; done
+          gh release upload --clobber amyboard \
+            "tulip/amyboard/dist/amyboard-full-AMYBOARD-${DATE_CODE}.bin"
           # Refresh the release body with the exact released commit for provenance.
           gh release edit amyboard \
             --notes "Rolling AMYboard release, built from main @ ${GITHUB_SHA}. Flashed by amyboard.com and on-device amyboard.upgrade(). Updated on every push to main; not a tagged version."
+          # Mirror onto the rolling 'tulip' release (= releases/latest): legacy
+          # AMYboards running monthly-release firmware (<= v-jun-2026) OTA from
+          # releases/latest and look for these exact asset names. Once upgraded,
+          # they track releases/tags/amyboard and no longer need the mirror.
+          if gh release view tulip >/dev/null 2>&1; then
+            gh release upload --clobber tulip \
+              tulip/amyboard/dist/amyboard-firmware-AMYBOARD.bin \
+              tulip/amyboard/dist/amyboard-full-AMYBOARD.bin \
+              tulip/amyboard/dist/amyboard-sys.bin
+          fi
 
   web:
     runs-on: ubuntu-latest

--- a/.github/workflows/tulip-release.yml
+++ b/.github/workflows/tulip-release.yml
@@ -1,16 +1,26 @@
 name: Tulip firmware release
 
-# Continuous Tulip FIRMWARE release on push to main: build TULIP4_R11 and publish
-# to the rolling 'tulip' GitHub release, kept NON-latest (--latest=false) so it
-# never displaces releases/latest (the monthly combined release). On-device
-# tulip.upgrade() reads releases/tags/tulip (see get_latest_release() in
-# tulip/shared/py/tulip.py). Mirrors the firmware job of amyboard-release.yml.
+# Continuous Tulip release on push to main: build TULIP4_R11 firmware (and Tulip
+# Desktop for macOS) and publish to the rolling 'tulip' GitHub release.
+#
+# The rolling 'tulip' release is marked LATEST: it is what the releases page
+# badges and what the GitHub API serves at releases/latest. That matters because
+# firmware shipped in the monthly releases (<= v-jun-2026, before continuous
+# release) OTAs from releases/latest — those Tulips find tulip-firmware-*/
+# tulip-sys.bin here, and legacy AMYboards find the amyboard-* bins that
+# amyboard-release.yml mirrors onto this release. Current firmware reads
+# releases/tags/tulip directly (see get_latest_release() in
+# tulip/shared/py/tulip.py). If a monthly release.sh release is ever cut again,
+# create it with --latest=false so it doesn't steal releases/latest back.
 #
 # Only TULIP4_R11 is shipped; TDECK/N16R8/N32R8 are developer-only (build them by
 # hand with `idf.py -DMICROPY_BOARD=<board> build`).
 #
-# Paths are firmware-only (NOT tulip/web/**) so a web-only change doesn't bump the
-# firmware release date; the web app is deployed separately by tulip-web-release.yml.
+# Paths are firmware/desktop-only (NOT tulip/web/**) so a web-only change doesn't
+# bump the release date; the web app is deployed separately by tulip-web-release.yml.
+#
+# Publishing is gated on main so a workflow_dispatch from a branch is a safe
+# dry-run: everything builds, nothing is uploaded to the release.
 
 on:
   push:
@@ -20,6 +30,7 @@ on:
       - 'tulip/esp32s3/**'
       - 'tulip/shared/**'
       - 'tulip/fs/tulip/**'
+      - 'tulip/macos/**'
       - '.github/workflows/tulip-release.yml'
   workflow_dispatch:
 
@@ -60,24 +71,174 @@ jobs:
             tulip/esp32s3/dist/tulip-full-TULIP4_R11.bin
             tulip/esp32s3/dist/tulip-sys.bin
 
-      - name: Publish to the rolling 'tulip' release (kept non-latest)
+      - name: Publish to the rolling 'tulip' release
+        if: github.ref == 'refs/heads/main'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          # Create the rolling release once, explicitly NOT 'latest' so it never
-          # displaces releases/latest (the monthly combined Tulip release).
+          # Create the rolling release once. It is kept marked LATEST (see the
+          # header comment: legacy pre-jun-2026 devices OTA from releases/latest).
           if ! gh release view tulip >/dev/null 2>&1; then
             gh release create tulip \
-              --latest=false \
               --target "$GITHUB_SHA" \
               --title "Tulip (rolling release)" \
               --notes "Rolling Tulip release built from main (TULIP4_R11). OTA'd by tulip.upgrade(). Updated on every push to main; not a tagged version."
           fi
+          # Stable asset names — consumed by tulip.upgrade(), the docs' direct
+          # download links, and legacy releases/latest OTA. Do not rename.
           gh release upload --clobber tulip \
             tulip/esp32s3/dist/tulip-firmware-TULIP4_R11.bin \
             tulip/esp32s3/dist/tulip-full-TULIP4_R11.bin \
             tulip/esp32s3/dist/tulip-sys.bin
-          # Refresh the body with the exact released commit for provenance.
+          # Date-coded copy of the full image for manufacturing ("which build is
+          # this file?"). One dated copy lives on the release at a time; older
+          # date codes are pruned. Same-day rebuilds clobber the same name.
+          DATE_CODE="$(date -u +%Y%m%d)"
+          cp tulip/esp32s3/dist/tulip-full-TULIP4_R11.bin \
+             "tulip/esp32s3/dist/tulip-full-TULIP4_R11-${DATE_CODE}.bin"
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/tulip" --jq '.assets[].name' \
+            | { grep -E '^tulip-full-TULIP4_R11-[0-9]{8}\.bin$' || true; } \
+            | { grep -v "${DATE_CODE}" || true; } \
+            | while read -r stale; do gh release delete-asset tulip "$stale" --yes; done
+          gh release upload --clobber tulip \
+            "tulip/esp32s3/dist/tulip-full-TULIP4_R11-${DATE_CODE}.bin"
+          # Refresh the body with the exact released commit for provenance, and
+          # (re)assert latest so releases/latest keeps serving legacy OTA.
           gh release edit tulip \
+            --latest \
             --notes "Rolling Tulip release (TULIP4_R11), built from main @ ${GITHUB_SHA}. OTA'd by tulip.upgrade(). Updated on every push to main; not a tagged version."
+
+  # Tulip Desktop for macOS (universal arm64+x86_64), mirroring tulip/macos/
+  # package.sh. Signing + notarization run only when the Apple credentials are
+  # present as repo secrets; without them the app is still built (and uploaded
+  # as a workflow artifact) but NOT published to the release, since an unsigned
+  # zip would be blocked by Gatekeeper on download.
+  #
+  # Required secrets for publishing:
+  #   MACOS_SIGNING_CERT_P12      — base64 of the "Developer ID Application"
+  #                                 certificate + private key (.p12)
+  #   MACOS_SIGNING_CERT_PASSWORD — password for the .p12
+  #   MACOS_NOTARY_API_KEY        — App Store Connect API key file contents (.p8)
+  #   MACOS_NOTARY_API_KEY_ID     — key ID for that key
+  #   MACOS_NOTARY_API_ISSUER_ID  — issuer ID for that key
+  desktop:
+    runs-on: macos-14
+    permissions:
+      contents: write                # upload Tulip_Desktop.zip to the 'tulip' release
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Build Tulip Desktop (universal binary)
+        run: |
+          set -euo pipefail
+          cd tulip/macos
+          # Mirrors package.sh: build each arch, lipo, assemble the app bundle.
+          make WHICH_ARCH=arm64
+          cp build-standard/tulip/obj/tulip.arm64 .
+          rm -rf build-standard
+          make WHICH_ARCH=x86_64
+          cp build-standard/tulip/obj/tulip.x86_64 .
+          rm -rf build-standard
+          lipo -create -output tulip tulip.x86_64 tulip.arm64
+          rm -rf dist
+          mkdir -p "dist/Tulip Desktop.app/Contents/MacOS" \
+                   "dist/Tulip Desktop.app/Contents/Resources" \
+                   "dist/Tulip Desktop.app/Contents/Frameworks" \
+                   "dist/Tulip Desktop.app/Contents/libs"
+          cp tulip "dist/Tulip Desktop.app/Contents/MacOS/"
+          cp Info.plist "dist/Tulip Desktop.app/Contents/"
+          cp -rf ../fs "dist/Tulip Desktop.app/Contents/Resources/"
+          cp -a SDL2.framework "dist/Tulip Desktop.app/Contents/Frameworks/"
+          install_name_tool -add_rpath @executable_path/../Frameworks \
+            "dist/Tulip Desktop.app/Contents/MacOS/tulip"
+          cp tulip.icns "dist/Tulip Desktop.app/Contents/Resources/"
+
+      - name: Check for signing secrets
+        id: signing
+        env:
+          CERT_P12: ${{ secrets.MACOS_SIGNING_CERT_P12 }}
+          NOTARY_KEY: ${{ secrets.MACOS_NOTARY_API_KEY }}
+        run: |
+          if [ -n "$CERT_P12" ] && [ -n "$NOTARY_KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::macOS signing/notarization secrets not set — building unsigned; Tulip_Desktop.zip will NOT be published to the release."
+          fi
+
+      - name: Sign, notarize, and staple
+        if: steps.signing.outputs.enabled == 'true'
+        env:
+          CERT_P12: ${{ secrets.MACOS_SIGNING_CERT_P12 }}
+          CERT_PASSWORD: ${{ secrets.MACOS_SIGNING_CERT_PASSWORD }}
+          NOTARY_KEY: ${{ secrets.MACOS_NOTARY_API_KEY }}
+          NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_API_KEY_ID }}
+          NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_API_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          cd tulip/macos
+          # Import the Developer ID cert into a throwaway keychain.
+          KEYCHAIN="$RUNNER_TEMP/tulip-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          echo "$CERT_P12" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$RUNNER_TEMP/cert.p12" -P "$CERT_PASSWORD" \
+            -A -t cert -f pkcs12 -k "$KEYCHAIN"
+          security set-key-partition-list -S apple-tool:,apple: \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" >/dev/null
+          security list-keychains -d user -s "$KEYCHAIN" login.keychain
+          DEV_ID="$(security find-identity -v -p codesigning "$KEYCHAIN" \
+            | awk -F'"' '/Developer ID Application/ {print $2; exit}')"
+          if [ -z "$DEV_ID" ]; then
+            echo "::error::No 'Developer ID Application' identity found in the imported .p12"; exit 1
+          fi
+          # Same signing order as package.sh: framework, binary, then the bundle
+          # with hardened runtime (required for notarization).
+          codesign -s "$DEV_ID" -f \
+            "dist/Tulip Desktop.app/Contents/Frameworks/SDL2.framework/Versions/A/SDL2"
+          codesign -s "$DEV_ID" -f "dist/Tulip Desktop.app/Contents/MacOS/tulip"
+          codesign --force --options runtime --timestamp --sign "$DEV_ID" \
+            "dist/Tulip Desktop.app"
+          # Notarize with an App Store Connect API key, then staple.
+          echo "$NOTARY_KEY" > "$RUNNER_TEMP/notary.p8"
+          cd dist
+          /usr/bin/ditto -c -k --sequesterRsrc --keepParent "Tulip Desktop.app" Tulip_Desktop.zip
+          xcrun notarytool submit Tulip_Desktop.zip \
+            --key "$RUNNER_TEMP/notary.p8" \
+            --key-id "$NOTARY_KEY_ID" \
+            --issuer "$NOTARY_ISSUER_ID" \
+            --wait
+          rm -rf "Tulip Desktop.app"
+          unzip -q Tulip_Desktop.zip
+          xcrun stapler staple "Tulip Desktop.app"
+          /usr/bin/ditto -c -k --sequesterRsrc --keepParent "Tulip Desktop.app" Tulip_Desktop.zip
+
+      - name: Zip unsigned app (no signing secrets)
+        if: steps.signing.outputs.enabled != 'true'
+        run: |
+          set -euo pipefail
+          cd tulip/macos/dist
+          /usr/bin/ditto -c -k --sequesterRsrc --keepParent "Tulip Desktop.app" Tulip_Desktop.zip
+
+      - name: Upload Tulip Desktop artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tulip-desktop-macos
+          if-no-files-found: error
+          path: tulip/macos/dist/Tulip_Desktop.zip
+
+      - name: Publish Tulip_Desktop.zip to the rolling 'tulip' release
+        if: github.ref == 'refs/heads/main' && steps.signing.outputs.enabled == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if ! gh release view tulip >/dev/null 2>&1; then
+            echo "::error::rolling 'tulip' release does not exist yet"; exit 1
+          fi
+          gh release upload --clobber tulip tulip/macos/dist/Tulip_Desktop.zip

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,30 @@ For `tulip cc` or `tulip esp32s3` build:
 
 ## Tulip Release
 
-Only perform a Tulip release when the user explicitly asks for it.
+Tulip firmware is **released continuously** by `.github/workflows/tulip-release.yml`
+(push to `main` on firmware-affecting paths; also `workflow_dispatch`): it builds
+TULIP4_R11 and publishes to the rolling **`tulip`** GitHub release, which is kept
+marked **Latest** — it IS `releases/latest`. That matters because firmware from the
+old monthly releases (≤ `v-jun-2026`) OTAs from `releases/latest`; current firmware
+reads `releases/tags/tulip` directly. The same workflow also builds **Tulip Desktop
+for macOS** (universal) and uploads `Tulip_Desktop.zip` to the rolling release —
+signing/notarization requires the `MACOS_SIGNING_CERT_P12`/`MACOS_SIGNING_CERT_PASSWORD`
+and `MACOS_NOTARY_API_KEY`/`MACOS_NOTARY_API_KEY_ID`/`MACOS_NOTARY_API_ISSUER_ID` repo
+secrets; without them the zip is built as a CI artifact but not published.
+
+Both rolling releases also carry a **date-coded copy of the full flash image**
+(`tulip-full-TULIP4_R11-YYYYMMDD.bin`, `amyboard-full-AMYBOARD-YYYYMMDD.bin`) for the
+manufacturing partner; the stable-named bins must never be renamed (the web flasher,
+docs links, and `upgrade()` fetch them by exact name). Only the newest date code is
+kept on the release.
+
+### Monthly release.sh (legacy)
+
+The monthly `release.sh` flow below is legacy — only perform it when the user
+explicitly asks for it. **If a monthly release is ever cut again, create it with
+`--latest=false`**: it must not take the Latest mark back from the rolling `tulip`
+release, or legacy devices and the releases page would point at a stale build again
+(this is exactly why `v-jun-2026` was retired).
 
 **Important:** Releases must always be built from the `main` branch (or a worktree reset to `origin/main`). Before starting a release, ensure the working tree is on `main` with all intended changes merged. Never release from an unmerged feature branch.
 
@@ -158,20 +181,20 @@ The workflow is `.github/workflows/amyboard-release.yml` (push to `main` on
 AMYboard-affecting paths; also `workflow_dispatch`):
 
 1. **firmware** → built and uploaded to the rolling **`amyboard`** GitHub release. That
-   release is kept **non-latest** (`gh release create --latest=false`) so it never
-   displaces `releases/latest` — which stays the monthly combined Tulip release that
-   `tulip.upgrade()` and Tulip firmware downloads depend on. amyboard.com's flasher
-   reads `releases/download/amyboard`, and on-device `amyboard.upgrade()` reads
-   `releases/tags/amyboard` (see `get_latest_release()` in `tulip/shared/py/tulip.py`).
+   release is kept **non-latest** — the rolling `tulip` release owns the Latest mark
+   (`releases/latest`). amyboard.com's flasher reads `releases/download/amyboard`, and
+   on-device `amyboard.upgrade()` reads `releases/tags/amyboard` (see
+   `get_latest_release()` in `tulip/shared/py/tulip.py`). The firmware + sys bins are
+   also **mirrored onto the rolling `tulip` release** so legacy AMYboards (monthly
+   firmware ≤ `v-jun-2026`, which OTA from `releases/latest`) can still upgrade.
 2. **web** → `amyboardweb/stage/` is built and deployed `--prod` to the **`amyboard`**
    Vercel project (amyboard.com). Requires repo secret `VERCEL_TOKEN`
    (scope `bwhitmans-projects`), same as the PR-preview workflow.
 
-Tulip is **not** released here — Tulip firmware/web stay on the monthly cadence (see
-"Tulip Release"), and `releases/latest` remains the monthly `v-XXX-2026` release.
-`release.sh` still also uploads AMYboard assets to that monthly release, which older
-firmware (from before this decoupling) OTAs from `releases/latest` until it is flashed
-once to pick up the new `amyboard`-tag upgrade path.
+Tulip firmware is **not** built here — it has its own continuous release,
+`tulip-release.yml` (see "Tulip Release"). `releases/latest` is the rolling `tulip`
+release; the monthly `v-XXX-2026` releases are retired (the misleading
+"Latest"-badged `v-jun-2026` was demoted in July 2026).
 
 ### How the flasher chooses a channel
 


### PR DESCRIPTION
## What

1. **`releases/latest` moves to the rolling `tulip` release.** The misleading "Latest"-badged `v-jun-2026` monthly release was sending people (and legacy `tulip.upgrade()` firmware, which reads `releases/latest`) to a stale June build. `tulip-release.yml` now keeps the rolling release marked Latest (`gh release edit tulip --latest` on every publish).
2. **Legacy AMYboard OTA keeps working**: `amyboard-release.yml` mirrors `amyboard-firmware-AMYBOARD.bin` / `amyboard-full-AMYBOARD.bin` / `amyboard-sys.bin` onto the rolling `tulip` release, since pre-jun-2026 AMYboards also OTA from `releases/latest`. Once upgraded they track `releases/tags/amyboard`.
3. **Date-coded full bins for manufacturing**: each publish also uploads `tulip-full-TULIP4_R11-YYYYMMDD.bin` / `amyboard-full-AMYBOARD-YYYYMMDD.bin`. Stable names are untouched (web flasher, docs links, and `upgrade()` fetch by exact name); older date codes are pruned so one dated copy lives on each release.
4. **Tulip Desktop built in CI**: new `desktop` job on `macos-14` mirrors `tulip/macos/package.sh` (arm64 + x86_64, lipo, app bundle). With Apple credential secrets set (`MACOS_SIGNING_CERT_P12`, `MACOS_SIGNING_CERT_PASSWORD`, `MACOS_NOTARY_API_KEY`, `MACOS_NOTARY_API_KEY_ID`, `MACOS_NOTARY_API_ISSUER_ID`) it signs, notarizes, staples, and publishes `Tulip_Desktop.zip` to the rolling release; without them it uploads the unsigned zip as a CI artifact only.
5. **Publishing is gated on `main`** in both workflows, so a `workflow_dispatch` from a branch is a safe dry-run build.
6. AGENTS.md updated to match (including: any future monthly `release.sh` release must be created `--latest=false`).

## Why

People were downloading `v-jun-2026` because GitHub badged it "Latest", even though Tulip and AMYboard have released continuously since. This makes the rolling release the real (and only) "latest" without breaking any legacy OTA path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)