### PR TITLE
amyboard web: soft keyboard sends real MIDI to AMY instead of iXnY synth messages

### DIFF
--- a/tulip/amyboardweb/static/editor/index.html
+++ b/tulip/amyboardweb/static/editor/index.html
@@ -2374,13 +2374,23 @@
             borderColour: "#111"
           });
 
+          // The soft keyboard sends real MIDI note on/off bytes into AMY (via
+          // inject_midi_bytes in spss.js) rather than an AMY synth message
+          // (iXnY). That way it behaves exactly like an external MIDI keyboard
+          // on the selected channel: it reaches the user's own MIDI routing
+          // (Python midi callbacks, custom synth setups), and it needs no
+          // WebMIDI, so it works on Safari too.
+          const keyboardMidiChannel = function() {
+            return ((Number(window.current_synth) || 1) - 1) & 0x0F;
+          };
+
           qwerty.keyDown = function(note, freq) {
             if (!audio_started && amyboard_mode !== 'control') return;
             const midi = noteToMidi(note);
             const midiFromFreq = freqToMidi(freq);
             const finalMidi = Number.isFinite(midi) ? midi : midiFromFreq;
             if (Number.isFinite(finalMidi)) {
-              amy_send({synth: window.current_synth, vel: 1, note: finalMidi}, true);
+              inject_midi_bytes([0x90 | keyboardMidiChannel(), finalMidi & 0x7F, 127]);
             }
             if (typeof window.onKeyboardNote === "function") {
               window.onKeyboardNote(finalMidi, note);
@@ -2392,7 +2402,7 @@
             const midiFromFreq = freqToMidi(freq);
             const finalMidi = Number.isFinite(midi) ? midi : midiFromFreq;
             if (Number.isFinite(finalMidi)) {
-              amy_send({synth: window.current_synth, vel: 0, note: finalMidi}, true);
+              inject_midi_bytes([0x80 | keyboardMidiChannel(), finalMidi & 0x7F, 0]);
             }
           };
         }

--- a/tulip/amyboardweb/static/spss.js
+++ b/tulip/amyboardweb/static/spss.js
@@ -1693,7 +1693,33 @@ window.refresh_knobs_for_active_channel = async function(options) {
 // so AMY's `typeof amy_external_midi_input_js_hook === 'function'` check still
 // passes. NOTE: tulip/web (not this file) still relies on this hook as its only
 // path, so don't "fix" it the same way there.
-function amy_external_midi_input_js_hook(bytes, len, sysex) { /* no-op: see comment above */ } 
+function amy_external_midi_input_js_hook(bytes, len, sysex) { /* no-op: see comment above */ }
+
+// Inject raw MIDI bytes from on-page UI (the soft keyboard) into AMY exactly
+// as if they had arrived on a real MIDI input. This does NOT use WebMIDI, so
+// it works on Safari/Firefox. Simulate mode: feed the bytes into the local
+// AMY WASM MIDI parser and forward the complete message to MicroPython's
+// midi callbacks — the same two paths the hardware "midimessage" listener in
+// setup_midi_devices() takes. Control mode: send the bytes out the selected
+// MIDI output so the AMYboard parses them like any other MIDI input.
+function inject_midi_bytes(bytes) {
+  if (!bytes || bytes.length === 0) return;
+  if (amyboard_mode === 'control') {
+    var out = get_selected_midi_output_device() || midiOutputDevice;
+    if (out && typeof out.send === "function") {
+      try { out.send(bytes); } catch (e) {}
+    }
+    return;
+  }
+  if (!audio_started || typeof amy_process_single_midi_byte !== "function") return;
+  for (var i = 0; i < bytes.length; i++) {
+    amy_process_single_midi_byte(bytes[i], 1);
+  }
+  if (typeof mp !== 'undefined' && mp && mp.midiInHook) {
+    var sysex = bytes[0] === 0xF0 ? 1 : 0;
+    mp.midiInHook(new Uint8Array(bytes), bytes.length, sysex);
+  }
+}
 
 function safe_midi_port_id(port) {
   try {


### PR DESCRIPTION
## What

The on-screen piano keyboard in AMYboard Online sent `amy_send({synth, vel, note})` — an AMY wire message (`iXnY`) targeting the selected channel's synth directly. That bypassed AMY's MIDI layer entirely, so users who set up their own MIDI routing (Python `midi.add_callback`, custom setups without a synth on the selected channel) never saw the notes.

Now the keyboard sends real MIDI note on/off bytes on the selected channel:

- **New `inject_midi_bytes()` in `spss.js`** — injects raw MIDI bytes into AMY exactly as if they arrived on a real MIDI input.
  - **Simulate mode:** bytes go byte-by-byte into the local AMY WASM MIDI parser (`amy_process_single_midi_byte`) and the complete message is forwarded to `mp.midiInHook` for Python midi callbacks — the same two paths the hardware `midimessage` listener in `setup_midi_devices()` takes. No WebMIDI involved, so **the keyboard now works on Safari/Firefox**.
  - **Control mode:** bytes are sent out the selected MIDI output so the AMYboard hardware parses them like any other MIDI input (same mechanism as the existing MIDI thru path).
- **`editor/index.html`** — `keyDown`/`keyUp` build `0x90|ch, note, 127` / `0x80|ch, note, 0` and call `inject_midi_bytes` instead of `amy_send`.

## Testing

Verified live in the web simulator in a browser context **without WebMIDI** (the Safari case):

- Clicking C3 delivered `[0x90, 48, 127]` then `[0x80, 48, 0]` into AMY's MIDI parser (spy on `amy_process_single_midi_byte`).
- A Python `midi.add_callback` registered in the sim received both messages — the previously-broken case.
- With channel 10 selected, status bytes were `0x99`/`0x89` (GM drums route correctly).
- No new console errors.

Control mode not hardware-tested; it reuses the exact send path of the existing MIDI pass-thru. Behavior note: in control mode the board now receives the keyboard as plain MIDI notes (so on-board Python midi callbacks see them too), instead of sysex-wrapped AMY messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)