### PR TITLE
Remove redundant start-audio instruction from simulate welcome modal

### DIFF
--- a/tulip/amyboardweb/static/editor/index.html
+++ b/tulip/amyboardweb/static/editor/index.html
@@ -1388,7 +1388,6 @@
               <h4 class="modal-title w-100 text-center" id="simulateWelcomeModalLabel">Welcome to AMYboard Simulator</h4>
             </div>
             <div class="modal-body text-center px-4 py-4">
-              <p class="text-muted mb-4">To get started, click the button below to start audio.</p>
               <button type="button" class="btn btn-success btn-lg px-4" id="simulate-welcome-start-btn">Click anywhere to start</button>
             </div>
           </div>


### PR DESCRIPTION
The simulate-mode welcome modal on AMYboard Web said "To get started, click the button below to start audio." while the button itself says "Click anywhere to start" — and clicking anywhere does dismiss it. Removes the contradictory line so the modal is just the title and the button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)