### PR TITLE
Fix silent Tulip World upload failures on web; allow empty descriptions

### DIFF
--- a/tulip/amyboardweb/static/spss.js
+++ b/tulip/amyboardweb/static/spss.js
@@ -4249,6 +4249,7 @@ function prompt_admin_token() {
 }
 
 // Create a js File object and upload it to the AMYboard World API.
+// Returns {ok, detail} — detail is a human-readable error when ok is false.
 async function amyboard_world_upload_file(pwd, filename, username, description) {
     var contents = await mp.FS.readFile(pwd+filename, {encoding:'binary'});
     var file = await new File([new Uint8Array(contents)], filename, {type: 'application/binary'})
@@ -4256,10 +4257,25 @@ async function amyboard_world_upload_file(pwd, filename, username, description) 
     data.append('file',file);
     data.append('username', username);
     data.append('description', description);
-    return fetch(world_api_url("/api/amyboardworld/upload"), {
-        method: 'POST',
-        body: data,
-    });
+    var resp;
+    try {
+        resp = await fetch(world_api_url("/api/amyboardworld/upload"), {
+            method: 'POST',
+            body: data,
+        });
+    } catch (e) {
+        return { ok: false, detail: 'network error: ' + e };
+    }
+    var detail = '';
+    if (!resp.ok) {
+        try {
+            var err = await resp.json();
+            if (typeof err.detail === 'string') detail = err.detail;
+            else if (err.detail !== undefined) detail = JSON.stringify(err.detail);
+        } catch (e) {}
+        if (!detail) detail = 'HTTP ' + resp.status;
+    }
+    return { ok: resp.ok, detail: detail };
 }
 
 function sanitize_environment_description(raw) {

--- a/tulip/server/amyboardworld_db_api.py
+++ b/tulip/server/amyboardworld_db_api.py
@@ -322,8 +322,10 @@ def _normalize_username(raw: str) -> str:
     return username
 
 
-def _normalize_description(raw: str) -> str:
+def _normalize_description(raw: str, allow_empty: bool = False) -> str:
     description = " ".join((raw or "").split()).strip()
+    if allow_empty and not description:
+        return ""
     if len(description) < 1 or len(description) > MAX_DESCRIPTION:
         raise HTTPException(status_code=400, detail="Description must be 1-400 chars")
     return description
@@ -791,12 +793,14 @@ def delete_amyboard_file(item_id: int) -> dict[str, Any]:
 async def upload_tulip_file(
     request: Request,
     username: str = Form(...),
-    description: str = Form(...),
+    description: str = Form(default=""),
     file: UploadFile = File(...),
     created_at_ms: int | None = Form(default=None),
 ) -> dict[str, Any]:
     user = _normalize_username(username)
-    desc = _normalize_description(description)
+    # Tulip World uploads have always allowed a missing description
+    # (world.upload(filename) with no second arg), so empty is OK here.
+    desc = _normalize_description(description, allow_empty=True)
     contents = await file.read()
     filename = _validate_tulip_upload(file.filename or "", contents)
     item_id = _insert_file_row(

--- a/tulip/shared/py/world_web.py
+++ b/tulip/shared/py/world_web.py
@@ -182,7 +182,10 @@ def upload(filename, description=""):
         filename += ".tar"
 
     def clean_up(x):
-        print("Uploaded %s to Tulip World." % (filename))
+        if x.ok:
+            print("Uploaded %s to Tulip World." % (filename))
+        else:
+            print("Upload failed for %s (%s)" % (filename, x.detail))
         if tar:
             os.remove(filename)
 

--- a/tulip/web/static/spss.js
+++ b/tulip/web/static/spss.js
@@ -459,7 +459,8 @@ async function fill_tree() {
 }
 
 
-// Create a js File object and upload it to the TW proxy API. This is easier to do here than in python
+// Create a js File object and upload it to the TW proxy API. This is easier to do here than in python.
+// Returns {ok, detail} — detail is a human-readable error when ok is false.
 async function tulip_world_upload_file(pwd, filename, username, description) {
     var contents = await mp.FS.readFile(pwd+filename, {encoding:'binary'});
     var file = await new File([new Uint8Array(contents)], filename, {type: 'application/binary'})
@@ -467,10 +468,25 @@ async function tulip_world_upload_file(pwd, filename, username, description) {
     data.append('file',file);
     data.append('username', username);
     data.append('description', description);
-    return fetch('https://tulipcc-production.up.railway.app/api/tulipworld/upload', {
-        method: 'POST',
-        body: data,
-    });
+    var resp;
+    try {
+        resp = await fetch('https://tulipcc-production.up.railway.app/api/tulipworld/upload', {
+            method: 'POST',
+            body: data,
+        });
+    } catch (e) {
+        return { ok: false, detail: 'network error: ' + e };
+    }
+    var detail = '';
+    if (!resp.ok) {
+        try {
+            var err = await resp.json();
+            if (typeof err.detail === 'string') detail = err.detail;
+            else if (err.detail !== undefined) detail = JSON.stringify(err.detail);
+        } catch (e) {}
+        if (!detail) detail = 'HTTP ' + resp.status;
+    }
+    return { ok: resp.ok, detail: detail };
 }
 
 async function resize_tulip_grippie() {


### PR DESCRIPTION
## Problem

`world.upload("test.txt")` from Tulip Web printed "Uploaded test.txt to Tulip World." but nothing was actually uploaded — no file in `world.ls()`, no Discord post.

Two stacked bugs:

1. **Server rejects the default empty description.** `world.upload(filename)` defaults `description=""`, but `/api/tulipworld/upload` required 1–400 chars, so the upload was rejected with a 400.
2. **The web client swallows the error.** The JS upload bridge returned the raw `fetch` Response (which resolves on HTTP 4xx/5xx) and `world_web.upload`'s callback printed the success message unconditionally. Native `world.py` already reported failures correctly; only the web ports lied.

## Fix

- `tulip/web/static/spss.js` + `tulip/amyboardweb/static/spss.js`: upload bridges now return `{ok, detail}`, extracting the server's error `detail` on failure and catching network errors.
- `tulip/shared/py/world_web.py`: prints `Upload failed for <file> (<detail>)` when the upload didn't succeed, matching native behavior.
- `tulip/server/amyboardworld_db_api.py`: `/api/tulipworld/upload` accepts an empty or missing description (the >400-char cap still applies; AMYboard uploads still require a description).

## Verification

- Local uvicorn: empty/missing description → 200; >400 chars → 400; amyboard upload with empty description → still rejected.
- Built Tulip Web locally and drove the real WASM app in a browser against the local API (prod URL redirected via fetch shim): `world.upload('test.txt')` with no description → "Uploaded test.txt to Tulip World." and the file lands in the DB with an empty description; invalid username → "Upload failed for test.txt (Username must be 1-20 chars: A-Z, a-z, 0-9)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)