### PR TITLE
Factory reset: tear down AMY synths unconditionally

### DIFF
--- a/tulip/amyboardweb/static/spss.js
+++ b/tulip/amyboardweb/static/spss.js
@@ -6046,6 +6046,18 @@ async function reset_amyboard() {
                 await mp.runPythonAsync("import amyboard; amyboard.factory_reset()");
             } catch (e) {
                 console.warn('reset: amyboard.factory_reset() failed', e);
+                // The Python reset died somewhere — possibly BEFORE its AMY
+                // teardown reached the synth engine. The UI below resets to
+                // factory state regardless, so enforce the same on AMY from
+                // here: clear all synths and reinstall the boot defaults
+                // (idempotent with what restart_sketch sends). Without this,
+                // a silent failure left AMY still playing the old session's
+                // synths (e.g. a DX7 on a channel the UI showed as empty).
+                if (typeof amy_add_log_message === 'function' && typeof AMY !== 'undefined') {
+                    amy_add_log_message('S' + AMY.RESET_SYNTHS + 'Z');
+                    amy_add_log_message('i1K257iv6Z');
+                    amy_add_log_message('i' + window.DRUM_CHANNEL + 'K' + window.DRUM_DEFAULT_PATCH + 'iv1Z');
+                }
             }
             sync_persistent_fs();
             // SYNC 2: clear the knob log so a later Write doesn't re-emit the old

--- a/tulip/shared/amyboard-py/amyboard.py
+++ b/tulip/shared/amyboard-py/amyboard.py
@@ -502,6 +502,13 @@ def factory_reset(*_args):
     """Reset AMYboard to defaults: clear current/ folder and restart sketch."""
     import os
     tulip.stderr_write("factory reset — clearing current/ and writing default sketch.py")
+    # Tear down AMY FIRST. restart_sketch() below sends this again as part of
+    # _apply_knobs_text, but only after the file cleanup, an env re-create and
+    # a cd — if any of those throws, the reset must not leave the old
+    # session's synths playing (the web editor resets its UI regardless, so a
+    # silent failure here left AMY holding e.g. a DX7 synth the UI no longer
+    # showed). Idempotent: worst case AMY resets twice.
+    amy.send_raw("S%dZ" % amy.RESET_SYNTHS)
     user_base = tulip.root_dir() + "user"
     current_base = user_base + "/current"
     try:


### PR DESCRIPTION
Follow-up to #1172. Repro report from testing the merged build: load a DX7 preset on channel 2, hit the simulator's **Reset** button, switch back to channel 2 — the UI shows the factory-default (greyed Juno) state but MIDI keys still play the DX7 sound. The UI reset and the AMY reset had diverged.

## Root cause window

`factory_reset()` deleted `current/*` **first**, and the AMY teardown (`S<RESET_SYNTHS>`) only ran deep inside `restart_sketch → run_sketch → _apply_knobs_text` — after `stop_sketch`, a `RESET_SEQUENCER` send, the env re-create and a `cd`. Any exception in that chain (emscripten FS races right after the deletion are the usual suspect) aborted before `RESET_SYNTHS` reached AMY — and `reset_amyboard()`'s simulate branch caught the Python failure with a bare `console.warn` and reset the UI anyway, leaving AMY playing synths on channels the UI showed as empty. (The happy path is fine: I could not reproduce the report with the normal flow, old or new amy pin — the divergence needs the silent mid-reset failure.)

## Fix (two-sided, both idempotent)

- **`amyboard.py`**: `factory_reset()` sends `S<RESET_SYNTHS>` **first**, before touching files. On success `restart_sketch` sends it again (harmless); on failure the synths are at least silenced, matching the reset-to-defaults intent. Covers hardware (`zP factory_reset`) and simulator alike.
- **`spss.js`**: if the simulate branch's `mp.runPythonAsync("amyboard.factory_reset()")` rejects, enforce the same end state from JS — `S<RESET_SYNTHS>` + `i1K257iv6` + `i10K384iv1` — so the freshly-reset UI can never diverge from a still-configured AMY.

## Verified in the simulator (fresh build, amy pin 2505e75)

- Normal reset: ch2's DX7 synth is gone (`yield_synth_commands` empty), MIDI notes on ch2 produce zero output, ch1 holds the K257 default.
- Failure injection (`mp.runPythonAsync` monkeypatched to reject `factory_reset`): the JS fallback produces the same end state — synth 2 dead, ch2 silent, defaults installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)