### PR TITLE
Add tools/amyboard_loadsweep: per-day render-load regression sweep

### DIFF
--- a/tools/amyboard_loadsweep/README.md
+++ b/tools/amyboard_loadsweep/README.md
@@ -1,0 +1,99 @@
+# amyboard_loadsweep
+
+Answer "**when did this sketch start killing the AMYboard's CPU?**" by
+building the AMYboard firmware from `main` as of each midnight UTC over a
+date range, running the sketch on a physically connected board, and graphing
+AMY's render load day by day. A discontinuity in the graph is the day to
+bisect.
+
+This is how we established that dpwe's `eno_ambient` saturates the synth
+(render load pinned at ~0.99, board wedged on 11 of 14 days) on *every* build
+from 2026-06-25 through 2026-07-08 — i.e. that regression predates the
+window, and isn't any of the six amy pin bumps inside it.
+
+## How it works
+
+For each date in the range, [`sweep.py`](sweep.py):
+
+1. resolves `origin/main` as of that midnight UTC (`git rev-list -1 --before`),
+   deduplicating dates that share a commit;
+2. checks the tree out in a throwaway clone (default
+   `~/.cache/amyboard_loadsweep_ws`), syncs `amy`/`micropython` to that day's
+   pins, and applies [`patch_render_load.py`](patch_render_load.py) — a
+   self-contained backport of the render-load measurement from
+   [amy#826](https://github.com/shorepine/amy/pull/826) that makes the
+   fill-buffer task `fprintf` a smoothed `RENDER_LOAD ms=… load=…` line to
+   stderr once per second (no failsafe, no API changes, applies cleanly to
+   months of amy history);
+3. builds with `idf.py -DMICROPY_BOARD=AMYBOARD` + `fs_create.py`
+   (`IDF_CCACHE_ENABLE=1`, so 13 near-identical daily builds take minutes,
+   not hours);
+4. hands the **full merged image** to [`measure.py`](measure.py), which
+   flashes it at `0x0` (always the full image — the partition table has
+   changed over time, so app-only flashes onto an old table don't boot),
+   uploads the sketch over USB-MIDI SysEx (via
+   [`tools/amyboardctl`](../amyboardctl/)), and tails the debug UART for the
+   `RENDER_LOAD` lines for N seconds (default 60);
+5. writes `results/<date>/{firmware.bin,shas.txt,load.csv,serial.log,meta.json}`.
+
+The sweep is resumable: re-running skips any date that already has a
+`load.csv`, and reuses firmware for dates that resolve to an already-built
+SHA. To re-measure a day, delete its `load.csv`.
+
+[`plot.py`](plot.py) then renders one PNG: all days overlaid, per-day small
+multiples, and a steady-state mean/max bar chart with amy pin changes marked
+and wedged days flagged.
+
+## Bench requirements
+
+* An AMYboard on USB (enumerates as the `AMYboard` MIDI device), **plus** a
+  USB-serial dongle on the debug header whose **DTR/RTS drive the board's
+  auto-reset circuit** (DTR→IO0, RTS→EN — same wiring as
+  [`tulip/amyboard/hwci`](../../tulip/amyboard/hwci/)). esptool needs it to
+  enter the ROM bootloader unattended, and — the important part for a tool
+  whose test case *wedges the board on purpose* — RTS recovers a dead board
+  between days. Fallback when the handshake fails: `zP machine.bootloader()`
+  over USB-MIDI, then flashing over the board's native USB; that only works
+  while the board still answers MIDI.
+* ESP-IDF v5.4.1 (the tulipcc build env; see repo `CLAUDE.md`/docs), with
+  `littlefs-python` in its python env. Defaults assume
+  `~/.espressif/python_env/idf5.4_py3.13_env` + `~/esp/esp-idf-v5.4.1`;
+  override with `--idf-venv`/`--idf-export`, or pre-export the env.
+  `ccache` recommended.
+* Host python: `pip install ./tools/amyboardctl pyserial esptool matplotlib`.
+
+## Usage
+
+```sh
+cd tools/amyboard_loadsweep
+
+# 14 days ending today, sketch fetched from AMYboard World:
+python3 sweep.py --days 14 --sketch-world dpwe/eno_ambient \
+    --port /dev/cu.usbserial-A5069RR4 --native-port /dev/cu.usbmodem22234101
+
+# graph it:
+python3 plot.py --results results/
+
+# extend the search further back (already-measured days are skipped):
+python3 sweep.py --days 42 --sketch-world dpwe/eno_ambient
+
+# one-off: flash any firmware and measure any local sketch for 90s
+python3 measure.py results/2026-07-08/firmware.bin \
+    --sketch mysketch.py --out /tmp/oneoff --seconds 90
+```
+
+Other useful flags: `--end YYYY-MM-DD` (sweep a historical window),
+`--build-only` (prebuild all firmwares without touching the board),
+`--seconds`, `--no-patch` (once amy's own render-load print has landed at the
+pins being tested).
+
+## Reading the results
+
+* Load is `busy/(busy+blocked)` per 256-sample block, smoothed 0.05/block —
+  the fraction of real time the fill-buffer task spends rendering vs parked
+  in the i2s DMA write. ~1.0 means rendering can't keep up (audio underruns).
+* `meta.json`: `wedged` = board stopped answering MIDI after the run;
+  `serial_died_early` = the RENDER_LOAD prints themselves stopped (hard
+  crash); `load_max`/`load_last` for quick triage.
+* Generative sketches make survival-within-a-window partly luck — compare
+  the steady-state mean (bottom panel of the plot), not just who wedged.

--- a/tools/amyboard_loadsweep/measure.py
+++ b/tools/amyboard_loadsweep/measure.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Flash one AMYboard firmware and record its render load running a sketch.
+
+Flashes a full merged image (bootloader + partition table + app + sys + vfs)
+at 0x0 over the debug-UART dongle — always the full image, because the
+partition table has changed over the project's history and an app-only flash
+onto an old table bricks the boot. Then boots the board, uploads the sketch
+over USB-MIDI SysEx (amyboardctl), and tails the same UART for the
+`RENDER_LOAD ms=<ms> load=<0..1>` lines that patch_render_load.py adds to the
+firmware. Writes <out>/{load.csv,serial.log,meta.json}.
+
+The dongle's DTR/RTS must drive the board's auto-reset circuit (DTR->IO0,
+RTS->EN): esptool then enters the ROM bootloader by itself, and — important
+for this tool — RTS recovers a board that the sketch wedged. If the handshake
+fails, we fall back to `zP machine.bootloader()` over USB-MIDI and flash via
+the board's native USB (the ROM USB-Serial-JTAG usually enumerates at the
+same /dev/cu.usbmodem name on macOS).
+
+Requires: pyserial, esptool, mido + python-rtmidi (all in the amyboardctl
+install), and the board's USB-MIDI visible as "AMYboard".
+"""
+import argparse
+import csv
+import json
+import os
+import re
+import subprocess
+import sys
+import threading
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+try:
+    import amyboardctl  # noqa: F401
+except ImportError:
+    sys.path.insert(0, os.path.join(HERE, "..", "amyboardctl"))
+from amyboardctl import AMYboardLink, board_present  # noqa: E402
+
+RL = re.compile(r"RENDER_LOAD ms=(\d+) load=([\d.]+)")
+MIDI_NAME = "AMYboard"
+
+
+def esptool(port, *args, timeout=300):
+    cmd = [sys.executable, "-m", "esptool", "--chip", "esp32s3",
+           "--port", port] + list(args)
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+
+
+class SerialTail:
+    """Line-oriented tail of the debug UART, host-timestamping each line.
+
+    Opens with DTR/RTS de-asserted, but the open itself can still pulse the
+    modem lines and reboot the board through the auto-reset circuit — so open
+    the tail BEFORE starting the sketch and wait for MIDI to (re)appear.
+    """
+
+    def __init__(self, port, baud):
+        import serial
+        self.ser = serial.Serial()
+        self.ser.port = port
+        self.ser.baudrate = baud
+        self.ser.timeout = 0.2
+        self.ser.dtr = False
+        self.ser.rts = False
+        self.lines = []           # (host_time, text)
+        self._stop = threading.Event()
+        self._buf = b""
+        self._t = threading.Thread(target=self._run, daemon=True)
+
+    def open(self, retries=20):
+        for _ in range(retries):
+            try:
+                self.ser.open()
+                self._t.start()
+                return True
+            except Exception:
+                time.sleep(0.4)
+        return False
+
+    def _run(self):
+        while not self._stop.is_set():
+            try:
+                data = self.ser.read(4096)
+            except Exception:
+                break
+            if data:
+                self._buf += data
+                while b"\n" in self._buf:
+                    line, self._buf = self._buf.split(b"\n", 1)
+                    self.lines.append(
+                        (time.time(), line.decode("utf-8", "replace").rstrip("\r")))
+
+    def stop(self):
+        self._stop.set()
+        self._t.join(timeout=3)
+        try:
+            self.ser.close()
+        except Exception:
+            pass
+
+
+def wait_for_midi(timeout=40):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        p = board_present(MIDI_NAME, backend="mido")
+        if p:
+            return p
+        time.sleep(0.5)
+    return None
+
+
+def reset_via_chipid(uart_port):
+    """Hard-reset cycle over the dongle (also recovers a wedged board).
+    hwci lesson: this boots the board more reliably than a flash's own
+    post-flash hard-reset."""
+    r = esptool(uart_port, "chip-id", timeout=90)
+    ok = r.returncode == 0 and "MAC:" in r.stdout
+    print(f"[reset] chip-id {'ok' if ok else 'FAILED'}")
+    return ok
+
+
+def software_enter_bootloader(native_port):
+    midi = wait_for_midi(15)
+    if not midi:
+        return False
+    try:
+        with AMYboardLink(port_match=midi, verbose=False, backend="mido",
+                          ack_timeout=2.0) as link:
+            link.send_python("import machine; machine.bootloader()", timeout=3.0)
+    except Exception as e:
+        print(f"[flash] bootloader cmd: {e!r}")
+    time.sleep(3.0)
+    r = esptool(native_port, "--before", "no-reset", "--after", "no-reset",
+                "chip-id", timeout=60)
+    return r.returncode == 0 and "MAC:" in r.stdout
+
+
+def flash(bin_path, uart_port, native_port, baud):
+    print("[flash]", os.path.basename(bin_path))
+    r = esptool(uart_port, "--baud", str(baud), "--before", "default-reset",
+                "--after", "hard-reset", "write-flash", "0x0", bin_path)
+    if r.returncode == 0:
+        print("[flash] ok (dongle)")
+        return
+    print("[flash] dongle handshake failed; trying software bootloader entry")
+    if not software_enter_bootloader(native_port):
+        raise RuntimeError("could not get board into ROM bootloader "
+                           "(board wedged and no working reset line?)")
+    r = esptool(native_port, "--baud", str(baud), "--before", "no-reset",
+                "--after", "hard-reset", "write-flash", "0x0", bin_path)
+    if r.returncode != 0:
+        sys.stdout.write(r.stdout[-2000:] + r.stderr[-2000:])
+        raise RuntimeError("flash failed")
+    print("[flash] ok (native USB)")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("firmware", help="full merged image (amyboard-full-*.bin)")
+    ap.add_argument("--sketch", required=True, help="sketch .py file to run")
+    ap.add_argument("--out", required=True, help="output directory")
+    ap.add_argument("--port", default="/dev/cu.usbserial-A5069RR4",
+                    help="debug-UART dongle (flash + stderr console)")
+    ap.add_argument("--native-port", default="/dev/cu.usbmodem22234101",
+                    help="board native USB (software-bootloader fallback)")
+    ap.add_argument("--baud", type=int, default=921600, help="flash baud")
+    ap.add_argument("--debug-baud", type=int, default=115200, help="console baud")
+    ap.add_argument("--seconds", type=float, default=60.0,
+                    help="capture window after sketch start")
+    ap.add_argument("--label", default=None, help="label stored in meta.json")
+    args = ap.parse_args()
+
+    os.makedirs(args.out, exist_ok=True)
+    meta = {"label": args.label or os.path.basename(args.out.rstrip("/")),
+            "firmware": args.firmware, "sketch": args.sketch,
+            "seconds": args.seconds, "wedged": False,
+            "midi_alive_after": None, "errors": []}
+
+    flash(args.firmware, args.port, args.native_port, args.baud)
+    reset_via_chipid(args.port)
+    time.sleep(5.0)
+
+    midi = wait_for_midi(40)
+    if not midi:
+        print("[boot] MIDI not up after flash; retrying chip-id reset")
+        reset_via_chipid(args.port)
+        time.sleep(5.0)
+        midi = wait_for_midi(40)
+    if not midi:
+        meta["errors"].append("board never enumerated MIDI after flash")
+        json.dump(meta, open(os.path.join(args.out, "meta.json"), "w"), indent=1)
+        sys.exit("[boot] board never enumerated MIDI")
+    print(f"[boot] MIDI up: {midi}")
+
+    tail = SerialTail(args.port, args.debug_baud)
+    if not tail.open():
+        meta["errors"].append("could not open debug UART for tail")
+        sys.exit("[tail] cannot open debug UART")
+    time.sleep(3.0)
+    midi = wait_for_midi(30)   # opening the tail may have rebooted the board
+    if not midi:
+        meta["errors"].append("MIDI gone after opening UART tail")
+        tail.stop()
+        sys.exit("[tail] board did not come back after UART open")
+    time.sleep(1.5)
+
+    print(f"[sketch] uploading {os.path.basename(args.sketch)}")
+    text = open(args.sketch).read()
+    t_start = None
+    try:
+        with AMYboardLink(port_match=midi, verbose=False, backend="mido",
+                          ack_timeout=2.0) as link:
+            link.reset_amy()
+            time.sleep(0.3)
+            link.transfer_file(text)
+            link.environment_transfer_done()
+            t_start = time.time()
+            print(f"[sketch] started; capturing {args.seconds:.0f}s")
+            time.sleep(args.seconds)
+            try:
+                meta["midi_alive_after"] = bool(link.ping_ok(timeout=2.5))
+            except Exception:
+                meta["midi_alive_after"] = False
+    except Exception as e:
+        meta["errors"].append(f"sketch upload/run: {e!r}")
+        print(f"[sketch] ERROR: {e!r}")
+        if t_start is None:
+            t_start = time.time()
+            time.sleep(args.seconds)
+
+    tail.stop()
+    if meta["midi_alive_after"] is False:
+        meta["wedged"] = True
+        print("[result] board WEDGED (MIDI dead after run)")
+
+    with open(os.path.join(args.out, "serial.log"), "w") as f:
+        for ts, line in tail.lines:
+            f.write(f"{ts - t_start:+9.3f} {line}\n")
+
+    rows = []
+    for ts, line in tail.lines:
+        m = RL.search(line)
+        if m:
+            rows.append((round(ts - t_start, 3), int(m.group(1)), float(m.group(2))))
+    with open(os.path.join(args.out, "load.csv"), "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["t_s", "board_ms", "load"])
+        w.writerows(rows)
+
+    during = [r for r in rows if r[0] >= 0]
+    meta["n_samples_total"] = len(rows)
+    meta["n_samples_during"] = len(during)
+    if during:
+        meta["load_max"] = max(r[2] for r in during)
+        meta["load_last"] = during[-1][2]
+        meta["last_sample_t"] = during[-1][0]
+        if during[-1][0] < args.seconds - 3.0:
+            meta["serial_died_early"] = True   # prints stopped: hard crash
+    print(f"[result] {len(rows)} samples ({len(during)} during run), "
+          f"max load {meta.get('load_max')}, alive={meta['midi_alive_after']}")
+
+    json.dump(meta, open(os.path.join(args.out, "meta.json"), "w"), indent=1)
+    # leave the board freshly reset (also un-wedges it for the next flash)
+    reset_via_chipid(args.port)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/amyboard_loadsweep/measure.py
+++ b/tools/amyboard_loadsweep/measure.py
@@ -23,6 +23,7 @@ import argparse
 import csv
 import json
 import os
+import fcntl
 import re
 import subprocess
 import sys
@@ -44,6 +45,28 @@ def esptool(port, *args, timeout=300):
     cmd = [sys.executable, "-m", "esptool", "--chip", "esp32s3",
            "--port", port] + list(args)
     return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+
+
+def acquire_bench_lock(uart_port, lockfile="/tmp/amyboard-bench.lock"):
+    """Serialize board access across processes/sessions sharing this bench.
+
+    Takes a blocking exclusive flock held for the whole flash+capture (the
+    caller keeps the returned file object alive), then waits until nothing
+    else holds the UART -- a cooperating session releases the lock between
+    its own runs, and the lsof wait guards against non-cooperating holders."""
+    f = open(lockfile, "w")
+    print(f"[lock] waiting for {lockfile}")
+    fcntl.flock(f, fcntl.LOCK_EX)
+    while True:
+        r = subprocess.run(["lsof", "-t", uart_port,
+                            uart_port.replace("/cu.", "/tty.")],
+                           capture_output=True, text=True)
+        if r.returncode != 0 or not r.stdout.strip():
+            break
+        print(f"[lock] {uart_port} still held by pid(s) {r.stdout.split()}")
+        time.sleep(1.0)
+    print("[lock] bench acquired")
+    return f
 
 
 class SerialTail:
@@ -175,6 +198,10 @@ def main():
             "firmware": args.firmware, "sketch": args.sketch,
             "seconds": args.seconds, "wedged": False,
             "midi_alive_after": None, "errors": []}
+
+    # held (via the returned file object) until this process exits — one
+    # measurement is one bench turn
+    bench_lock = acquire_bench_lock(args.port)  # noqa: F841
 
     flash(args.firmware, args.port, args.native_port, args.baud)
     reset_via_chipid(args.port)

--- a/tools/amyboard_loadsweep/patch_render_load.py
+++ b/tools/amyboard_loadsweep/patch_render_load.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Inject a 1 Hz render-load stderr print into amy/src/i2s.c.
+
+Self-contained minimal version of the measurement from shorepine/amy#826:
+in esp_fill_audio_buffer_task, time the render work (busy) vs the i2s DMA
+write / update-sync wait (blocked), keep a 0.05-per-block smoothed load =
+busy/(busy+blocked), and fprintf it to stderr once per second as:
+
+    RENDER_LOAD ms=<board_ms> load=<0..1>
+
+No failsafe, no header/API changes -- the anchors are stable, so it applies
+unmodified to months of amy history (the function was byte-identical across
+every pin from 2026-06-25 to 2026-07-08). Idempotent; fails loudly if an
+anchor is missing (e.g. a future amy where the measurement landed upstream --
+use sweep.py --no-patch there and print amy's own render load instead).
+
+Usage: patch_render_load.py <path-to-amy>/src/i2s.c
+"""
+import re
+import sys
+
+MARK = "/* rl-patch */"
+
+DECLS = """
+%s
+#include "esp_timer.h"
+#include <stdio.h>
+static float _rl_load = 0.0f;
+static int64_t _rl_last_print = 0;
+""" % MARK
+
+
+def main(path):
+    src = open(path).read()
+    if MARK in src:
+        print(f"[patch] {path} already patched")
+        return 0
+    orig = src
+    subs = []
+
+    def sub(pattern, repl, label):
+        # repl is a template using \1 \2 ... group refs; expand it via a
+        # function so other backslashes (e.g. \n inside C strings) survive.
+        nonlocal src
+
+        def expand(m):
+            return re.sub(r"\\(\d)", lambda g: m.group(int(g.group(1))) or "", repl)
+
+        new, n = re.subn(pattern, expand, src, count=1)
+        if n != 1:
+            sys.exit(f"[patch] FAILED: anchor not found: {label}")
+        src = new
+        subs.append(label)
+
+    # 0) statics + includes before the task function
+    sub(r"(?m)^(// Make AMY's FABT run forever.*\n)?^void esp_fill_audio_buffer_task\(\) \{",
+        DECLS + "void esp_fill_audio_buffer_task() {",
+        "function head")
+
+    # 1) locals at top of the while loop + busy timer start after the
+    #    (blocked-time-tracked) audio-in read
+    sub(r"(void esp_fill_audio_buffer_task\(\) \{\n    while\(1\) \{\n)",
+        "\\1        int64_t _rl_t; uint32_t _rl_busy = 0, _rl_blocked = 0;\n",
+        "loop head")
+
+    sub(r"( *)if\(AMY_HAS_I2S && AMY_HAS_AUDIO_IN\) \{\n( *)esp_read_i2s_input\(\);\n(\s*)\}",
+        "\\1if(AMY_HAS_I2S && AMY_HAS_AUDIO_IN) {\n"
+        "\\2_rl_t = esp_timer_get_time();\n"
+        "\\2esp_read_i2s_input();\n"
+        "\\2_rl_blocked += (uint32_t)(esp_timer_get_time() - _rl_t);\n"
+        "\\3}\n"
+        "        _rl_t = esp_timer_get_time();",
+        "audio-in block")
+
+    # 2) busy time ends after amy_fill_buffer
+    sub(r"( *)(output_sample_type \*block = amy_fill_buffer\(\);)",
+        "\\1\\2\n\\1_rl_busy = (uint32_t)(esp_timer_get_time() - _rl_t);",
+        "fill buffer")
+
+    # 3) blocked time around the i2s write / sync wait, then smooth + 1 Hz print
+    sub(r"( *)(if \(AMY_HAS_I2S\) \{\n"
+        r" *amy_i2s_write\(\(uint8_t \*\)block, AMY_BLOCK_SIZE \* AMY_NCHANS \* sizeof\(int16_t\)\);\n"
+        r" *\} else \{\n"
+        r" *// Wait for update sync\.\n"
+        r" *ulTaskNotifyTake\(pdTRUE, portMAX_DELAY\);.*\n"
+        r" *\})\n",
+        "\\1_rl_t = esp_timer_get_time();\n"
+        "\\1\\2\n"
+        "\\1_rl_blocked += (uint32_t)(esp_timer_get_time() - _rl_t);\n"
+        "\\1if (_rl_busy + _rl_blocked > 0)\n"
+        "\\1    _rl_load += 0.05f * ((float)_rl_busy / (float)(_rl_busy + _rl_blocked) - _rl_load);\n"
+        "\\1{ int64_t _rl_now = esp_timer_get_time();\n"
+        "\\1  if (_rl_now - _rl_last_print > 1000000) {\n"
+        "\\1      _rl_last_print = _rl_now;\n"
+        "\\1      fprintf(stderr, \"RENDER_LOAD ms=%lu load=%.4f\\n\", (unsigned long)(_rl_now/1000), _rl_load);\n"
+        "\\1      fflush(stderr);\n"
+        "\\1  } }\n",
+        "i2s write block")
+
+    open(path, "w").write(src)
+    print(f"[patch] OK: {', '.join(subs)} -> {path}")
+    assert src != orig
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1]))

--- a/tools/amyboard_loadsweep/plot.py
+++ b/tools/amyboard_loadsweep/plot.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Graph a render-load sweep produced by sweep.py.
+
+Three views: all days overlaid, per-day small multiples, and a steady-state
+mean/max bar chart (the discontinuity view) with amy submodule pin changes
+marked. Wedged days (board stopped answering MIDI) are flagged.
+"""
+import argparse
+import csv
+import glob
+import json
+import os
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt          # noqa: E402
+import matplotlib.cm as cm               # noqa: E402
+import numpy as np                       # noqa: E402
+
+
+def load_days(results):
+    days = []
+    for d in sorted(glob.glob(os.path.join(results, "*/"))):
+        csvp = os.path.join(d, "load.csv")
+        if not os.path.exists(csvp):
+            continue
+        rows = [(float(r["t_s"]), float(r["load"]))
+                for r in csv.DictReader(open(csvp)) if float(r["t_s"]) >= -1]
+        meta = {}
+        mp = os.path.join(d, "meta.json")
+        if os.path.exists(mp):
+            meta = json.load(open(mp))
+        amy = ""
+        sp = os.path.join(d, "shas.txt")
+        if os.path.exists(sp):
+            for line in open(sp):
+                if line.startswith("amy "):
+                    amy = line.split()[1][:8]
+        days.append({"label": os.path.basename(d.rstrip("/")),
+                     "rows": rows, "meta": meta, "amy": amy})
+    return days
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--results", default=os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "results"))
+    ap.add_argument("--out", default=None, help="output PNG "
+                    "(default <results>/render_load_sweep.png)")
+    ap.add_argument("--title", default="AMYboard render load by day of tulipcc main")
+    args = ap.parse_args()
+    out = args.out or os.path.join(args.results, "render_load_sweep.png")
+
+    days = load_days(args.results)
+    if not days:
+        raise SystemExit(f"no load.csv files under {args.results}")
+    n = len(days)
+    tmax = max((r[0] for d in days for r in d["rows"]), default=60) + 2
+    colors = cm.viridis(np.linspace(0.05, 0.95, n))
+
+    fig = plt.figure(figsize=(14, 16))
+    gs = fig.add_gridspec(3, 1, height_ratios=[1.1, 1.6, 0.8], hspace=0.35)
+
+    # overlay
+    ax = fig.add_subplot(gs[0])
+    for day, c in zip(days, colors):
+        t = [r[0] for r in day["rows"]]
+        v = [r[1] for r in day["rows"]]
+        wedge = " (WEDGED)" if day["meta"].get("wedged") else ""
+        ax.plot(t, v, color=c, lw=1.8, label=day["label"] + wedge)
+    ax.axhline(0.98, color="red", ls=":", lw=1, alpha=0.6)
+    ax.text(0.2, 0.985, "overload threshold", color="red", fontsize=8, va="bottom")
+    ax.set_xlim(-1, tmax)
+    ax.set_ylim(0, 1.05)
+    ax.set_xlabel("seconds since sketch start")
+    ax.set_ylabel("AMY render load (0..1)")
+    ax.set_title(args.title)
+    ax.legend(fontsize=7.5, ncol=2, loc="lower right")
+    ax.grid(alpha=0.25)
+
+    # small multiples
+    cols = 5
+    rows_n = int(np.ceil(n / cols))
+    sub = gs[1].subgridspec(rows_n, cols, hspace=0.45, wspace=0.25)
+    for i, (day, c) in enumerate(zip(days, colors)):
+        axs = fig.add_subplot(sub[i // cols, i % cols])
+        t = [r[0] for r in day["rows"]]
+        v = [r[1] for r in day["rows"]]
+        axs.plot(t, v, color=c, lw=1.5)
+        axs.fill_between(t, v, color=c, alpha=0.25)
+        axs.set_xlim(-1, tmax)
+        axs.set_ylim(0, 1.05)
+        axs.axhline(0.98, color="red", ls=":", lw=0.7, alpha=0.6)
+        title = day["label"][5:] + (" ⚠wedged" if day["meta"].get("wedged") else "")
+        axs.set_title(f"{title}\namy {day['amy']}", fontsize=8)
+        axs.tick_params(labelsize=7)
+        if i % cols:
+            axs.set_yticklabels([])
+
+    # steady-state summary
+    axb = fig.add_subplot(gs[2])
+    labels = [d["label"][5:] for d in days]
+    means, maxes, wedged = [], [], []
+    for d in days:
+        ss = [v for t, v in d["rows"] if t >= 5.0]
+        means.append(np.mean(ss) if ss else 0)
+        maxes.append(max(ss) if ss else 0)
+        wedged.append(d["meta"].get("wedged", False))
+    x = np.arange(n)
+    axb.bar(x - 0.2, means, 0.4, color=list(colors), label="mean load (t≥5s)")
+    axb.bar(x + 0.2, maxes, 0.4, color=list(colors), alpha=0.45,
+            label="max load (t≥5s)")
+    for i, w in enumerate(wedged):
+        if w:
+            axb.text(i, maxes[i] + 0.02, "wedged", ha="center", fontsize=7,
+                     color="red", rotation=90)
+    axb.axhline(0.98, color="red", ls=":", lw=1, alpha=0.6)
+    axb.set_xticks(x)
+    axb.set_xticklabels(labels, rotation=45, ha="right", fontsize=8)
+    axb.set_ylim(0, 1.1)
+    axb.set_ylabel("render load")
+    axb.set_title("steady-state render load by day (discontinuity view)")
+    axb.legend(fontsize=8)
+    axb.grid(axis="y", alpha=0.25)
+
+    prev = None
+    for i, d in enumerate(days):
+        if prev is not None and d["amy"] != prev:
+            axb.axvline(i - 0.5, color="k", ls="--", lw=0.8, alpha=0.5)
+            axb.text(i - 0.45, 1.04, f"amy→{d['amy']}", fontsize=6.5)
+        prev = d["amy"]
+
+    fig.savefig(out, dpi=130, bbox_inches="tight")
+    print("wrote", out)
+    for d, m, mx in zip(days, means, maxes):
+        print(f"{d['label']}  amy={d['amy']}  mean={m:.3f}  max={mx:.3f}"
+              f"{'  WEDGED' if d['meta'].get('wedged') else ''}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/amyboard_loadsweep/sweep.py
+++ b/tools/amyboard_loadsweep/sweep.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Day-by-day AMYboard render-load sweep over tulipcc main history.
+
+For each date in the range: resolve `main` as of that midnight UTC, build the
+AMYboard firmware from that tree in a throwaway clone (with amy patched to
+print its render load — see patch_render_load.py), flash a connected board
+with the full merged image, run a sketch for N seconds, and record the load
+trace. Then plot.py graphs the traces to spot the day a regression landed.
+
+    # 14 days ending today, dpwe's eno_ambient from AMYboard World:
+    python3 sweep.py --days 14 --sketch-world dpwe/eno_ambient
+
+    # then:
+    python3 plot.py --results results/
+
+Builds are resumable and deduplicated: a date whose load.csv exists is
+skipped, and dates that resolve to the same tulipcc SHA share one firmware.
+A wedged board (the point of the exercise) is recovered by the flash's
+DTR/RTS reset lines — see measure.py for the bench wiring this needs.
+
+Run this with the ESP-IDF v5.4.1 environment available: either already
+exported, or at the default install paths (see --idf-*). The IDF python env
+needs littlefs-python (for fs_create.py).
+"""
+import argparse
+import datetime
+import os
+import shutil
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.abspath(os.path.join(HERE, "..", ".."))
+
+MICROPYTHON_LIBS = ["lib/axtls", "lib/libffi", "lib/mbedtls",
+                    "lib/berkeley-db-1.xx", "lib/micropython-lib", "lib/tinyusb"]
+
+
+def run(cmd, cwd=None, check=True, quiet=False, env=None):
+    r = subprocess.run(cmd, cwd=cwd, text=True, env=env,
+                       capture_output=quiet)
+    if check and r.returncode != 0:
+        if quiet:
+            sys.stderr.write((r.stdout or "")[-2000:] + (r.stderr or "")[-2000:])
+        raise RuntimeError(f"command failed: {cmd}")
+    return r
+
+
+def git(repo, *args, capture=True):
+    r = subprocess.run(["git", "-C", repo] + list(args), text=True,
+                       capture_output=capture)
+    if r.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)}: {r.stderr.strip()[:500]}")
+    return (r.stdout or "").strip()
+
+
+def resolve_days(args):
+    """[(label, sha)] for each midnight UTC in the range, oldest first."""
+    git(REPO, "fetch", "origin", "main")
+    end = (datetime.date.fromisoformat(args.end) if args.end
+           else datetime.datetime.now(datetime.timezone.utc).date())
+    days = []
+    for i in range(args.days - 1, -1, -1):
+        d = end - datetime.timedelta(days=i)
+        # --first-parent: walk main's merge spine only, so a PR commit authored
+        # before midnight but merged after doesn't masquerade as that day's main
+        sha = git(REPO, "rev-list", "-1", "--first-parent",
+                  f"--before={d}T00:00:00Z", "origin/main")
+        if not sha:
+            print(f"[days] {d}: no commit before this date on origin/main, skipping")
+            continue
+        days.append((str(d), sha))
+    return days
+
+
+def init_workspace(ws):
+    if os.path.exists(os.path.join(ws, ".git")):
+        # pick up any new commits from the source repo
+        git(ws, "fetch", REPO,
+            "+refs/remotes/origin/main:refs/heads/upstream-main")
+        return
+    print(f"[ws] cloning {REPO} -> {ws}")
+    run(["git", "clone", REPO, ws], quiet=True)
+    git(ws, "fetch", REPO, "+refs/remotes/origin/main:refs/heads/upstream-main")
+    # submodules fetch from the local checkouts when present (fast, offline);
+    # a worktree without them falls back to the .gitmodules URLs
+    for sub in ("amy", "micropython"):
+        local = os.path.join(REPO, sub)
+        if os.path.exists(os.path.join(local, ".git")):
+            git(ws, "config", f"submodule.{sub}.url", local)
+
+
+def build_day(ws, sha, label, outdir, args):
+    fw = os.path.join(outdir, "firmware.bin")
+    if os.path.exists(fw):
+        print(f"== {label}: firmware already built")
+        return fw
+    print(f"== {label}: building {sha[:12]}")
+    git(ws, "checkout", "-q", "-f", sha)
+    git(ws, "-c", "protocol.file.allow=always", "submodule", "update",
+        "--init", "--force", "amy", "micropython")
+    git(os.path.join(ws, "micropython"), "submodule", "update", "--init",
+        *MICROPYTHON_LIBS)
+    # keep .submodules_ok so grab_submodules only (re)applies its mpy-cross
+    # Makefile warning patches (needed whenever the micropython pin moved)
+    open(os.path.join(ws, ".submodules_ok"), "w").close()
+    run(["./grab_submodules.sh"], cwd=os.path.join(ws, "tulip", "shared"),
+        quiet=True)
+
+    if not args.no_patch:
+        run([sys.executable, os.path.join(HERE, "patch_render_load.py"),
+             os.path.join(ws, "amy", "src", "i2s.c")])
+
+    # build inside the IDF environment; ccache makes repeated daily builds fast
+    build_sh = (
+        f'[ -n "${{IDF_PATH:-}}" ] || {{ source {args.idf_venv}/bin/activate && '
+        f'source {args.idf_export} > /dev/null; }} && '
+        f'export IDF_CCACHE_ENABLE=1 && '
+        f'cd "{ws}/tulip/amyboard" && rm -rf build && '
+        f'idf.py -DMICROPY_BOARD=AMYBOARD build && '
+        f'cd .. && python fs_create.py amyboard'
+    )
+    log = os.path.join(outdir, "build.log")
+    with open(log, "w") as lf:
+        r = subprocess.run(["bash", "-c", build_sh], stdout=lf,
+                           stderr=subprocess.STDOUT, text=True)
+    if r.returncode != 0:
+        print(f"== {label}: BUILD FAILED (see {log})")
+        return None
+
+    dist = os.path.join(ws, "tulip", "amyboard", "dist")
+    full = [f for f in sorted(os.listdir(dist)) if f.startswith("amyboard-full")]
+    if not full:
+        print(f"== {label}: no amyboard-full*.bin in {dist}")
+        return None
+    shutil.copy(os.path.join(dist, full[0]), fw)
+    amy_sha = git(os.path.join(ws, "amy"), "rev-parse", "HEAD")
+    with open(os.path.join(outdir, "shas.txt"), "w") as f:
+        f.write(f"tulipcc {sha}\namy {amy_sha}\n")
+    print(f"== {label}: built -> {fw}")
+    return fw
+
+
+def find_built(results, sha):
+    """A results dir whose firmware was already built from this tulipcc SHA."""
+    for label in sorted(os.listdir(results)):
+        d = os.path.join(results, label)
+        shas = os.path.join(d, "shas.txt")
+        if os.path.exists(os.path.join(d, "firmware.bin")) and os.path.exists(shas):
+            if f"tulipcc {sha}" in open(shas).read():
+                return d
+    return None
+
+
+def fetch_world_sketch(spec, dest):
+    sys.path.insert(0, os.path.join(REPO, "tools", "amyboardctl"))
+    from amyboardctl import world
+    author, name = spec.split("/", 1)
+    name = name.removesuffix(".py")
+    text = world.fetch_sketch(name, author)
+    open(dest, "w").write(text)
+    print(f"[sketch] fetched {spec} ({len(text)} bytes)")
+    return dest
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter, epilog=__doc__)
+    ap.add_argument("--days", type=int, default=14, help="number of daily samples")
+    ap.add_argument("--end", default=None,
+                    help="last date (YYYY-MM-DD, default today UTC)")
+    sk = ap.add_mutually_exclusive_group(required=True)
+    sk.add_argument("--sketch-world", help="AMYboard World sketch author/name, "
+                    "e.g. dpwe/eno_ambient")
+    sk.add_argument("--sketch-file", help="local sketch .py to run")
+    ap.add_argument("--results", default=os.path.join(HERE, "results"))
+    ap.add_argument("--workspace",
+                    default=os.path.expanduser("~/.cache/amyboard_loadsweep_ws"),
+                    help="throwaway tulipcc clone used for historical builds")
+    ap.add_argument("--seconds", type=float, default=60.0,
+                    help="capture window per day")
+    ap.add_argument("--port", default="/dev/cu.usbserial-A5069RR4",
+                    help="debug-UART dongle (flash + console)")
+    ap.add_argument("--native-port", default="/dev/cu.usbmodem22234101",
+                    help="board native USB (bootloader fallback)")
+    ap.add_argument("--no-patch", action="store_true",
+                    help="don't patch amy (its render-load print already landed)")
+    ap.add_argument("--build-only", action="store_true",
+                    help="build all firmwares, skip the hardware runs")
+    ap.add_argument("--idf-venv", default=os.path.expanduser(
+        "~/.espressif/python_env/idf5.4_py3.13_env"))
+    ap.add_argument("--idf-export", default=os.path.expanduser(
+        "~/esp/esp-idf-v5.4.1/export.sh"))
+    args = ap.parse_args()
+
+    os.makedirs(args.results, exist_ok=True)
+    days = resolve_days(args)
+    uniq = len({sha for _, sha in days})
+    print(f"[days] {len(days)} dates, {uniq} unique builds")
+
+    sketch = args.sketch_file
+    if args.sketch_world:
+        sketch = os.path.join(args.results, "sketch.py")
+        fetch_world_sketch(args.sketch_world, sketch)
+
+    init_workspace(args.workspace)
+
+    failed = []
+    for label, sha in days:
+        outdir = os.path.join(args.results, label)
+        os.makedirs(outdir, exist_ok=True)
+        if os.path.exists(os.path.join(outdir, "load.csv")):
+            print(f"== {label}: already measured, skipping")
+            continue
+        fw = os.path.join(outdir, "firmware.bin")
+        if not os.path.exists(fw):
+            prev = find_built(args.results, sha)
+            if prev:
+                print(f"== {label}: reusing firmware from {os.path.basename(prev)}")
+                shutil.copy(os.path.join(prev, "firmware.bin"), fw)
+                shutil.copy(os.path.join(prev, "shas.txt"),
+                            os.path.join(outdir, "shas.txt"))
+            elif not build_day(args.workspace, sha, label, outdir, args):
+                failed.append(label)
+                continue
+        if args.build_only:
+            continue
+        r = subprocess.run([sys.executable, os.path.join(HERE, "measure.py"),
+                            fw, "--sketch", sketch, "--out", outdir,
+                            "--port", args.port, "--native-port", args.native_port,
+                            "--seconds", str(args.seconds), "--label", label])
+        if r.returncode != 0:
+            print(f"== {label}: MEASURE FAILED")
+            failed.append(label)
+    print(f"== sweep done ({len(failed)} failed: {failed})" if failed
+          else "== sweep done")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
New tool for answering "when did this sketch start killing the AMYboard's CPU?": build the AMYboard firmware from `main` as of each midnight UTC over a date range, run a sketch on a connected board, record AMY's render load, and graph the days side by side — a discontinuity is the day to bisect.

**How**

- `sweep.py` resolves each date to `origin/main` at that midnight (first-parent, deduped), builds each tree in a throwaway clone with that day's submodule pins (`IDF_CCACHE_ENABLE=1` keeps 13 near-identical builds down to minutes), and is resumable per day.
- `patch_render_load.py` backports just the render-load measurement from [amy#826](https://github.com/shorepine/amy/pull/826) as a self-contained textual patch to `amy/src/i2s.c` (1 Hz `RENDER_LOAD ms=… load=…` on stderr, no failsafe, no API changes) — it applied unmodified to every amy pin in the tested window, so historical builds get instrumentation that didn't exist yet.
- `measure.py` flashes the **full merged image** at 0x0 (the partition table changed over time, so app-only flashes onto old tables don't boot), uploads the sketch over USB-MIDI SysEx via `tools/amyboardctl`, and tails the debug UART. A wedged board — the expected outcome — is recovered by the flash dongle's DTR/RTS reset lines (same wiring as `tulip/amyboard/hwci`), with a `zP machine.bootloader()` + native-USB fallback.
- `plot.py` renders overlay + small multiples + a steady-state mean/max bar chart with amy pin bumps marked and wedged days flagged.

**First result** (the sweep that motivated this): dpwe's `eno_ambient` saturates AMY on **every** daily build of main from 2026-06-25 through 2026-07-08 — load ramps to ~0.8 immediately on patch load, pins at ~0.99 as voices stack, and wedged the board (MIDI dead) on 11 of 14 days; the three survivors were luck of the generative note draw. No discontinuity across the window or any of its six amy pin bumps, so the overload predates 2026-06-25. Next step is extending the sweep further back (`--days 42` just works, already-measured days are skipped).

Usage:

```sh
cd tools/amyboard_loadsweep
python3 sweep.py --days 14 --sketch-world dpwe/eno_ambient
python3 plot.py --results results/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)