### PR TITLE
Fix stale PatchSynth positional calls in web examples and docs

### DIFF
--- a/docs/music.md
+++ b/docs/music.md
@@ -183,7 +183,7 @@ You may want to programatically change the MIDI to synth mapping. One example wo
 You can change the parameters of channel synths like this:
 
 ```python
-midi.config.add_synth(channel=c, synth=synth.PatchSynth(patch_number=p, num_voices=n))
+midi.config.add_synth(channel=c, synth=synth.PatchSynth(patch=p, num_voices=n))
 ```
 
 Note that `add_synth` will stop any running synth on that channel and boot a new one in its place. 

--- a/docs/tulip_api.md
+++ b/docs/tulip_api.md
@@ -624,7 +624,7 @@ Here's an example of using both sequencers:
 
 ```python
 import sequencer
-syn = synth.PatchSynth(1, 0) # make a synthesizer to control
+syn = synth.PatchSynth(num_voices=1, patch=0) # make a synthesizer to control
 
 arp_notes = [48,50,52,49,56,58,60,57]
 
@@ -662,7 +662,7 @@ By default, Tulip boots into AMY's live MIDI synthesizer mode. Any note-ons, not
 
 By default, MIDI notes on channel 1 will map to Juno-6 patch 0. And MIDI notes on channel 10 will play the PCM samples (like a drum machine).
 
-You can adjust which voices are sent with `midi.config.add_synth(channel, patch_number, num_voices)`. For example, you can have Tulip play DX7 patch 129 on channel 2 with `midi.config.add_synth(channel=2, patch_number=129, num_voices=1)`. `channel=2` is a MIDI channel (we use 1-16 indexing), `patch_number=129` is an AMY patch number, `num_voices=1` is the number of voices (polyphony) you want to support for that channel and patch. 
+You can adjust which voices are sent with `midi.config.add_synth(channel=channel, synth=synth)`. For example, you can have Tulip play DX7 patch 129 on channel 2 with `midi.config.add_synth(channel=2, synth=synth.PatchSynth(patch=129, num_voices=1))`. `channel=2` is a MIDI channel (we use 1-16 indexing), `patch=129` is an AMY patch number, `num_voices=1` is the number of voices (polyphony) you want to support for that channel and patch. 
 
 (A good rule of thumb is Tulip CC can support about 6 simultaneous total voices for Juno-6, 8-10 for DX7, and 20-30 total voices for PCM and more for other simpler oscillator patches.)
 

--- a/tulip/amyboardweb/static/examples.js
+++ b/tulip/amyboardweb/static/examples.js
@@ -4,7 +4,7 @@ const example_snippets = [{
     'd':"Set up a MIDI channel to play a piano",
     'c':`
 midi.config.reset()
-midi.config.add_synth(synth.PatchSynth(6, 256))
+midi.config.add_synth(synth.PatchSynth(num_voices=6, patch=256))
 # Now set your MIDI device on this page and play a note!
 `},{
     't':'music',
@@ -34,7 +34,7 @@ def make_patch(x):
     amy.stop_store_patch(1024)
 
 def next(t):
-    s = synth.PatchSynth(8, 1024)
+    s = synth.PatchSynth(num_voices=8, patch=1024)
     p = music.Progression(["I", "vi", "IV", "V"], music.Key("E:maj"))
     chord_len = 2000
     note_len = 500

--- a/tulip/web/static/examples.js
+++ b/tulip/web/static/examples.js
@@ -15,7 +15,7 @@ tulip.run('drums')
     'c':`
 import midi, synth
 midi.config.reset()
-midi.config.add_synth(synth.PatchSynth(6, 256))
+midi.config.add_synth(synth.PatchSynth(num_voices=6, patch=256))
 # Now set your MIDI device on this page and play a note!
 `},{
     't':'games',
@@ -353,7 +353,7 @@ def make_patch(x):
     amy.stop_store_patch(1024)
 
 def next(t):
-    s = synth.PatchSynth(8, 1024)
+    s = synth.PatchSynth(num_voices=8, patch=1024)
     p = music.Progression(["I", "vi", "IV", "V"], music.Key("E:maj"))
     chord_len = 2000
     note_len = 500
@@ -392,7 +392,7 @@ import sequencer
 midi.config.reset()
 midi.add_default_synths()
 sequencer.tempo(140)
-syn = synth.PatchSynth(1, 0)
+syn = synth.PatchSynth(num_voices=1, patch=0)
 midi.config.add_synth(channel=2, synth=syn)
 arp_notes = [48,50,None,49,56,None,46,44,None,None,49,56,58,60,None,56]
 seq= sequencer.AMYSequence(16,8)


### PR DESCRIPTION
PatchSynth's second positional argument changed from `patch_number` to `channel` in the AMY-synth rewrite, so bundled examples still using the old positional form crash with `ValueError: Just 1 of patch (None) patch-string (None) or oscs_per_voice needed` (reported from the Tulip Web "Sequence with drums and the Juno-6 editor" example).

Fixed call sites, all switched to keyword args:

- `tulip/web/static/examples.js` — Juno-6 sequencer example (`PatchSynth(num_voices=1, patch=0)`), MIDI piano (`num_voices=6, patch=256`), custom FM synth (`num_voices=8, patch=1024`)
- `tulip/amyboardweb/static/examples.js` — same piano and FM synth examples
- `docs/tulip_api.md` — sequencers example, plus the MIDI section that documented `add_synth(channel=2, patch_number=129, num_voices=1)` (`add_synth` no longer has a `patch_number` parameter)
- `docs/music.md` — `PatchSynth(patch_number=p)` → `patch=p`

Verified against the real `synth.py` with a stubbed `amy`: the old calls reproduce the reported ValueError, the fixed calls initialize the synth and sequence note-ons cleanly. Examples that pass only `num_voices` and then `program_change(...)` are left alone — they work because `program_change` sets the patch before deferred init.

Note: the "A simple pattern note player" example's `ValueError: No arg for key synth` is a separate bug (note_off on a released synth), not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)