### PR TITLE
amyboard_fs_create: flash the Gamma9001 drums partition

### DIFF
--- a/tulip/amyboard/amyboard_fs_create.py
+++ b/tulip/amyboard/amyboard_fs_create.py
@@ -83,10 +83,31 @@ with open("build/amyboard-sys.bin","wb") as fh:
 print("... done.")
 
 
+# Gamma9001 drum banks: generate drums.bin from the amy submodule and flash it
+# into the `drums` partition (AMY mmaps it at boot; see amy_connector.c).
+drums_partition = None
+try:
+    drums_partition = partition_table.find_by_name('drums')
+except Exception:
+    pass
+if drums_partition is not None:
+    import subprocess
+    subprocess.check_call([sys.executable, '-m', 'amy.headers', 'gamma9001'], cwd='../../amy')
+    drums_bin = open('../../amy/build/drums.bin', 'rb').read()
+    if len(drums_bin) > drums_partition.size:
+        raise SystemExit("drums.bin (%d bytes) does not fit the drums partition (%d bytes)"
+                         % (len(drums_bin), drums_partition.size))
+    with open('build/amyboard-drums.bin', 'wb') as fh:
+        fh.write(drums_bin)
+    print("drums.bin: %d bytes into %s partition at %s" % (
+        len(drums_bin), 'drums', hex(drums_partition.offset)))
+
 # Update the flash_args file to have the sys and user partitions
 flash_args = open('build/flash_args','r').read().split('\n')[:-1]
 flash_args.append('%s amyboard-sys.bin' % (hex(sys_partition.offset)))
 flash_args.append('%s amyboard-vfs.bin' % (hex(vfs_partition.offset)))
+if drums_partition is not None:
+    flash_args.append('%s amyboard-drums.bin' % (hex(drums_partition.offset)))
 new_flash_args = open('build/flash_args_amyboard','w')
 for f in flash_args:
     new_flash_args.write('%s\n' % (f))


### PR DESCRIPTION
## Summary

`tulip/amyboard/amyboard_fs_create.py` never packs `drums.bin` into the `drums`
partition, even though the partition table declares it. This ports the same
conditional block `tulip/fs_create.py` already uses (added in #1084).

## Why

`fs_create.py amyboard` (what release CI runs) packs drums, so released firmware is
fine. But `docs/amyboard/firmware.md` and `docs/amyboard/faq.md` both point people at
`amyboard_fs_create.py` for local rebuilds, and that path leaves the `drums` partition
erased. The missing-partition stderr note from #1084 doesn't fire here — the partition
*entry* exists, so AMY mmaps the erased region and Gamma9001 presets (256–391) just
play nothing.

Looks like an oversight from #1084: its description covers `fs_create.py` only.

## Verified

- `python3 -m amy.headers gamma9001` produces `drums.bin` (3,735,788 bytes), within
  the partition's 3,801,088-byte capacity.
- A full image built with this block carries `drums.bin` byte-identical at `0xc60000`.
