### PR TITLE
Fix stuck simulate welcome modal on early click

### DIFF
--- a/tulip/amyboardweb/static/editor/index.html
+++ b/tulip/amyboardweb/static/editor/index.html
@@ -1088,15 +1088,24 @@
         // Show a welcome modal that forces a click (required by browser audio
         // policy). A click anywhere on the modal (button, content, or backdrop)
         // dismisses it and starts audio via start_audio().
+        //
+        // If the user already clicked/keyed during the WASM boot above, the
+        // global body listeners have started audio — the modal's job is done,
+        // so don't show it at all.
         var welcomeEl = document.getElementById('simulateWelcomeModal');
-        if (welcomeEl && window.bootstrap) {
+        if (welcomeEl && window.bootstrap && !audio_started && !_audio_starting) {
           var welcomeModal = bootstrap.Modal.getOrCreateInstance(welcomeEl, { backdrop: 'static', keyboard: false });
           var dismissed = false;
           welcomeEl.addEventListener('click', function() {
-            if (dismissed) return;
             dismissed = true;
             welcomeModal.hide();
             if (typeof start_audio === 'function') { start_audio(); }
+          });
+          // hide() during the fade-in is silently ignored by Bootstrap's
+          // transition guard, which would strand the modal on screen — re-hide
+          // once fully shown if it was dismissed (or audio started) meanwhile.
+          welcomeEl.addEventListener('shown.bs.modal', function() {
+            if (dismissed || audio_started || _audio_starting) welcomeModal.hide();
           });
           welcomeModal.show();
         }


### PR DESCRIPTION
## Problem

In AMYboard Online simulate mode, loading the page and quickly clicking a control (e.g. the channel dropdown) before the "Click anywhere to start" modal appears left the modal stuck on screen: audio started (the global body click listener fired), but the modal showed anyway and could not be dismissed.

Two defects combined:

1. **Race**: the welcome modal was shown unconditionally after the WASM/MicroPython boot, even if the user's early click had already started audio — the modal's only purpose (capturing the user gesture required by browser audio policy) was already satisfied.
2. **Stuck-forever mechanism**: the click handler set a one-shot `dismissed` flag before calling `hide()`. A click landing during the modal's ~300 ms fade-in hits Bootstrap 5's transition guard, which silently ignores `hide()` — but `dismissed` was already `true`, so every subsequent click returned early and the modal could never be closed.

## Fix

- Skip showing the modal entirely if audio already started (or is starting).
- Add a `shown.bs.modal` handler that re-hides the modal once fully shown if it was dismissed (or audio started) during the fade-in, and drop the wedging one-shot early-return (`hide()` and `start_audio()` are both idempotent).

## Verification

Tested against a local `dev.py` build, using a temporary 8 s boot delay to make the race deterministic (removed before commit):

- Early click during boot → audio starts, modal never appears.
- Click during the fade-in → modal still dismisses (old code reproduced the permanent stuck state: 5 follow-up clicks did nothing).
- Normal flow → modal appears, click dismisses, audio starts, backdrop cleans up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)