### PR TITLE
Remove last uses of AMY's removed voices= / wire-code-r API

### DIFF
--- a/AMY_AGENTS.md
+++ b/AMY_AGENTS.md
@@ -27,7 +27,7 @@ invent names like `lfo_osc` / `lfo0_osc`:
 osc wave note vel amp freq duty feedback time reset phase pan client volume
 pitch_bend filter_freq resonance bp0 bp1 eg0 eg1 eg0_type eg1_type debug
 chained_osc mod_source eq filter_type ratio latency_ms algo_source load_sample
-transfer_file disk_sample algorithm chorus reverb echo patch voices
+transfer_file disk_sample algorithm chorus reverb echo patch
 external_channel portamento sequence tempo synth pedal synth_flags num_voices
 oscs_per_voice to_synth grab_midi_notes note_source synth_delay preset
 num_partials start_sample stop_sample bus midi_cc midi_note_cmd cv_trigger

--- a/docs/tulip_api.md
+++ b/docs/tulip_api.md
@@ -498,9 +498,10 @@ You can use `amy.py` to control the AMY synthesizer directly.
 amy.drums() # plays a test song
 amy.volume(4) # change volume
 amy.reset() # stops all music / sounds playing
-amy.send(voices='0', load_patch=129, note=45, vel=1) # plays a tone
-amy.send(voices='0', pan=0) # set to the right channel
-amy.send(voices='0', pan=1) # set to the left channel
+amy.send(synth=1, patch=129, num_voices=1) # set up a DX7 patch on synth 1
+amy.send(synth=1, note=45, vel=1) # plays a tone
+amy.send(synth=1, pan=0) # set to the left channel
+amy.send(synth=1, pan=1) # set to the right channel
 
 # start mesh mode (control multiple speakers over wifi)
 # once mesh mode is set, you can't go back to local mode until you restart Tulip. 
@@ -509,8 +510,9 @@ alles.mesh(local_ip='192.168.50.4') # useful for setting a network on Tulip Desk
 
 alles.map() # returns booted Alles synths on the mesh
 
-amy.send(voices='0', load_patch=101, note=50, vel=1) # all Alles speakers in a mesh will respond
-amy.send(voices='0', load_patch=101, note=50, vel=1, client=2) # just a certain client
+amy.send(synth=1, patch=101, num_voices=1) # load a patch on every Alles speaker in the mesh
+amy.send(synth=1, note=50, vel=1) # all Alles speakers in a mesh will respond
+amy.send(synth=1, note=50, vel=1, client=2) # just a certain client
 ```
 
 To load your own WAVE files as samples you can play like an instrument, use `amy.load_sample`:

--- a/tulip/web/static/examples.js
+++ b/tulip/web/static/examples.js
@@ -571,7 +571,7 @@ def process_key( key ):
             note_num = 36 + 12 * math.log( ratio ) / math.log( 2 )
             print( f"note_num: {note_num}" )
                   
-            amy.send(voices=0,patch=patch_num,note=note_num,vel=1)
+            amy.send(synth=1,note=note_num,vel=1)
             
         pass
     
@@ -589,11 +589,11 @@ def process_key( key ):
         #print(1)
         patch_num += 1
         print(f'patch_num: {patch_num}')
-        amy.send(osc=0,vel=0)
+        amy.send(synth=1,patch=patch_num)
     elif key == 22:#print(-1)
         patch_num -= 1
         print(f'patch_num: {patch_num}')
-        amy.send(osc=0,vel=0)
+        amy.send(synth=1,patch=patch_num)
 
     else:   
         print("unhandled key: %d" % (key))
@@ -601,7 +601,8 @@ def process_key( key ):
 
 
 patch_num = 129
-amy.send(voices=0,patch=patch_num,note=45,vel=1)
+amy.send(synth=1,patch=patch_num,num_voices=1)
+amy.send(synth=1,note=45,vel=1)
 
 tulip.key_scan(1)
 tulip.keyboard_callback( process_key )


### PR DESCRIPTION
AMY is removing the old `voices=` kwarg (wire code `r`). This audits tulipcc for anything still using it and ports the survivors to the synth API:

- **docs/tulip_api.md** — rewrote the "Low level AMY control" and Alles mesh examples to `synth=` / `num_voices=`. Also fixed the pan comments, which had left/right backwards (AMY pan: 0.0 = left, 1.0 = right).
- **tulip/web/static/examples.js** — ported the ratio-keyboard example: synth set up once, keypresses just send notes, page up/down reloads the patch on the synth (replacing the old `osc=0, vel=0` note-off hack).
- **AMY_AGENTS.md** — dropped `voices` from the `_KW_MAP_LIST` reproduction so the sketch generator can't emit the removed kwarg.

Everything else that greps for `voices` is the modern `num_voices` synth API (unaffected), AMY's C instrument API in `amy_connector.c`, or prose. No raw wire strings using `r` exist in the repo.

**Not touched, by design** — these regenerate with the next amy pin bump past the removal:
- `tulip/amyboardweb/static/amy_api.generated.js` / `amy_event_layout.generated.js` (codegen)
- `tulip/server/refdocs/amy/*.md` (`python3 tulip/server/sync_amy_docs.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)