### PR TITLE
Try AMY CPU overload detection + failsafe (amy#826)

### DIFF
--- a/tulip/amyboardweb/static/spss.js
+++ b/tulip/amyboardweb/static/spss.js
@@ -1754,6 +1754,20 @@ function _process_complete_sysex(d) {
         if (_fw_version_resolve) { var vr = _fw_version_resolve; _fw_version_resolve = null; vr(verStr); }
         return;
     }
+    // AMY CPU overload report: F0 00 03 45 'L' <base64 load percent> F7.
+    // Sent by amyboard._on_amy_overload() after AMY's failsafe reset the synth
+    // and the sketch loop was stopped. Like 'V', intercept before the
+    // chunk-marker logic.
+    if (d[4] === 0x4C /* 'L' */) {
+        var loadB64 = '';
+        for (var li = 5; li < d.length - 1; li++) loadB64 += String.fromCharCode(d[li]);
+        var loadPct = '';
+        if (loadB64) { try { loadPct = atob(loadB64); } catch (e) { loadPct = ''; } }
+        console.log('AMY overload report from board, load ' + loadPct + '%');
+        show_python_error('This sketch needed more CPU than the AMYboard has, so the sketch was stopped and the synth was reset.\n\n'
+            + 'Try fewer voices, less reverb/chorus, or shorter note releases, then run it again.');
+        return;
+    }
     // Chunk marker at position 4.
     var marker = d[4];
     var payloadStart, isChunked, isEnd;

--- a/tulip/server/amyboardworld_db_api.py
+++ b/tulip/server/amyboardworld_db_api.py
@@ -1286,6 +1286,12 @@ Modulation routing: a parameter may be a dict to mix a constant with a control s
 - In an amp dict, NEVER set 'const' to 0: amp's 'const' is the oscillator's overall gain and 0 mutes it completely. Omit 'const' (it defaults to 1) or set it to 1, e.g. amp={'vel': 1, 'eg0': 1}.
 Global effects are strings, e.g. amy.send(reverb="0.5,0.3,0.05"), amy.send(chorus="0.6,2,0.3"), amy.send(echo="0.4,200,0.3,0.3").
 
+CPU / VOICE BUDGET (hard limit -- overloaded sketches get stopped by the board):
+The AMYboard has a fixed CPU budget. Before writing any amy.send(synth=..., num_voices=...) calls, add up the cost of EVERY voice you allocate across ALL synths:
+- A Juno-6 voice (patch 0-127) costs 1/8 of the budget.
+- A DX7 voice (patch 128-255) costs 1/12 of the budget.
+The total must never exceed 1.0. So the ceiling is 8 Juno-6 voices total, OR 12 DX7 voices total, OR a proportional mixture -- e.g. 4 Juno + 6 DX7 (4/8 + 6/12 = 1.0), or 2 Juno + 9 DX7 (2/8 + 9/12 = 1.0). Any mix of timbres/patches within a family is fine; it is the voice counts that matter. When in doubt, allocate fewer voices -- exceeding the budget causes audio dropouts and the board will stop the sketch and reset the synth.
+
 THE amyboard MODULE (import amyboard) -- physical I/O (present on hardware; safe to call in the simulator)
 - amyboard.cv_in(channel) -> volts (-10..10). channel 0 = CV1, 1 = CV2.
 - amyboard.cv_out(volts, channel): write a CV output.

--- a/tulip/shared/amy_connector.c
+++ b/tulip/shared/amy_connector.c
@@ -50,9 +50,18 @@ void midi_out(uint8_t * bytes, uint16_t len) {
 uint8_t last_midi[MIDI_QUEUE_DEPTH][MAX_MIDI_BYTES_PER_MESSAGE];
 uint8_t last_midi_len[MIDI_QUEUE_DEPTH];
 extern mp_obj_t midi_callback;
+extern mp_obj_t amy_overload_callback;
 
 int16_t midi_queue_head = 0;
 int16_t midi_queue_tail = 0;
+
+// AMY calls this from its render task when the CPU overload failsafe trips
+// (it has already reset the synth and played its bleep). Hand off to Python
+// with the load as a percent -- a small int, so no cross-task heap allocation.
+void tulip_amy_overload_hook(float load) {
+    if (amy_overload_callback != NULL)
+        mp_sched_schedule(amy_overload_callback, MP_OBJ_NEW_SMALL_INT((mp_int_t)(load * 100.0f)));
+}
 
 
 #ifdef ESP_PLATFORM
@@ -425,6 +434,7 @@ void run_amy(uint8_t midi_out_pin) {
     amy_config.amy_external_update_file_hook = mp_update_file_hook;
     amy_config.amy_external_exec_hook = mp_exec_hook;
     amy_config.amy_external_reboot_hook = mp_reboot_hook;
+    amy_config.amy_external_overload_hook = tulip_amy_overload_hook;
     extern void tulip_amy_sequencer_hook(uint32_t tick_count);
     amy_config.amy_external_sequencer_hook = tulip_amy_sequencer_hook;
     amy_config.audio = AMY_AUDIO_IS_I2S;
@@ -487,6 +497,7 @@ void amyboard_set_midi_out(uint8_t midi_out_pin) {
 void run_amy(uint8_t capture_device_id, uint8_t playback_device_id) {
     amy_config_t amy_config = amy_default_config();
     amy_config.amy_external_midi_input_hook = tulip_midi_input_hook;
+    amy_config.amy_external_overload_hook = tulip_amy_overload_hook;
     extern void tulip_amy_sequencer_hook(uint32_t tick_count);
     amy_config.amy_external_sequencer_hook = tulip_amy_sequencer_hook;
     amy_config.features.default_synths = 0; // midi.py does this for us

--- a/tulip/shared/amyboard-py/amyboard.py
+++ b/tulip/shared/amyboard-py/amyboard.py
@@ -566,6 +566,7 @@ def start_amy():
     # needs AMY's UART driver, which amy_start() installs, so it must come second.
     tulip.amyboard_start(_MIDI_OUT_PINS[_midi_type])
     set_midi_type(_midi_type)
+    tulip.amy_overload_callback(_on_amy_overload)
     # Boot defaults so the board makes sound before (or without) a sketch:
     # the amyboard patch on channel 1 and GM drums (kit 0, TR-808) on channel
     # 10. Sketch startup re-applies these via _apply_knobs_text.
@@ -629,6 +630,23 @@ def _report_sketch_error(detail):
         import binascii
         payload = binascii.b2a_base64(str(detail).encode('utf-8')).rstrip()
         tulip.midi_out(bytes([0xF0, 0x00, 0x03, 0x45, 0x58]) + payload + bytes([0xF7]))
+    except Exception:
+        pass
+
+def _on_amy_overload(load_pct):
+    """Called (via tulip.amy_overload_callback, scheduled from the AMY render
+    task) after AMY's CPU overload failsafe has already reset the synth and
+    played its bleep. Stop the sketch loop so it can't drive the board back
+    into overload, then tell the web editor over sysex, framed as
+    F0 00 03 45 'L' <base64 load percent> F7, so it can pop the "this sketch
+    took too many resources" message. Best-effort: with no web host attached
+    the send goes nowhere and the bleep was the user's notification."""
+    stop_sketch()
+    tulip.stderr_write("AMY overload (%d%% render load): sketch stopped, synth reset" % load_pct)
+    try:
+        import binascii
+        payload = binascii.b2a_base64(str(load_pct).encode('utf-8')).rstrip()
+        tulip.midi_out(bytes([0xF0, 0x00, 0x03, 0x45, 0x4C]) + payload + bytes([0xF7]))
     except Exception:
         pass
 

--- a/tulip/shared/modtulip.c
+++ b/tulip/shared/modtulip.c
@@ -38,6 +38,12 @@ STATIC mp_obj_t tulip_amy_ticks_ms(size_t n_args, const mp_obj_t *args) {
     return mp_obj_new_int(amy_sysclock());
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(tulip_amy_ticks_ms_obj, 0, 0, tulip_amy_ticks_ms);
+
+// Smoothed fraction of real time AMY spends rendering (0..1); ~1.0 means overloaded.
+STATIC mp_obj_t tulip_amy_render_load(size_t n_args, const mp_obj_t *args) {
+    return mp_obj_new_float(amy_get_render_load());
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(tulip_amy_render_load_obj, 0, 0, tulip_amy_render_load);
 #endif
 
 STATIC mp_obj_t tulip_ticks_ms(size_t n_args, const mp_obj_t *args) {
@@ -1710,6 +1716,7 @@ STATIC const mp_rom_map_elem_t tulip_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_amy_send), MP_ROM_PTR(&tulip_amy_send_obj) },
     { MP_ROM_QSTR(MP_QSTR_amy_send_sysex), MP_ROM_PTR(&tulip_amy_send_sysex_obj) },
     { MP_ROM_QSTR(MP_QSTR_amy_ticks_ms), MP_ROM_PTR(&tulip_amy_ticks_ms_obj) },
+    { MP_ROM_QSTR(MP_QSTR_amy_render_load), MP_ROM_PTR(&tulip_amy_render_load_obj) },
     { MP_ROM_QSTR(MP_QSTR_pcm_load_file), MP_ROM_PTR(&tulip_pcm_load_file_obj) },
 #endif
 

--- a/tulip/shared/modtulip.c
+++ b/tulip/shared/modtulip.c
@@ -96,6 +96,16 @@ STATIC mp_obj_t tulip_midi_callback(size_t n_args, const mp_obj_t *args) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(tulip_midi_callback_obj, 1, 1, tulip_midi_callback);
 
+// Called (via mp_sched_schedule from the AMY render task) when AMY's CPU
+// overload failsafe trips, with the render load percent as a small int.
+mp_obj_t amy_overload_callback = NULL;
+
+STATIC mp_obj_t tulip_amy_overload_callback(size_t n_args, const mp_obj_t *args) {
+    amy_overload_callback = (args[0] == mp_const_none) ? NULL : args[0];
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(tulip_amy_overload_callback_obj, 1, 1, tulip_amy_overload_callback);
+
 // tulip.external_midi_sync() is defined in tulip.py: it sends the AMY wire
 // command (external_midi_sync / zC) so it also works on the web builds, where
 // AMY is a separate WASM module reachable only via the wire protocol.
@@ -1690,6 +1700,7 @@ STATIC const mp_rom_map_elem_t tulip_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_seq_remove_callback), MP_ROM_PTR(&tulip_seq_remove_callback_obj) },
     { MP_ROM_QSTR(MP_QSTR_seq_remove_callbacks), MP_ROM_PTR(&tulip_seq_remove_callbacks_obj) },
     { MP_ROM_QSTR(MP_QSTR_midi_callback), MP_ROM_PTR(&tulip_midi_callback_obj) },
+    { MP_ROM_QSTR(MP_QSTR_amy_overload_callback), MP_ROM_PTR(&tulip_amy_overload_callback_obj) },
 #ifndef __EMSCRIPTEN__
     { MP_ROM_QSTR(MP_QSTR_amy_block_done_callback), MP_ROM_PTR(&tulip_amy_block_done_callback_obj) },
     { MP_ROM_QSTR(MP_QSTR_amy_get_input_buffer), MP_ROM_PTR(&tulip_amy_get_input_buffer_obj) },


### PR DESCRIPTION
Pins the `amy` submodule to the head of [shorepine/amy#826](https://github.com/shorepine/amy/pull/826) (CPU overload detection + failsafe, issue shorepine/amy#791) so this PR's firmware and webapp preview builds carry it for hardware testing.

Also adds **`tulip.amy_render_load()`** → float in modtulip.c: AMY's smoothed fraction of real time spent rendering (0..1, ~1.0 = overloaded), backed by the new `amy_get_render_load()`. Poll it while a heavy sketch runs to watch the load climb.

What to try on AMYboard with this build:
- Run dpwe's Eno sketch (or anything heavy). As it stacks up voices, `tulip.amy_render_load()` should climb toward 1.0.
- At sustained ≥0.98 for 250ms, AMY resets itself and plays four descending doots instead of wedging — and USB CDC / MIDI should stay alive throughout (the fill-buffer task now yields when the i2s write stops blocking).

Follow-up (not in this PR): implement `config.amy_external_overload_hook` in tulip to stop the running sketch and pop up "this sketch took too many resources" in AMYboard Online.

🤖 Generated with [Claude Code](https://claude.com/claude-code)