### PR TITLE
amyboardctl: fix CLI double-open and one-frame-late ALSA reader

### DIFF
--- a/tools/amyboardctl/amyboardctl/link.py
+++ b/tools/amyboardctl/amyboardctl/link.py
@@ -106,7 +106,12 @@ class AMYboardLink:
         self.transport = None
 
     def __enter__(self):
-        return self.open()
+        # idempotent: `with AMYboardLink(...).open() as link:` must not open a
+        # second transport — on ALSA two amidi readers fight over the rawmidi
+        # port and ACKs are lost
+        if not self.transport:
+            self.open()
+        return self
 
     def __exit__(self, *a):
         self.close()

--- a/tools/amyboardctl/amyboardctl/transport.py
+++ b/tools/amyboardctl/amyboardctl/transport.py
@@ -6,8 +6,8 @@ Two interchangeable backends:
     mido is importable (macOS dev machines, most desktops).
   * AlsaTransport — the ALSA CLI tools (`amidi`). No Python MIDI libraries or
     root needed; the backend the Raspberry Pi HW-CI runner uses. Sends are
-    one-shot `amidi -S`; receives are a persistent line-buffered `amidi -d`
-    reader parsed into SysEx frames.
+    one-shot `amidi -S`; receives are a persistent unbuffered `amidi -d`
+    reader whose raw hex stream is parsed into SysEx frames.
 
 A transport knows nothing about the AMYboard protocol. It moves raw MIDI:
 
@@ -174,12 +174,13 @@ class AlsaTransport:
         return self
 
     def _spawn_reader(self):
-        # Persistent receive stream: line-buffered so frames arrive in real time
-        # (block buffering would sit on the board's ACKs). Coexists fine with the
-        # one-shot `amidi -S` sends on the same rawmidi device.
+        # Persistent receive stream: fully unbuffered (`stdbuf -o0`) so frames
+        # arrive in real time (buffering would sit on the board's ACKs).
+        # Coexists fine with the one-shot `amidi -S` sends on the same rawmidi
+        # device.
         self._reader = subprocess.Popen(
-            ["stdbuf", "-oL", "amidi", "-p", self.port, "-d"],
-            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, bufsize=1)
+            ["stdbuf", "-o0", "amidi", "-p", self.port, "-d"],
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, bufsize=0)
         threading.Thread(target=self._read_loop, daemon=True).start()
         self.ack_available = True
 
@@ -195,16 +196,29 @@ class AlsaTransport:
 
     def _read_loop(self):
         """Parse the `amidi -d` hex dump into SysEx frames and dispatch each
-        frame's payload (the bytes between F0 and F7) to on_sysex."""
+        frame's payload (the bytes between F0 and F7) to on_sysex. Parses the
+        raw byte stream two hex digits at a time — amidi separates bytes with
+        whitespace but writes a newline only BEFORE each frame, and nothing
+        after the final F7, so anything that waits for a delimiter (a line, a
+        token boundary) sees each frame one frame late and a single-reply
+        exchange like ping never completes."""
         reader = self._reader
         buf, insx = [], False
+        tok = ""
+        hexdigits = "0123456789abcdefABCDEF"
         try:
-            for line in reader.stdout:
-                for tok in line.split():
-                    try:
-                        b = int(tok, 16)
-                    except ValueError:
+            while True:
+                data = reader.stdout.read(4096)
+                if not data:
+                    break
+                for ch in data.decode("ascii", "replace"):
+                    if ch not in hexdigits:
+                        tok = ""
                         continue
+                    tok += ch
+                    if len(tok) < 2:
+                        continue
+                    b, tok = int(tok, 16), ""
                     if b == 0xF0:
                         insx, buf = True, []
                     elif b == 0xF7:


### PR DESCRIPTION
Two stacked bugs made every `amyboardctl` CLI command report "no reply" on the ALSA backend (observed on the amyboardci Pi bench against a healthy board), while direct library use worked fine.

## Bug 1: CLI opened two links per invocation

`_open_link()` in `cli.py` returns `AMYboardLink(...).open()` — already opened — and every command then does `with _open_link(args) as link:`, whose `__enter__` was `return self.open()`. That opened a **second** transport on the same object and orphaned the first (never closed). On ALSA each transport spawns a persistent `stdbuf amidi -d` reader, and only one can hold the rawmidi input — the loser dies rc=1 and respawn-loops, the two instances fight over the port, and ACKs/replies are lost. Symptom: `connected: ...` printed twice, then `no reply`.

Fix: `__enter__` is now idempotent (opens only if not already open). This also fixes the same silent double-open on the mido backend, which happened to survive because CoreMIDI tolerates multiple clients on one port. Library callers (`hwci.py`, `measure.py`, `record.py`) use only one of the two patterns and were never affected.

## Bug 2: ALSA reader delivered every frame one frame late

After fixing the double-open, `ping` still timed out. A raw `od` capture showed `amidi -d` writes a newline **before** each frame and nothing after the final `F7` (`\nF0 00 03 45 4F 4B F7`). The reader parsed line-by-line, so a frame was only delivered when the *next* frame's leading newline arrived — multi-frame ACK streams limped along one behind (why sketch uploads seemed to work), but a single-reply exchange like ping never completed.

Fix: spawn `stdbuf -o0 amidi -d` (unbuffered) and parse the raw hex stream two digits at a time, no delimiter needed. Ping reply now arrives ~15 ms after the send.

## Verified on the Pi bench (amyboardci.local, hw:3,0,0)

- Reproduced the original double-connect + respawn-fight + `no reply` first
- With the fix: `ping` → OK, `version` → `20260719-82e69df`, `run` / `seq` ack, single `connected:` line per invocation
- 437-frame `upload_sketch` fully acked (exercises ACK flow control through the new parser)
- 82 KB `download_sketch` roundtrip byte-identical; `download_state` streams wire commands

Note (pre-existing, not addressed here): a large sketch download takes ~35 s at the board's pacing, slightly over the default `--timeout 30`, and a timed-out request leaves the board still streaming, which can contaminate the next dump request. A per-chunk inactivity timeout would fix that properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)