### PR TITLE
No-op HW CI trigger test

### DIFF
--- a/tulip/amyboard/hwci/README.md
+++ b/tulip/amyboard/hwci/README.md
@@ -202,3 +202,5 @@ Gated to same-repo
 PRs (the runner is on a public repo). Stable `/dev` names come from
 [`99-amyboard.rules`](99-amyboard.rules); install it on the Pi (needs sudo) after
 adding a board.
+
+<!-- HW CI trigger test 2026-07-08: no-op change to exercise the PR preview -> HW CI chain. -->


### PR DESCRIPTION
No-op comment added to `tulip/amyboard/hwci/README.md` to trigger the AMYboard PR preview workflow and, chained off it, the HW CI run on the Pi bench. Purely to confirm the HW CI pipeline works end to end — do not merge for content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)