### PR TITLE
sync_amy_docs.py: add --sha to vendor from a given amy commit

### DIFF
--- a/tulip/server/sync_amy_docs.py
+++ b/tulip/server/sync_amy_docs.py
@@ -19,8 +19,9 @@ Source priority:
   2. GitHub raw at the pinned amy SHA (read from ``git ls-tree HEAD amy``)
 
 Usage:
-    python3 tulip/server/sync_amy_docs.py            # refresh the snapshot
-    python3 tulip/server/sync_amy_docs.py --check    # exit 1 if snapshot is stale
+    python3 tulip/server/sync_amy_docs.py             # refresh the snapshot
+    python3 tulip/server/sync_amy_docs.py --check     # exit 1 if snapshot is stale
+    python3 tulip/server/sync_amy_docs.py --sha SHA   # vendor from SHA, not the gitlink
 """
 from __future__ import annotations
 
@@ -93,9 +94,13 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--check", action="store_true",
                     help="verify refdocs/amy matches the pinned amy SHA; no writes")
+    ap.add_argument("--sha", metavar="SHA",
+                    help="vendor from this amy commit instead of the pinned gitlink "
+                         "(amy's tulipcc-pin workflow uses this to build the snapshot "
+                         "for a pin bump before the gitlink moves)")
     opts = ap.parse_args()
 
-    sha = pinned_sha()
+    sha = opts.sha or pinned_sha()
     use_local = (SUBMODULE_DOCS.is_dir() and md_names_local()
                  and submodule_head() == sha)
     source = "local submodule" if use_local else "GitHub raw @ pinned SHA"


### PR DESCRIPTION
Adds a `--sha SHA` option to `tulip/server/sync_amy_docs.py` that vendors the refdocs snapshot from an explicit amy commit instead of the pinned gitlink.

This is the tulipcc half of making amy's `tulipcc-pin.yml` auto-pin PRs pass the `refdocs-fresh` check out of the box: the workflow will run this script against the just-merged amy SHA and fold the refreshed `tulip/server/refdocs/amy/` snapshot into the same bump commit it opens the PR with (see the companion amy PR). Today every auto-pin PR starts red because `_VENDORED_FROM.txt` still stamps the old SHA — that's exactly what happened on #1215.

No behavior change without the flag: `--check` and the default refresh still key off the gitlink. Tested locally: `--sha <other-commit>` writes that stamp and `--check` then correctly fails against the pin; plain `--check` on main passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)