### PR TITLE
hwci: make mid-run bench failures loud and self-healing

### DIFF
--- a/tools/amyboardctl/amyboardctl/link.py
+++ b/tools/amyboardctl/amyboardctl/link.py
@@ -52,6 +52,7 @@ SKETCH_PATH = "/user/current/sketch.py"
 TAG_ACK = 0x41       # 'A' (followed by 'K')
 TAG_OK = 0x4F        # 'O' (followed by 'K') — zI pong
 TAG_ERROR = 0x58     # 'X'
+TAG_OVERLOAD = 0x4C  # 'L' — AMY overload failsafe tripped (b64 load percent)
 TAG_VERSION = 0x56   # 'V'
 TAG_DUMP_ONE = 0x30  # '0' single-frame dump
 TAG_DUMP_MID = 0x43  # 'C' chunk, more follow
@@ -83,6 +84,7 @@ class AMYboardLink:
         self._dump = bytearray()
         self._dump_done = threading.Event()
         self.errors = []      # decoded sketch-error tracebacks since last clear
+        self.overloads = []   # load percents from 'L' overload-failsafe frames
         self.version = None
         self.in_name = None
         self.out_name = None
@@ -126,6 +128,18 @@ class AMYboardLink:
                 text = "<undecodable sketch error frame>"
             self.errors.append(text)
             self._log("  ⚠ sketch error frame received (%d bytes)" % len(text))
+        elif tag == TAG_OVERLOAD:
+            # amyboard.py's _on_amy_overload: AMY's CPU failsafe tripped on the
+            # board (synth reset + bleep already happened, sketch stopped).
+            # Always loud — a run that hits this has stopped making the sound
+            # under test, whatever the harness thinks it's recording.
+            try:
+                pct = base64.b64decode(bytes(data[4:])).decode("ascii", "replace").strip()
+            except Exception:
+                pct = "?"
+            self.overloads.append(pct)
+            print("[amyboardctl] ⚠ AMY OVERLOAD failsafe tripped on the board "
+                  "(load %s%%) — sketch stopped" % pct, file=sys.stderr)
         elif tag == TAG_VERSION:
             self.version = bytes(data[4:]).decode("ascii", "replace").strip()
             self._version_evt.set()

--- a/tools/amyboardctl/amyboardctl/transport.py
+++ b/tools/amyboardctl/amyboardctl/transport.py
@@ -157,6 +157,7 @@ class AlsaTransport:
         self.ack_available = False
         self.in_name = self.out_name = None
         self._reader = None
+        self._closing = False
 
     def open(self):
         self.port = self.port_match if self.port_match.startswith("hw:") \
@@ -165,21 +166,25 @@ class AlsaTransport:
             raise RuntimeError("Could not find an AMYboard ALSA MIDI device "
                                "(match=%r); see `amidi -l`." % self.port_match)
         self.in_name = self.out_name = self.port
-        # Persistent receive stream: line-buffered so frames arrive in real time
-        # (block buffering would sit on the board's ACKs). Coexists fine with the
-        # one-shot `amidi -S` sends on the same rawmidi device.
         try:
-            self._reader = subprocess.Popen(
-                ["stdbuf", "-oL", "amidi", "-p", self.port, "-d"],
-                stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, bufsize=1)
-            threading.Thread(target=self._read_loop, daemon=True).start()
-            self.ack_available = True
+            self._spawn_reader()
         except Exception as e:
             print("[amyboardctl] no amidi read stream (%s); send-only" % e,
                   file=sys.stderr)
         return self
 
+    def _spawn_reader(self):
+        # Persistent receive stream: line-buffered so frames arrive in real time
+        # (block buffering would sit on the board's ACKs). Coexists fine with the
+        # one-shot `amidi -S` sends on the same rawmidi device.
+        self._reader = subprocess.Popen(
+            ["stdbuf", "-oL", "amidi", "-p", self.port, "-d"],
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, bufsize=1)
+        threading.Thread(target=self._read_loop, daemon=True).start()
+        self.ack_available = True
+
     def close(self):
+        self._closing = True
         if self._reader:
             try:
                 self._reader.terminate()
@@ -191,9 +196,10 @@ class AlsaTransport:
     def _read_loop(self):
         """Parse the `amidi -d` hex dump into SysEx frames and dispatch each
         frame's payload (the bytes between F0 and F7) to on_sysex."""
+        reader = self._reader
         buf, insx = [], False
         try:
-            for line in self._reader.stdout:
+            for line in reader.stdout:
                 for tok in line.split():
                     try:
                         b = int(tok, 16)
@@ -209,6 +215,33 @@ class AlsaTransport:
                         buf.append(b)
         except Exception:
             pass
+        # `amidi -d` dies when the board re-enumerates (its rawmidi node goes
+        # away). That used to be silent — every later send_and_ack just timed
+        # out and transfers aborted with no trace. Respawn it once the device
+        # is back; if it never comes back, drop to send-only pacing and say so.
+        if self._closing:
+            return
+        print("[amyboardctl] amidi read stream died (rc=%s); respawning"
+              % reader.poll(), file=sys.stderr)
+        self.ack_available = False
+        deadline = time.time() + 15.0
+        while not self._closing and time.time() < deadline:
+            time.sleep(1.0)
+            port = self.port_match if self.port_match.startswith("hw:") \
+                else _alsa_find(self.port_match)
+            if not port:
+                continue
+            self.port = self.in_name = self.out_name = port
+            try:
+                self._spawn_reader()
+                print("[amyboardctl] amidi read stream back on %s" % port,
+                      file=sys.stderr)
+                return
+            except Exception:
+                continue
+        if not self._closing:
+            print("[amyboardctl] amidi read stream gone for good; "
+                  "continuing send-only (paced)", file=sys.stderr)
 
     def send(self, data):
         cmd = ["amidi", "-p", self.port, "-S", " ".join("%02X" % b for b in data)]

--- a/tulip/amyboard/hwci/hwci.py
+++ b/tulip/amyboard/hwci/hwci.py
@@ -290,7 +290,20 @@ class Midi:
                 pass
             self.link.reset_amy()
             time.sleep(0.3)
-            self.link.transfer_file(text)
+            # An unACKed transfer means the sketch may not actually be on the
+            # board — recording it anyway just measures 10s of silence with a
+            # clean log (the 2026-07-08 woodpiano incident). Retry once, then
+            # fail this sketch loudly instead of recording nothing.
+            for attempt in (1, 2):
+                sent, acked = self.link.transfer_file(text)
+                if acked == sent:
+                    break
+                print(f"[world] TRANSFER NOT ACKED ({acked}/{sent} frames), "
+                      f"attempt {attempt}/2")
+                if attempt == 2:
+                    raise RuntimeError(
+                        f"sketch transfer failed: {acked}/{sent} frames acked")
+                time.sleep(1.0)
             self.link.environment_transfer_done()
             time.sleep(settle)
         finally:
@@ -365,14 +378,9 @@ class SerialLog:
     def start(self):
         self._t.start()
 
-    def _run(self):
-        try:
-            import serial  # pyserial (ships with esptool)
-        except ImportError:
-            print(f"[log] pyserial missing; cannot capture {self.port}")
-            return
+    def _open(self, serial, window_s):
         ser = None
-        deadline = time.monotonic() + 8.0
+        deadline = time.monotonic() + window_s
         while ser is None and not self._stop.is_set() and time.monotonic() < deadline:
             try:
                 ser = serial.Serial()
@@ -385,21 +393,53 @@ class SerialLog:
             except Exception:
                 ser = None
                 time.sleep(0.3)
-        if ser is None:
-            print(f"[log] could not open {self.port} ({self.label})")
-            return
-        self.opened = True
-        while not self._stop.is_set():
-            try:
-                data = ser.read(4096)
-            except Exception:
-                break
-            if data:
-                self.buf.extend(data)
+        return ser
+
+    def _run(self):
         try:
-            ser.close()
-        except Exception:
-            pass
+            import serial  # pyserial (ships with esptool)
+        except ImportError:
+            print(f"[log] pyserial missing; cannot capture {self.port}")
+            return
+        first = True
+        while not self._stop.is_set():
+            # A read error mid-run usually means the board re-enumerated its
+            # USB (reboot / self-heal). Dying silently here truncated the log
+            # with no trace (the 2026-07-08 woodpiano incident) — instead say
+            # so, mark the log, and reopen so the post-reboot console (boot
+            # log, tracebacks) is captured too. 15s covers a re-enumeration.
+            ser = self._open(serial, 8.0 if first else 15.0)
+            if ser is None:
+                if self._stop.is_set():
+                    return
+                if first:
+                    print(f"[log] could not open {self.port} ({self.label})")
+                else:
+                    print(f"[log] {self.port} ({self.label}) did not come back; "
+                          "capture stops here")
+                    self.buf.extend(b"\n===== [log] port did not come back; "
+                                    b"capture truncated =====\n")
+                return
+            self.opened = True
+            if not first:
+                print(f"[log] {self.port} ({self.label}) reopened")
+                self.buf.extend(b"\n===== [log] reopened after read error =====\n")
+            first = False
+            while not self._stop.is_set():
+                try:
+                    data = ser.read(4096)
+                except Exception as e:
+                    print(f"[log] {self.port} ({self.label}) read error: {e}; "
+                          "reopening")
+                    self.buf.extend(f"\n===== [log] read error: {e}; "
+                                    "reopening =====\n".encode())
+                    break
+                if data:
+                    self.buf.extend(data)
+            try:
+                ser.close()
+            except Exception:
+                pass
 
     def stop(self):
         self._stop.set()


### PR DESCRIPTION
Hardens the three silent failure modes that made the 2026-07-08 woodpiano incident undiagnosable (every HW CI run 02:46Z–15:25Z failed exactly the woodpiano check with a clean-looking log; the state cleared before it could be dissected):

1. **`SerialLog` (hwci.py)** — the CDC/UART tail died on any read exception with `except Exception: break`, silently truncating the log (the incident's `n=22` load samples). It now prints the reason, writes a marker into the log, and reopens the port (15 s window, covers a re-enumeration) so the post-reboot console — boot banner, tracebacks — is captured as evidence.
2. **`load_world_sketch` (hwci.py)** — `transfer_file()`'s `(sent, acked)` return was discarded, so an ACK-dead transfer meant the sketch silently never loaded and the harness recorded 10 s of silence. UnACKed transfers now print loudly, retry once, then fail that sketch as a distinct load failure.
3. **`AlsaTransport` (amyboardctl)** — the persistent `amidi -d` ACK reader was spawned once with `stderr=DEVNULL` and no restart; a board USB re-enum killed it invisibly and every later `send_and_ack` just timed out. It now respawns once the device returns (re-resolving the port), or drops to the existing send-only pacing fallback and says so.
4. **Bonus** — `amyboardctl` now recognizes the AMY overload-failsafe `'L'` sysex frame (`amyboard.py` `_on_amy_overload`, #1105) and reports the load percent on stderr, so a failsafe trip mid-run is directly visible in the run log.

**Bench-validated on the Pi (amyboardci):**
- Clean run: 4/4 PASS unchanged, n=44 load samples — no behavior change on the happy path.
- Chaos run: injected a `zB1Z` reboot sysex mid-suite. The log now reads `amidi read stream died; respawning` → `back on hw:3,0,0`, `CDC read error: device reports readiness to read but returned no data; reopening` → `reopened`, and the serial-log artifact contains the reopen marker plus the post-reboot MicroPython boot banner. The run then **recovered and passed 4/4** (woodpiano 0.9999) — the same event class under the old harness produced the silent-woodpiano signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)