### PR TITLE
Docs: MIDI in ground-loop hum troubleshooting + TRS ground-lift workaround

### DIFF
--- a/docs/amyboard/faq.md
+++ b/docs/amyboard/faq.md
@@ -265,6 +265,12 @@ print(amyboard.midi_type())   # -> 'A' or 'B', whichever is live
 
 This isn't persisted -- it resets to Type A on reboot -- so put the call in your sketch.
 
+### I hear a mains hum on the audio output when my MIDI gear is plugged into MIDI in
+
+That's a **ground loop**, not a broken board. Current AMYboards connect the TRS MIDI in jack's sleeve to ground, and most MIDI gear grounds the cable shield at its MIDI out (as the MIDI spec directs). If audio or power also connects the two devices, hum current (60 Hz / 120 Hz, or 50/100 Hz in 50 Hz countries) circulates through the shield and lands in your audio.
+
+The cure is to **break the ground in the MIDI cable** -- MIDI data rides a current loop that never uses ground, so nothing else is affected. Use a ground-lifted TRS adapter or cable (sleeve disconnected), or cut the shield at one end of a DIN cable. Future board revisions will lift the MIDI in sleeve in hardware ([issue #1198](https://github.com/shorepine/tulipcc/issues/1198)).
+
 ### Can I connect several MIDI inputs (and power sources) at the same time?
 
 Yes -- it's fine to have TRS MIDI, USB MIDI, and multiple power sources (USB + Eurorack) all connected at once; notes from all MIDI inputs are handled. Just remember the USB port is **device mode only** -- a USB MIDI connection works to a computer (or USB host), not from a controller plugged into the AMYboard (see [USB host](#can-i-plug-a-usb-midi-keyboard-straight-into-the-amyboard-usb-host)).

--- a/docs/amyboard/troubleshooting.md
+++ b/docs/amyboard/troubleshooting.md
@@ -97,6 +97,14 @@ We've fixed a lot of USB issues recently, so [upgrade to the latest firmware](fi
    ```
  - Add this to your `sketch.py` to make it permanent.
 
+### Hum on the audio output when TRS MIDI in is connected
+
+ - A mains hum (60 Hz / 120 Hz, or 50/100 Hz in 50 Hz countries) that appears the moment you plug a synth or controller into **MIDI in** is a **ground loop**: current AMYboards ground the MIDI in jack's sleeve, and most MIDI gear grounds the cable shield at its MIDI out end (per the MIDI spec). Audio or power connections between the two devices complete the loop.
+ - Fix it by **breaking ground in the MIDI cable** -- MIDI is a current loop and doesn't use ground for data, so this is harmless:
+   - Use a **ground-lifted TRS adapter or cable** (sleeve disconnected), or
+   - Cut the shield at one end of a DIN MIDI cable.
+ - Future board revisions will lift the MIDI in sleeve in hardware -- see [issue #1198](https://github.com/shorepine/tulipcc/issues/1198).
+
 ## Board won't boot / crashes on startup
 
  - **Safe mode**: Hold the BOOT button while AMYboard is powering up. This skips running your `sketch.py` and also runs a hardware self-test (audio input, CV in/out). You'll hear a chime if all tests pass. Once it finishes you'll have a normal REPL where you can fix or delete your sketch.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -99,6 +99,18 @@ If your USB computer keyboard is not working, please find us on [issues](https:/
 
 If you can't seem to control your modular synths with the DAC, please note that the current revision of the <a href="https://www.makerfabs.com/mabee-dac-gp8413.html">Mabee DAC</a>is set up for TRS (stereo 3.5mm) cables. To use with a mono modular patch cable, you will need a stereo to mono <a href="https://www.amazon.com/3-5mm-Stereo-Adapter-Plated-Female/dp/B0919C5D93">adapter</a> or <a href="https://www.amazon.com/Gold-Plated-Connector-Splitter-RFAdapter-Headphone/dp/B096XNHTH3/">cable</a> plugged in at the DAC end. You can also slightly pull out a mono cable's connector. We are working on fixing this for future batches and will update this when we do.
 
+## You hear a hum from Tulip's audio output when MIDI in is connected
+
+If a loud mains hum (60 Hz / 120 Hz, or 50 Hz / 100 Hz outside North America) appears on Tulip's audio output as soon as you connect another synth or controller to Tulip's **TRS MIDI in**, you're hearing a **ground loop**: current Tulip boards connect the MIDI in jack's sleeve to ground, and most MIDI gear grounds the cable shield at its MIDI out (as the MIDI spec says to). With audio cables also connecting the two devices, hum current flows through the loop and into the audio path.
+
+The fix is to **break the ground connection in the MIDI cable** -- MIDI data travels on a current loop that doesn't use ground at all, so nothing else changes:
+
+ * Use a **ground-lifted ("ground loop isolator") TRS adapter or cable**, or a TRS-to-DIN adapter with the sleeve unconnected.
+ * Or take a DIN MIDI cable and **cut the shield connection at one end**.
+ * Powering both devices from the same outlet/strip, or patching the MIDI through a device that doesn't create the loop, can also quiet it.
+
+Future board revisions will lift the MIDI in sleeve in hardware -- see [issue #1198](https://github.com/shorepine/tulipcc/issues/1198).
+
 ## Any other issues
 
 Please [reach out](#reach-us) with any other issues, and we'll add them here.


### PR DESCRIPTION
Adds a troubleshooting section to Tulip and AMYboard docs (plus an AMYboard FAQ entry) for the mains hum reported when TRS MIDI in is connected to gear that grounds its MIDI cable shield.

Current Tulip r11 and AMYboard v1.4 boards tie the MIDI in TRS sleeve to GND, which forms a ground loop with spec-compliant MIDI sources — background and the hardware fix for future revisions are tracked in #1198.

Each entry explains the cause and suggests the user-side workaround: a ground-lifted TRS adapter/cable (sleeve disconnected) or cutting the shield at one end of a DIN cable, which is harmless since the MIDI current loop doesn't use ground.

- `docs/troubleshooting.md` — new section before "Any other issues"
- `docs/amyboard/troubleshooting.md` — new subsection under "MIDI issues"
- `docs/amyboard/faq.md` — new Q&A in "Controlling the synth", next to the TRS Type A/B question

🤖 Generated with [Claude Code](https://claude.com/claude-code)