### PR TITLE
Restore tulip.amy_dump_state removed with the zA path (broke amy.dump_state() off CPython)

### DIFF
--- a/tulip/amyboardweb/static/spss.js
+++ b/tulip/amyboardweb/static/spss.js
@@ -18,6 +18,7 @@ var _url_env_pending = false;
 var _url_env_autoplay = false;
 var _url_env_loaded = false;
 var amy_yield_synth_commands = null;
+var amy_dump_state_to_string_c = null;
 
 var _python_error_buffer = "";
 var _python_error_timer = null;
@@ -949,6 +950,9 @@ if (typeof amyModule === 'function') _amy_wasm_ready = amyModule().then(async fu
   );
   amy_yield_synth_commands = am.cwrap(
     'yield_synth_commands', 'number', ['number', 'number', 'number', 'boolean', 'number']
+  );
+  amy_dump_state_to_string_c = am.cwrap(
+    'amy_dump_state_to_string', 'number', ['number']
   );
   amy_start_web_no_synths();
   amy_module = am;
@@ -4952,6 +4956,24 @@ async function load_knobs_from_sketch() {
     }
 }
 
+function amy_dump_state_js() {
+    // Call the C amy_dump_state_to_string via WASM. Returns the state text.
+    // AMY's WASM lives in a separate module from MicroPython's, so amy.dump_state()
+    // cannot reach the C symbol directly — this bridge is what backs
+    // tulip.amy_dump_state (and therefore amy.dump_state()) on the web build.
+    if (!amy_module || !amy_dump_state_to_string_c || !amy_module.HEAPU8) return '';
+    var lenPtr = amy_module._malloc(4);
+    var strPtr = amy_dump_state_to_string_c(lenPtr);
+    // Read 4-byte little-endian length from HEAPU8 (HEAPU32 isn't exported on this module).
+    var h = amy_module.HEAPU8;
+    var len = h[lenPtr] | (h[lenPtr + 1] << 8) | (h[lenPtr + 2] << 16) | (h[lenPtr + 3] << 24);
+    amy_module._free(lenPtr);
+    if (!strPtr || len <= 0) return '';
+    var result = read_c_string_from_heap(strPtr, len + 1);
+    amy_module._free(strPtr);
+    return result;
+}
+
 async function _send_text_file_to_amyboard(path, text) {
     // Upload a text file to the AMYboard via zT (base64-chunked over sysex).
     var encoder = new TextEncoder();
@@ -6549,6 +6571,8 @@ async function start_amyboard() {
   await mp.registerJsModule('amy_sysclock', amy_sysclock);
   await mp.registerJsModule('amyboard_world_upload_file', amyboard_world_upload_file);
   await mp.registerJsModule('amy_get_output_buffer', get_output_audio_samples);
+  // AMY WASM lives in a separate module; bridge amy_dump_state for Python via JS.
+  await mp.registerJsModule('amy_dump_state_js', amy_dump_state_js);
 //  await mp.registerJsModule('amy_get_input_buffer', get_audio_samples);
 //  await mp.registerJsModule('amy_set_external_input_buffer', set_audio_samples);
 
@@ -6557,11 +6581,16 @@ async function start_amyboard() {
 
   // Set up the micropython context for AMY.
   await mp.runPythonAsync(`
-    import tulip, amy, amy_js_message, amy_sysclock, amy_get_output_buffer as _amy_get_output_buf_js
+    import tulip, amy, amy_js_message, amy_sysclock, amy_get_output_buffer as _amy_get_output_buf_js, amy_dump_state_js as _amy_dump_state_js
     amy.override_send = amy_js_message
     amy.ticks_ms = amy_sysclock
     tulip.amy_ticks_ms = amy_sysclock
     tulip.amy_get_output_buffer = _amy_get_output_buf_js
+    tulip.amy_dump_state = _amy_dump_state_js
+    # amy binds _dump_state from tulip.amy_dump_state at import time, which already
+    # happened on the import line above — so patch amy's own name too, exactly like
+    # amy.ticks_ms right above. Without this amy.dump_state() raises NameError.
+    amy._dump_state = _amy_dump_state_js
   `);
 
   // If you don't have these sleeps we get a MemoryError with a locked heap. Not sure why yet.

--- a/tulip/shared/modtulip.c
+++ b/tulip/shared/modtulip.c
@@ -194,6 +194,20 @@ STATIC mp_obj_t tulip_sequencer_start(void) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(tulip_sequencer_start_obj, tulip_sequencer_start);
 
+// Backs amy.dump_state() on MicroPython: amy/__init__.py binds _dump_state to
+// tulip.amy_dump_state when the c_amy CPython module is unavailable.
+STATIC mp_obj_t tulip_amy_dump_state(void) {
+    int len = 0;
+    char *buf = amy_dump_state_to_string(&len);
+    if (!buf || len <= 0) {
+        return mp_obj_new_str("", 0);
+    }
+    mp_obj_t result = mp_obj_new_str(buf, len);
+    free(buf);
+    return result;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(tulip_amy_dump_state_obj, tulip_amy_dump_state);
+
 #endif
 
 #if defined(ESP_PLATFORM) || defined(AMYBOARD_VCV)
@@ -1835,6 +1849,7 @@ STATIC const mp_rom_map_elem_t tulip_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_amy_get_output_buffer), MP_ROM_PTR(&tulip_amy_get_output_buffer_obj) },
     { MP_ROM_QSTR(MP_QSTR_amy_set_external_input_buffer), MP_ROM_PTR(&tulip_amy_set_external_input_buffer_obj) },
     { MP_ROM_QSTR(MP_QSTR_amy_get_synth_commands), MP_ROM_PTR(&tulip_amy_get_synth_commands_obj) },
+    { MP_ROM_QSTR(MP_QSTR_amy_dump_state), MP_ROM_PTR(&tulip_amy_dump_state_obj) },
     { MP_ROM_QSTR(MP_QSTR_sequencer_start), MP_ROM_PTR(&tulip_sequencer_start_obj) },
 #endif
     { MP_ROM_QSTR(MP_QSTR_sysex_in), MP_ROM_PTR(&tulip_sysex_in_obj) },


### PR DESCRIPTION
## Summary
#1190 removed the zA control command and, with it, `tulip.amy_dump_state`
(`modtulip.c`) and the amyboardweb WASM bridge (`spss.js`), on the rationale
that shorepine/amy#934 exposes this as `amy.dump_state()`. But `amy.dump_state()` is not
self-contained off CPython — it looks up a module-global `_dump_state`
(`return _dump_state()`), and on non-CPython builds that global is meant to come
from `tulip.amy_dump_state`. Removing the tulip binding leaves it undefined, so
`amy.dump_state()` raises `NameError: name '_dump_state' isn't defined`. CPython
(`c_amy.dump_state`) is unaffected.

The exact failure differs by platform, and both matter:

- **Native MicroPython / ESP32:** the `tulip.amy_*` functions are real native
  bindings, so `amy/__init__.py`'s import-time try block binds the first four
  and then fails specifically at `_dump_state = tulip.amy_dump_state` — the one
  entry #1190 deleted.
- **Web / WASM:** every `tulip.amy_*` native is `#ifndef __EMSCRIPTEN__`-excluded,
  so that try block has always failed at its first line and none of these are
  bound at import; they're patched in from JS at runtime after import instead.
  #1190 removed the runtime `tulip.amy_dump_state` JS patch. And `amy._dump_state`
  was never patched directly on web, so restoring only `tulip.amy_dump_state` is
  not enough there — `amy.dump_state()` still NameErrors until amy's own global
  is set (see the spss.js note below).

## Changes
- **`modtulip.c`** — restore `tulip_amy_dump_state` (function body byte-identical
  to the pre-#1190 version, plus one explanatory comment) and its module-table
  entry, inside the existing `#ifndef __EMSCRIPTEN__` guard.
- **`spss.js`** — restore the `amy_dump_state_to_string` cwrap, the
  `amy_dump_state_js` bridge and its `registerJsModule`, and the
  `tulip.amy_dump_state = _amy_dump_state_js` patch. Also set
  `amy._dump_state = _amy_dump_state_js`: `amy`'s import-time bind can't succeed
  on web (above), and `dump_state()` resolves `_dump_state` as a module global at
  call time, so patching amy's own global is what makes `amy.dump_state()` work.
  This is analogous to the adjacent `amy.ticks_ms = amy_sysclock` patch, done for
  the same import-ordering reason — though note that one overrides the public
  function while this overrides the private `_dump_state` indirection.

Pure restore of the dump-state readback path; the dead zA authoring chain #1190
removed stays gone.

## Testing
- **AMYboard Web (Simulate), clean boot, no manual patching:** both
  `amy.dump_state()` and `tulip.amy_dump_state()` return the state dump
  (116-char FX dump for bus 0); reproduced the `NameError` before the fix.
- **amy `make test`:** 117/117 pass (incl. `TestDumpState`).
- **CPython:** `amy.dump_state()` returns a dump via `c_amy`.
- **macOS Desktop:** builds and links; `tulip_amy_dump_state` /
  `amy_dump_state_to_string` present in the binary.
- Not run locally: ESP32 firmware build, hardware smoke test.
