### PR TITLE
CI: continuous release of VCV Rack plugin (lin/win/mac) + Tulip Desktop for Windows

### DIFF
--- a/.github/workflows/amyboard-release.yml
+++ b/.github/workflows/amyboard-release.yml
@@ -142,7 +142,10 @@ jobs:
   # build scripts share tulip/vcvrack/build/ and clean up after themselves,
   # exactly the flow they were validated with.
   vcv-lin-win:
-    runs-on: ubuntu-latest
+    # arm64 runner (free for public repos): the toolchain image is arm64-only
+    # (built on an Apple Silicon mac); it cross-compiles to lin-x64/win-x64
+    # regardless of host arch. ubuntu-latest (amd64) cannot pull it.
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: write              # upload .vcvplugin assets to the release
     steps:

--- a/.github/workflows/amyboard-release.yml
+++ b/.github/workflows/amyboard-release.yml
@@ -15,6 +15,15 @@ name: AMYboard release
 #                 amyboard-* assets there.
 #   - web      -> amyboardweb/stage/ deployed --prod to the 'amyboard' Vercel
 #                 project (amyboard.com).
+#   - vcv-*    -> AMYboard VCV Rack plugin (.vcvplugin for lin-x64 / win-x64 /
+#                 mac-arm64) uploaded to the rolling 'amyboard' release for
+#                 sideloading (Rack manual: drop the file in
+#                 <Rack user folder>/plugins-<os>-<cpu>/ and Rack extracts it).
+#                 This is NOT the official VCV Library flow — that one is
+#                 manual: bump "version" in tulip/vcvrack/plugin.json, push,
+#                 then comment the new version + commit hash on our plugin's
+#                 issue thread in github.com/VCVRack/library; VCV's build farm
+#                 builds it from source (~1-2 weeks turnaround).
 #
 # Tulip firmware is NOT built here — it has its own continuous release
 # (tulip-release.yml). This replaces the old 'dev' channel (rolling 'dev'
@@ -31,6 +40,7 @@ on:
       - 'tulip/esp32s3/**'
       - 'tulip/amyboardweb/**'
       - 'tulip/shared/**'
+      - 'tulip/vcvrack/**'
       - '.github/workflows/amyboard-release.yml'
   workflow_dispatch:
 
@@ -121,6 +131,142 @@ jobs:
               tulip/amyboard/dist/amyboard-full-AMYBOARD.bin \
               tulip/amyboard/dist/amyboard-sys.bin
           fi
+
+  # --- AMYboard VCV Rack plugin ---------------------------------------------
+  # lin-x64 + win-x64 cross-build inside the rack-plugin-toolchain image
+  # (ghcr.io/shorepine/rack-plugin-toolchain:19 — a prebuilt image of
+  # VCVRack/rack-plugin-toolchain, pushed once from a local `make docker-build`
+  # and kept PUBLIC so the job can pull it unauthenticated; building the
+  # toolchain from scratch takes ~1 hr/platform, so CI always pulls).
+  # Both platforms build sequentially in one job on purpose: the
+  # build scripts share tulip/vcvrack/build/ and clean up after themselves,
+  # exactly the flow they were validated with.
+  vcv-lin-win:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write              # upload .vcvplugin assets to the release
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Generate AMY drum data
+        # The gamma9001 generator is stdlib-only (no numpy). patches.h is
+        # committed; touch it so make doesn't try to regenerate it (that
+        # path DOES need numpy, absent in the toolchain image).
+        run: |
+          cd amy
+          python3 -m amy.headers gamma9001
+          touch src/patches.h
+
+      - name: Build lin-x64 plugin
+        run: |
+          docker run --rm --user root -v "$PWD":/work -w /work/tulip/vcvrack \
+            ghcr.io/shorepine/rack-plugin-toolchain:19 \
+            bash /work/tulip/vcvrack/toolchain-build-lin.sh
+
+      - name: Build win-x64 plugin
+        run: |
+          docker run --rm --user root -v "$PWD":/work -w /work/tulip/vcvrack \
+            ghcr.io/shorepine/rack-plugin-toolchain:19 \
+            bash /work/tulip/vcvrack/toolchain-build-win.sh
+
+      - name: Upload plugin artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: amyboard-vcvplugin-lin-win
+          if-no-files-found: error
+          path: |
+            tulip/vcvrack/dist-lin/*.vcvplugin
+            tulip/vcvrack/dist-win/*.vcvplugin
+
+      - name: Publish to the rolling 'amyboard' release
+        if: github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if ! gh release view amyboard >/dev/null 2>&1; then
+            echo "::error::rolling 'amyboard' release does not exist yet"; exit 1
+          fi
+          # Canonical Rack asset names: AMYboard-<version>-<os>-<cpu>.vcvplugin.
+          # Same-version rebuilds clobber; when plugin.json's version bumps,
+          # prune the previous version's asset for the same platform so one
+          # .vcvplugin per platform lives on the release at a time.
+          for f in tulip/vcvrack/dist-lin/*.vcvplugin tulip/vcvrack/dist-win/*.vcvplugin; do
+            name="$(basename "$f")"
+            plat="${name#AMYboard-*-}"       # -> <os>-<cpu>.vcvplugin
+            gh api "repos/${GITHUB_REPOSITORY}/releases/tags/amyboard" --jq '.assets[].name' \
+              | { grep -E "^AMYboard-.*-${plat%.vcvplugin}\.vcvplugin$" || true; } \
+              | { grep -vx "$name" || true; } \
+              | while read -r stale; do gh release delete-asset amyboard "$stale" --yes; done
+            gh release upload --clobber amyboard "$f"
+          done
+
+  # mac-arm64 built natively on the macos runner with the official Rack SDK,
+  # mirroring the local dev flow (this is also how community plugin CI does
+  # mac — the docker toolchain's osxcross path needs an Xcode-extracted SDK).
+  # mac-x64 is a follow-up: Makefile.mp doesn't wire cross -arch flags yet.
+  vcv-mac:
+    runs-on: macos-14
+    permissions:
+      contents: write              # upload .vcvplugin assets to the release
+    env:
+      RACK_SDK_VERSION: 2.6.6
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Generate AMY drum data
+        run: |
+          cd amy
+          python3 -m amy.headers gamma9001
+          touch src/patches.h
+
+      - name: Download Rack SDK (mac-arm64)
+        run: |
+          set -euo pipefail
+          # plugin.mk shells out to jq (even at parse time) and zstd (dist).
+          # Both ship on macos runner images; install if that ever changes.
+          (command -v jq && command -v zstd) >/dev/null || brew install jq zstd
+          curl -fsSL "https://vcvrack.com/downloads/Rack-SDK-${RACK_SDK_VERSION}-mac-arm64.zip" \
+            -o "$RUNNER_TEMP/rack-sdk.zip"
+          unzip -q "$RUNNER_TEMP/rack-sdk.zip" -d "$RUNNER_TEMP/rack-sdk"
+
+      - name: Build mac-arm64 plugin
+        run: |
+          # Makefile.mp's frozen manifest needs mpy-cross prebuilt (the
+          # cross-build scripts do the same explicitly).
+          make -C micropython/mpy-cross -j4
+          cd tulip/vcvrack
+          make -j4 dist RACK_DIR="$RUNNER_TEMP/rack-sdk/Rack-SDK"
+
+      - name: Upload plugin artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: amyboard-vcvplugin-mac
+          if-no-files-found: error
+          path: tulip/vcvrack/dist/*.vcvplugin
+
+      - name: Publish to the rolling 'amyboard' release
+        if: github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if ! gh release view amyboard >/dev/null 2>&1; then
+            echo "::error::rolling 'amyboard' release does not exist yet"; exit 1
+          fi
+          for f in tulip/vcvrack/dist/*.vcvplugin; do
+            name="$(basename "$f")"
+            plat="${name#AMYboard-*-}"       # -> <os>-<cpu>.vcvplugin
+            gh api "repos/${GITHUB_REPOSITORY}/releases/tags/amyboard" --jq '.assets[].name' \
+              | { grep -E "^AMYboard-.*-${plat%.vcvplugin}\.vcvplugin$" || true; } \
+              | { grep -vx "$name" || true; } \
+              | while read -r stale; do gh release delete-asset amyboard "$stale" --yes; done
+            gh release upload --clobber amyboard "$f"
+          done
 
   web:
     runs-on: ubuntu-latest

--- a/.github/workflows/tulip-release.yml
+++ b/.github/workflows/tulip-release.yml
@@ -31,6 +31,7 @@ on:
       - 'tulip/shared/**'
       - 'tulip/fs/tulip/**'
       - 'tulip/macos/**'
+      - 'tulip/windows/**'
       - '.github/workflows/tulip-release.yml'
   workflow_dispatch:
 
@@ -244,3 +245,57 @@ jobs:
             echo "::error::rolling 'tulip' release does not exist yet"; exit 1
           fi
           gh release upload --clobber tulip tulip/macos/dist/Tulip_Desktop.zip
+
+  # Tulip Desktop for Windows (x64), MinGW-cross-built inside the
+  # rack-plugin-toolchain image (ghcr.io/shorepine/rack-plugin-toolchain:19,
+  # the same prebuilt image the AMYboard VCV jobs use — it carries
+  # x86_64-w64-mingw32 gcc). Ships Tulip_Desktop_Windows.zip (tulip.exe +
+  # SDL2.dll). The exe is unsigned — Windows SmartScreen will warn on first
+  # run (Windows code signing is a separate cert acquisition, unlike the mac
+  # notarization above). The build keeps the script's validated DEBUG=1
+  # (-O0) config for now; flipping to -Os is a follow-up once verified on
+  # real Windows hardware.
+  desktop-windows:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write              # upload Tulip_Desktop_Windows.zip to the 'tulip' release
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Generate AMY drum data
+        # stdlib-only generator; the build script touches patches.h itself.
+        run: cd amy && python3 -m amy.headers gamma9001
+
+      - name: Build tulip.exe (MinGW cross)
+        run: |
+          docker run --rm --user root -v "$PWD":/work -w /work/tulip/windows \
+            ghcr.io/shorepine/rack-plugin-toolchain:19 \
+            bash /work/tulip/windows/toolchain-build-windows.sh
+
+      - name: Package Tulip_Desktop_Windows.zip
+        # Write into RUNNER_TEMP: build-standard/ is root-owned (created
+        # inside the toolchain container), so this step can't create files there.
+        run: |
+          set -euo pipefail
+          cd tulip/windows/build-standard
+          zip -q "${RUNNER_TEMP}/Tulip_Desktop_Windows.zip" tulip.exe SDL2.dll
+
+      - name: Upload Tulip Desktop for Windows artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tulip-desktop-windows
+          if-no-files-found: error
+          path: ${{ runner.temp }}/Tulip_Desktop_Windows.zip
+
+      - name: Publish Tulip_Desktop_Windows.zip to the rolling 'tulip' release
+        if: github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if ! gh release view tulip >/dev/null 2>&1; then
+            echo "::error::rolling 'tulip' release does not exist yet"; exit 1
+          fi
+          gh release upload --clobber tulip "${RUNNER_TEMP}/Tulip_Desktop_Windows.zip"

--- a/.github/workflows/tulip-release.yml
+++ b/.github/workflows/tulip-release.yml
@@ -256,7 +256,10 @@ jobs:
   # (-O0) config for now; flipping to -Os is a follow-up once verified on
   # real Windows hardware.
   desktop-windows:
-    runs-on: ubuntu-latest
+    # arm64 runner (free for public repos): the toolchain image is arm64-only
+    # (built on an Apple Silicon mac); it cross-compiles to win-x64 regardless
+    # of host arch. ubuntu-latest (amd64) cannot pull it.
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: write              # upload Tulip_Desktop_Windows.zip to the 'tulip' release
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,13 @@ signing/notarization requires the `MACOS_SIGNING_CERT_P12`/`MACOS_SIGNING_CERT_P
 and `MACOS_NOTARY_API_KEY`/`MACOS_NOTARY_API_KEY_ID`/`MACOS_NOTARY_API_ISSUER_ID` repo
 secrets; without them the zip is built as a CI artifact but not published.
 
+The same workflow also builds **Tulip Desktop for Windows** (x64) in a
+`desktop-windows` job: MinGW cross-build inside the prebuilt public
+`ghcr.io/shorepine/rack-plugin-toolchain:19` docker image (pushed once from a
+local `make docker-build` of VCVRack/rack-plugin-toolchain — never rebuild it
+in CI, that takes ~1 hr/platform), publishing `Tulip_Desktop_Windows.zip`
+(unsigned `tulip.exe` + `SDL2.dll`) to the rolling `tulip` release.
+
 Both rolling releases also carry a **date-coded copy of the full flash image**
 (`tulip-full-TULIP4_R11-YYYYMMDD.bin`, `amyboard-full-AMYBOARD-YYYYMMDD.bin`) for the
 manufacturing partner; the stable-named bins must never be renamed (the web flasher,
@@ -190,6 +197,18 @@ AMYboard-affecting paths; also `workflow_dispatch`):
 2. **web** → `amyboardweb/stage/` is built and deployed `--prod` to the **`amyboard`**
    Vercel project (amyboard.com). Requires repo secret `VERCEL_TOKEN`
    (scope `bwhitmans-projects`), same as the PR-preview workflow.
+3. **vcv-lin-win / vcv-mac** → the AMYboard VCV Rack plugin
+   (`AMYboard-<version>-{lin-x64,win-x64,mac-arm64}.vcvplugin`) uploaded to the
+   rolling **`amyboard`** release for sideloading (drop into Rack's
+   `plugins-<os>-<cpu>/` folder). lin/win cross-build inside the public
+   `ghcr.io/shorepine/rack-plugin-toolchain:19` image; mac-arm64 builds
+   natively on the macos runner against the official Rack SDK (mac-x64 is a
+   known gap — `Makefile.mp` has no cross `-arch` support yet). The **official
+   VCV Library is a separate, manual flow**: bump `version` in
+   `tulip/vcvrack/plugin.json`, push to main, then comment the new version +
+   commit hash on our plugin's issue thread in `github.com/VCVRack/library`;
+   VCV's build farm builds from source (~1–2 week turnaround). Do not try to
+   automate that from CI.
 
 Tulip firmware is **not** built here — it has its own continuous release,
 `tulip-release.yml` (see "Tulip Release"). `releases/latest` is the rolling `tulip`


### PR DESCRIPTION
## What

Extends the two continuous-release workflows with the artifacts from #1155/#1154, all as parallel jobs (release wall clock stays ~10–15 min, nowhere near an hour):

- **amyboard-release.yml**
  - `vcv-lin-win`: lin-x64 + win-x64 `.vcvplugin` cross-built sequentially inside the prebuilt `ghcr.io/shorepine/rack-plugin-toolchain:19` image (the exact image the PR #1155 scripts were validated with), published to the rolling `amyboard` release.
  - `vcv-mac`: mac-arm64 built natively on `macos-14` against the official Rack SDK 2.6.6 (mirrors the local dev flow; community plugin CI does mac the same way). mac-x64 is a follow-up — `Makefile.mp` has no cross `-arch` wiring yet.
  - Publish steps clobber same-version assets and prune the previous version's asset per platform when `plugin.json` bumps.
- **tulip-release.yml**
  - `desktop-windows`: `Tulip_Desktop_Windows.zip` (unsigned `tulip.exe` + `SDL2.dll`) via the same toolchain image, published to the rolling `tulip` release. Keeps the validated `DEBUG=1` (-O0) config; flipping to `-Os` is a follow-up once verified on real Windows hardware.

Also documents in AGENTS.md that the **official VCV Library flow stays manual**: bump `plugin.json` version → push → comment version + commit hash on our `VCVRack/library` issue thread; VCV builds from source (~1–2 weeks). Nothing tag-driven, nothing to automate in CI.

## Validated locally

All four builds were run with the exact steps the jobs use (drum-data generation via stdlib-only `python3 -m amy.headers gamma9001`, then the container/native builds):

- `AMYboard-2.0.0-lin-x64.vcvplugin` ✅
- `AMYboard-2.0.0-win-x64.vcvplugin` ✅
- `AMYboard-2.0.0-mac-arm64.vcvplugin` ✅ (needed an explicit `make -C micropython/mpy-cross` first — added to the job)
- `tulip.exe` + `SDL2.dll` ✅

## ⚠️ Before merging

The jobs pull `ghcr.io/shorepine/rack-plugin-toolchain:19`, which doesn't exist yet — it must be pushed once from the local image and made public, or the first release run on main will fail at `docker pull`. (Current tokens lack `write:packages`; see session notes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)