### PR TITLE
Fix release publish: dated full bins go to RUNNER_TEMP (dist/ is root-owned)

### DIFF
--- a/.github/workflows/amyboard-release.yml
+++ b/.github/workflows/amyboard-release.yml
@@ -97,15 +97,17 @@ jobs:
           # Date-coded copy of the full image for manufacturing ("which build is
           # this file?"). One dated copy lives on the release at a time; older
           # date codes are pruned. Same-day rebuilds clobber the same name.
+          # Copy into RUNNER_TEMP: dist/ is root-owned (created inside the
+          # esp-idf-ci-action container), so this step can't create files there.
           DATE_CODE="$(date -u +%Y%m%d)"
           cp tulip/amyboard/dist/amyboard-full-AMYBOARD.bin \
-             "tulip/amyboard/dist/amyboard-full-AMYBOARD-${DATE_CODE}.bin"
+             "${RUNNER_TEMP}/amyboard-full-AMYBOARD-${DATE_CODE}.bin"
           gh api "repos/${GITHUB_REPOSITORY}/releases/tags/amyboard" --jq '.assets[].name' \
             | { grep -E '^amyboard-full-AMYBOARD-[0-9]{8}\.bin$' || true; } \
             | { grep -v "${DATE_CODE}" || true; } \
             | while read -r stale; do gh release delete-asset amyboard "$stale" --yes; done
           gh release upload --clobber amyboard \
-            "tulip/amyboard/dist/amyboard-full-AMYBOARD-${DATE_CODE}.bin"
+            "${RUNNER_TEMP}/amyboard-full-AMYBOARD-${DATE_CODE}.bin"
           # Refresh the release body with the exact released commit for provenance.
           gh release edit amyboard \
             --notes "Rolling AMYboard release, built from main @ ${GITHUB_SHA}. Flashed by amyboard.com and on-device amyboard.upgrade(). Updated on every push to main; not a tagged version."

--- a/.github/workflows/tulip-release.yml
+++ b/.github/workflows/tulip-release.yml
@@ -94,15 +94,17 @@ jobs:
           # Date-coded copy of the full image for manufacturing ("which build is
           # this file?"). One dated copy lives on the release at a time; older
           # date codes are pruned. Same-day rebuilds clobber the same name.
+          # Copy into RUNNER_TEMP: dist/ is root-owned (created inside the
+          # esp-idf-ci-action container), so this step can't create files there.
           DATE_CODE="$(date -u +%Y%m%d)"
           cp tulip/esp32s3/dist/tulip-full-TULIP4_R11.bin \
-             "tulip/esp32s3/dist/tulip-full-TULIP4_R11-${DATE_CODE}.bin"
+             "${RUNNER_TEMP}/tulip-full-TULIP4_R11-${DATE_CODE}.bin"
           gh api "repos/${GITHUB_REPOSITORY}/releases/tags/tulip" --jq '.assets[].name' \
             | { grep -E '^tulip-full-TULIP4_R11-[0-9]{8}\.bin$' || true; } \
             | { grep -v "${DATE_CODE}" || true; } \
             | while read -r stale; do gh release delete-asset tulip "$stale" --yes; done
           gh release upload --clobber tulip \
-            "tulip/esp32s3/dist/tulip-full-TULIP4_R11-${DATE_CODE}.bin"
+            "${RUNNER_TEMP}/tulip-full-TULIP4_R11-${DATE_CODE}.bin"
           # Refresh the body with the exact released commit for provenance, and
           # (re)assert latest so releases/latest keeps serving legacy OTA.
           gh release edit tulip \


### PR DESCRIPTION
Follow-up to #1104. Both release workflows failed on main at the publish step: `dist/` is created inside the esp-idf-ci-action Docker container as root, so the runner-user publish step got `Permission denied` creating the date-coded bin copy there. That happened *after* the stable-name uploads but *before* `gh release edit tulip --latest` and the amyboard→tulip mirror, so those never ran.

Writes the dated copy to `$RUNNER_TEMP` instead (asset name comes from the basename, so the uploaded name is unchanged). Merging this retriggers both workflows, which will complete the Latest flip and the mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)