### PR TITLE
vcvrack: clean up encoder row — drop ENC/PUSH labels, add PROG button

### DIFF
--- a/tulip/vcvrack/res/AMYboard.svg
+++ b/tulip/vcvrack/res/AMYboard.svg
@@ -4,7 +4,6 @@
        (Rack ignores SVG text). -->
   <rect x="0" y="0" width="50.8" height="128.5" fill="#161a22"/>
   <rect x="8.0" y="5.6" width="34.8" height="34.8" rx="1.5" fill="#0a0c10"/>
-  <rect x="2.2" y="43.2" width="46.4" height="12.6" rx="2.5" fill="#1c2430"/>
   <rect x="2.2" y="57.2" width="46.4" height="14.4" rx="2.5" fill="#1c2430"/>
   <rect x="2.2" y="72.2" width="46.4" height="14.4" rx="2.5" fill="#23303f"/>
   <rect x="2.2" y="87.2" width="46.4" height="14.4" rx="2.5" fill="#1c2430"/>

--- a/tulip/vcvrack/src/AmyBoard.cpp
+++ b/tulip/vcvrack/src/AmyBoard.cpp
@@ -318,6 +318,17 @@ struct AmyLabels : TransparentWidget {
     }
 };
 
+// Panel button that opens the AMYboard web editor in the system browser.
+struct ProgButton : app::SvgButton {
+    ProgButton() {
+        addFrame(Svg::load(asset::system("res/ComponentLibrary/TL1105_0.svg")));
+        addFrame(Svg::load(asset::system("res/ComponentLibrary/TL1105_1.svg")));
+    }
+    void onAction(const ActionEvent& e) override {
+        system::openBrowser("https://amyboard.com/editor");
+    }
+};
+
 struct AmyWidget : ModuleWidget {
     AmyWidget(AmyModule* module) {
         setModule(module);
@@ -335,9 +346,11 @@ struct AmyWidget : ModuleWidget {
         oled->box.size = mm2px(Vec(34.0, 34.0));
         addChild(oled);
 
-        // Encoder on the left, its push button beside it
-        addParam(createParamCentered<RoundBlackKnob>(mm2px(Vec(14.0, 49.5)), module, AmyModule::ENC_PARAM));
-        addParam(createParamCentered<TL1105>(mm2px(Vec(36.0, 49.5)), module, AmyModule::BTN_PARAM));
+        // Encoder on the left, its push button directly beside it, and the
+        // PROG button (opens amyboard.com/editor) on the right.
+        addParam(createParamCentered<RoundBlackKnob>(mm2px(Vec(12.5, 49.5)), module, AmyModule::ENC_PARAM));
+        addParam(createParamCentered<TL1105>(mm2px(Vec(22.5, 49.5)), module, AmyModule::BTN_PARAM));
+        addChild(createWidgetCentered<ProgButton>(mm2px(Vec(40.0, 49.5))));
 
         // Jack grid: rows of 2 columns
         static const float colL = 15.4, colR = 35.4;
@@ -354,8 +367,7 @@ struct AmyWidget : ModuleWidget {
         labels->box.size = box.size;
         labels->labels = {
             {25.4, 3.5, 9.f, "AMYBOARD"},
-            {14.0, 43.0, 8.f, "ENC"},
-            {36.0, 44.5, 8.f, "PUSH"},
+            {40.0, 44.5, 8.f, "PROG"},
             {25.4, 59.3, 8.f, "AUDIO IN"},
             {25.4, 74.3, 8.f, "AUDIO OUT"},
             {25.4, 89.3, 8.f, "CV IN"},


### PR DESCRIPTION
The AMYboard VCV panel's encoder row previously showed an `ENC`-labeled knob and a far-away `PUSH`-labeled button.

Now:
- The encoder knob is unlabeled, with its push button directly to its right (also unlabeled).
- A new **PROG** button (labeled) sits on the right of the same row, at the same vertical height, and opens https://amyboard.com/editor in the system browser (`system::openBrowser` via an `app::SvgButton` reusing the TL1105 frames — no fake param).

Built and packaged locally on mac-arm64 (`make && make dist && make install`) against the Rack SDK; the linked `plugin.dylib` compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)