### PR TITLE
hwci: take the shared bench flock so amy's HW CI can't stomp a tulipcc run

### DIFF
--- a/tulip/amyboard/hwci/README.md
+++ b/tulip/amyboard/hwci/README.md
@@ -202,3 +202,17 @@ Gated to same-repo
 PRs (the runner is on a public repo). Stable `/dev` names come from
 [`99-amyboard.rules`](99-amyboard.rules); install it on the Pi (needs sudo) after
 adding a board.
+
+## Bench lock (`/tmp/amyboard-bench.lock`)
+The bench is also used by **shorepine/amy's "AMY HW CI"** (and the loadsweep
+tools) through a *separate* runner registration on the same Pi — GitHub's
+per-repo `concurrency:` groups can't serialize across repos, so an amy bench
+job and a tulipcc HW CI job can be scheduled at the same time. Everything that
+touches the bench therefore takes a blocking exclusive **flock on
+`/tmp/amyboard-bench.lock`** for its whole flash+drive+record run, and
+additionally waits for its serial port to have no other holders (`lsof`):
+`hwci.py`, `tulip_hwci.py`, amy's `tools/arduino_loadsweep/measure.py`, and
+tulipcc's `tools/amyboard_loadsweep/measure.py` all cooperate on the same file.
+A colliding run waits (up to 15 min) instead of flashing over the other's
+capture or bleeding audio into the shared card. `--no-bench-lock` skips it for
+local bring-up on a bench nothing else shares.

--- a/tulip/amyboard/hwci/hwci.py
+++ b/tulip/amyboard/hwci/hwci.py
@@ -98,6 +98,59 @@ WORLD_SUITE = [
 ]
 
 
+# ── bench lock ───────────────────────────────────────────────────────────────
+# shorepine/amy's "AMY HW CI" + loadsweep sweeps share this physical bench (same
+# board, same dongle, same summed capture card) from a SEPARATE runner
+# registration, so GitHub never serializes the two repos' jobs. Every harness
+# that touches the bench takes this flock for its whole run — same path and
+# semantics as amy's tools/arduino_loadsweep/measure.py.
+BENCH_LOCK = "/tmp/amyboard-bench.lock"
+
+
+def acquire_bench(port, timeout_s=900):
+    """Serialize bench access across processes/sessions.
+
+    Holds an flock on BENCH_LOCK for the rest of this process (the caller keeps
+    the returned fd alive) AND waits for the serial port itself to be free —
+    tty devices are not exclusive, so a lock alone doesn't protect against
+    harnesses that don't take it."""
+    import fcntl
+    fd = os.open(BENCH_LOCK, os.O_CREAT | os.O_RDWR, 0o666)
+    deadline = time.time() + timeout_s
+    waited = False
+    while True:
+        got_lock = False
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            got_lock = True
+        except OSError:
+            pass
+        holders = ""
+        if port:
+            try:
+                holders = subprocess.run(
+                    ["lsof", "-t", port, port.replace("/cu.", "/tty.")],
+                    capture_output=True, text=True).stdout.strip()
+            except FileNotFoundError:      # no lsof on this bench: flock only
+                pass
+        if got_lock and not holders:
+            if waited:
+                print("[bench] free, proceeding")
+            return fd   # keep open: lock is held until process exit
+        if got_lock:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        if time.time() > deadline:
+            sys.exit(f"[bench] {port or BENCH_LOCK} still busy after {timeout_s}s "
+                     f"(lock={'ok' if got_lock else 'held'}, "
+                     f"holders={holders or 'none'})")
+        if not waited:
+            print(f"[bench] waiting for {port or BENCH_LOCK} "
+                  f"(lock={'ok' if got_lock else 'held elsewhere'}, "
+                  f"holder pids={holders or '?'})")
+            waited = True
+        time.sleep(5.0)
+
+
 # ── firmware ────────────────────────────────────────────────────────────────
 def resolve_firmware(args):
     if args.firmware:
@@ -588,6 +641,9 @@ def main():
                          "whole World suite (default: each sketch's own threshold)")
     ap.add_argument("--world-base", default=WORLD_BASE,
                     help="AMYboard World API base URL")
+    ap.add_argument("--no-bench-lock", action="store_true",
+                    help="skip the /tmp/amyboard-bench.lock flock (local bring-up "
+                         "on a bench nothing else shares)")
     args = ap.parse_args()
     print(f"[hwci] backend: {'ALSA cli' if ALSA else 'python libs'}")
 
@@ -597,6 +653,10 @@ def main():
     if not args.no_flash and not args.port:
         sys.exit("--port (the USB-serial dongle) is required to flash.")
     bin_path, tmp = resolve_firmware(args) if not args.no_flash else (None, False)
+
+    # Take the bench lock AFTER the firmware download (network time shouldn't
+    # hold the bench) and keep the fd referenced until the process exits.
+    bench_lock = None if args.no_bench_lock else acquire_bench(args.port)
 
     # We deliberately do NOT hold the debug UART open while the board boots: the
     # proven-good reset on this bench is `esptool chip-id` (hard-reset + release

--- a/tulip/amyboard/hwci/tulip_hwci.py
+++ b/tulip/amyboard/hwci/tulip_hwci.py
@@ -53,6 +53,60 @@ ALSA = bool(shutil.which("arecord"))
 WORLD_BASE = "https://tulipcc-production.up.railway.app"
 
 
+# ── bench lock ────────────────────────────────────────────────────────────────
+# The Tulip shares this bench with the AMYboard — their analog outs are summed
+# into ONE capture card — and shorepine/amy's "AMY HW CI" + loadsweep sweeps use
+# the same bench from a SEPARATE runner registration, so GitHub never serializes
+# the two repos' jobs. Every harness that touches the bench takes this flock for
+# its whole run — same path and semantics as hwci.py and amy's
+# tools/arduino_loadsweep/measure.py.
+BENCH_LOCK = "/tmp/amyboard-bench.lock"
+
+
+def acquire_bench(port, timeout_s=900):
+    """Serialize bench access across processes/sessions.
+
+    Holds an flock on BENCH_LOCK for the rest of this process (the caller keeps
+    the returned fd alive) AND waits for the serial port itself to be free —
+    tty devices are not exclusive, so a lock alone doesn't protect against
+    harnesses that don't take it."""
+    import fcntl
+    fd = os.open(BENCH_LOCK, os.O_CREAT | os.O_RDWR, 0o666)
+    deadline = time.time() + timeout_s
+    waited = False
+    while True:
+        got_lock = False
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            got_lock = True
+        except OSError:
+            pass
+        holders = ""
+        if port:
+            try:
+                holders = subprocess.run(
+                    ["lsof", "-t", port, port.replace("/cu.", "/tty.")],
+                    capture_output=True, text=True).stdout.strip()
+            except FileNotFoundError:      # no lsof on this bench: flock only
+                pass
+        if got_lock and not holders:
+            if waited:
+                print("[bench] free, proceeding")
+            return fd   # keep open: lock is held until process exit
+        if got_lock:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        if time.time() > deadline:
+            sys.exit(f"[bench] {port or BENCH_LOCK} still busy after {timeout_s}s "
+                     f"(lock={'ok' if got_lock else 'held'}, "
+                     f"holders={holders or 'none'})")
+        if not waited:
+            print(f"[bench] waiting for {port or BENCH_LOCK} "
+                  f"(lock={'ok' if got_lock else 'held elsewhere'}, "
+                  f"holder pids={holders or '?'})")
+            waited = True
+        time.sleep(5.0)
+
+
 # ── firmware ──────────────────────────────────────────────────────────────────
 def resolve_firmware(args):
     """Return (path, is_temp). Tulip firmware is a built artifact, not a preview."""
@@ -487,6 +541,9 @@ def main():
     ap.add_argument("--serial-log", default=None,
                     help="serial log path (default: {name}-serial.log)")
     ap.add_argument("--no-serial-log", action="store_true")
+    ap.add_argument("--no-bench-lock", action="store_true",
+                    help="skip the /tmp/amyboard-bench.lock flock (local bring-up "
+                         "on a bench nothing else shares)")
     args = ap.parse_args()
     args_g = args
     print(f"[hwci] backend: {'ALSA cli' if ALSA else 'python libs'}")
@@ -503,6 +560,11 @@ def main():
               "skipping WiFi+screenshot check")
         if args.require_wifi:
             sys.exit("[wifi] --require-wifi set but no WiFi creds provided.")
+
+    # Hold the bench lock from before the flash until the process exits (the
+    # firmware here is a local CI artifact, so there's no download to keep
+    # outside the lock).
+    bench_lock = None if args.no_bench_lock else acquire_bench(args.port)
 
     if not args.no_flash:
         bin_path, tmp = resolve_firmware(args)


### PR DESCRIPTION
## Problem

The Pi bench has **two runner registrations** — `amyboardci-pi` (this repo) and `amyboardci-pi-amy` (shorepine/amy's "AMY HW CI") — and GitHub `concurrency:` groups only serialize within one repo. So an amy bench job can start mid-tulipcc-HW-CI-run: amy's harness waits only while our dongle is literally open (its `lsof` check), i.e. during our ~2-min flash, then flashes LoadTestChord onto the AMYboard during our recording phase. That kills the CDC (`could not open /dev/amyboard-cdc`, render-load poll dead) and plays a held Juno chord into the shared capture card, failing every audio compare — including the Tulip half (262 Hz chord root under the 440 Hz sine check).

Seen live 2026-07-08: tulipcc run [28954586568](https://github.com/shorepine/tulipcc/actions/runs/28954586568) (15:27:02–15:33:06Z) ∩ amy run [28954600959](https://github.com/shorepine/amy/actions/runs/28954600959) (15:27:15–15:30:53Z). The amy run "passed" (it only reads its own debug UART); ours failed everything.

## Fix

amy's `tools/arduino_loadsweep/measure.py` already takes a blocking exclusive flock on `/tmp/amyboard-bench.lock` + an `lsof` wait on the port. `hwci.py` and `tulip_hwci.py` now take the **same lock with the same semantics**, held for the whole flash+drive+record run (fd kept alive until process exit), so whichever harness gets the bench first runs alone and the other waits (up to 15 min, then exits with a clear message). The firmware download stays outside the lock. `--no-bench-lock` opts out for local bring-up on an unshared bench. README documents the protocol.

Verified locally: with another process holding the flock, `acquire_bench()` waits and proceeds the moment it's released.

Note: this PR's own HW CI run is expected to fail the `woodpiano` check — that's the pre-existing regression on main since 80fbf976 (silent woodpiano, all runs since 2026-07-08 02:46Z), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)