### PR TITLE
amyboardweb: verify sketch writes to AMYboard, retry on corruption

### DIFF
--- a/docs/amyboard/faq.md
+++ b/docs/amyboard/faq.md
@@ -68,7 +68,12 @@ A working board enumerates as a USB MIDI device (VID `0xCAF0`, PID `0x4009`) plu
 
 ### The online editor / "Control" can't find my AMYboard
 
-The editor talks to the board over **WebSerial/WebMIDI**, which only work in **Chrome or Edge** (desktop). Safari and Firefox don't support them, so the board won't show up at all. Also plug the board in and finish any DFU/BOOT step **before** clicking Connect/Control, and pick the right port when the browser prompts.
+The editor talks to the board over two browser APIs, with different support:
+
+- **Web MIDI** (Control mode -- knobs, writing sketches): works in **Chrome, Edge, and Firefox** (desktop). Firefox will ask to install a small site-permission add-on the first time -- allow it (see the Firefox question below). Safari doesn't support Web MIDI at all.
+- **WebSerial** (the **firmware flasher** only): **Chrome or Edge only** -- Firefox and Safari can't flash firmware.
+
+Also plug the board in and finish any DFU/BOOT step **before** clicking Connect/Control, and pick the right port when the browser prompts.
 
 If the **Update firmware** button shows something like "amyboard.com refused to connect," clear your browser cache and reload the page -- a stale cached page has caused exactly this.
 
@@ -83,6 +88,28 @@ Most setups work across macOS, Linux, and Windows, especially after a firmware u
 - On **Linux**, add your user to the `dialout` group, then e.g. `screen /dev/ttyACM0 115200`.
 
 Still stuck on a particular machine? **Ask on the [Discord](https://discord.gg/TzBFkUb8pG) `#amyboard` channel** -- it's the fastest way to get help, and your report helps us catch any remaining edge cases.
+
+### Windows: my DAW sees the AMYboard, but no browser does
+
+If the AMYboard shows up fine in Device Manager and in DAWs/MIDI apps, but **every browser** (Chrome, Edge, Firefox) says no MIDI devices exist, you've likely hit a **Windows MIDI Services migration problem**. Microsoft is rolling out a new MIDI stack to Windows 11 in 2026, and on some machines -- especially **refurbs, or PCs restored from an older image, that then pull months of Windows updates at once** -- old per-device MIDI registrations in the registry block the handoff that browsers depend on. Desktop apps keep working through the legacy path, so everything *looks* healthy except browsers.
+
+To confirm and fix:
+
+1. Make sure Windows is fully updated and the **"Windows MIDI Service"** (`midisrv`) is running in `services.msc` (set it to Automatic).
+2. Install Microsoft's tools: `winget install Microsoft.MIDI.SDK`, then run **`mididiag`** -- if it prints an error about `wdmaud2.drv` missing from `Drivers32`, that's this problem.
+3. Run **`midifixreg`** (from the same tools) in an **Administrator** terminal and reboot.
+4. If it *still* reverts after a reboot, old audio devices each carry a leftover `Drivers\midi` registration that recreates the bad entries every boot -- ask on [Discord](https://discord.gg/TzBFkUb8pG) `#amyboard` and we'll walk you through removing them (it's a small registry cleanup we've verified end-to-end).
+
+You can verify the fix (or capture a report to share) with the one-click test at [amyboard.com/miditest.html](https://amyboard.com/miditest.html).
+
+### Firefox: "site permission add-on" prompts, or MIDI silently refused
+
+Firefox supports Web MIDI, but gates it behind a **site-permission add-on**: the first time a site asks for MIDI, a small icon appears near the address bar asking to install a Firefox-generated add-on for that site -- click **Allow/Add** and you're set. Things to know:
+
+- The prompt only appears on **real https sites** like amyboard.com -- Firefox never grants MIDI to local/`localhost` pages.
+- If Firefox sees **no MIDI devices at all**, it silently auto-denies without ever showing the prompt (the devtools console says "no devices were detected"). Fix device visibility first -- on Windows, see the question above.
+- If you dismissed the prompt once, Firefox auto-rejects afterward -- click the small permissions icon in the address bar to bring it back.
+- The **firmware flasher** still needs Chrome or Edge (WebSerial); only the editor's Control mode works in Firefox.
 
 ### Can I plug a USB-MIDI keyboard straight into the AMYboard? (USB host)
 

--- a/tulip/amyboardweb/static/editor/index.html
+++ b/tulip/amyboardweb/static/editor/index.html
@@ -1140,8 +1140,6 @@
           // board's fresh USB descriptor. A sessionStorage flag tells the
           // post-reload page to skip zB (avoiding an infinite reboot loop)
           // and go straight into the sync.
-          var _IS_WINDOWS_CHROME = /Windows/i.test(navigator.userAgent) &&
-                                   /Chrome/i.test(navigator.userAgent);
           window.pageload_control_sync = async function() {
             // Post-reset reload path: reset_amyboard() on Windows Chrome
             // sends zB, sets this flag, and reloads — we land here on the

--- a/tulip/amyboardweb/static/miditest.html
+++ b/tulip/amyboardweb/static/miditest.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>AMYboard WebMIDI transfer test</title>
+<style>
+body { font-family: monospace; margin: 2em; background: #111; color: #ddd; }
+#verdict { font-size: 2em; margin: 0.5em 0; }
+.pass { color: #4c4; } .fail { color: #e55; } .warn { color: #fa3; }
+#log { white-space: pre-wrap; font-size: 0.9em; }
+button { font-size: 1.2em; padding: 0.5em 1em; }
+</style></head>
+<body>
+<h2>AMYboard WebMIDI transfer test</h2>
+<p>Diagnoses MIDI file-transfer reliability between this browser and a
+USB-connected AMYboard. Writes a small test file (your sketch is not touched),
+verifies it with a checksum computed on the board, then reads it back to
+measure large-sysex handling. Click Run, allow the MIDI permission prompt,
+then copy the results box to whoever asked you to run this.</p>
+<button id="go" onclick="run()">Run test (allow MIDI when prompted)</button>
+<div id="verdict"></div>
+<textarea id="results" rows="8" style="width:100%; background:#222; color:#ddd;"
+  placeholder="results JSON appears here after the test"></textarea>
+<div id="log"></div>
+<script>
+'use strict';
+const MFR = [0x00, 0x03, 0x45];
+const CHUNK = 188;
+const PATH = '/user/verifytest.txt';
+const logEl = document.getElementById('log');
+const verdictEl = document.getElementById('verdict');
+const lines = [];
+function log(s) { lines.push(s); logEl.textContent = lines.join('\n'); console.log(s); }
+
+// CRC32 (same poly as binascii.crc32)
+const CRC_T = (() => { const t = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) { let c = n;
+    for (let k = 0; k < 8; k++) c = (c & 1) ? (0xEDB88320 ^ (c >>> 1)) : (c >>> 1);
+    t[n] = c >>> 0; } return t; })();
+function crc32(bytes) { let c = 0xFFFFFFFF;
+  for (let i = 0; i < bytes.length; i++) c = CRC_T[(c ^ bytes[i]) & 0xFF] ^ (c >>> 8);
+  return (c ^ 0xFFFFFFFF) >>> 0; }
+
+let inPort = null, outPort = null;
+const rxFrames = [];          // reassembled complete sysex frames (Uint8Array)
+const rxEventSizes = [];      // raw midimessage event sizes (fragmentation info)
+let reasm = null;
+
+function onMidi(ev) {
+  const d = ev.data;
+  rxEventSizes.push(d.length);
+  for (let i = 0; i < d.length; i++) {
+    const b = d[i];
+    if (b === 0xF0) reasm = [0xF0];
+    else if (reasm !== null) {
+      reasm.push(b);
+      if (b === 0xF7) { rxFrames.push(new Uint8Array(reasm)); reasm = null; }
+    }
+  }
+}
+
+function sendStr(s) {
+  const bytes = [0xF0].concat(MFR);
+  for (const ch of s) bytes.push(ch.charCodeAt(0));
+  bytes.push(0xF7);
+  outPort.send(bytes);
+}
+
+function waitFrame(markers, timeoutMs) {
+  // Resolve with the next reassembled AMY frame whose marker is in `markers`.
+  const t0 = Date.now();
+  return new Promise((resolve) => {
+    (function poll() {
+      while (rxFrames.length) {
+        const f = rxFrames.shift();
+        if (f.length >= 5 && f[1] === 0 && f[2] === 3 && f[3] === 0x45) {
+          const m = String.fromCharCode(f[4]);
+          if (markers.includes(m)) return resolve({ m, payload: f.slice(5, f.length - 1) });
+        }
+      }
+      if (Date.now() - t0 > timeoutMs) return resolve(null);
+      setTimeout(poll, 5);
+    })();
+  });
+}
+
+function b64(bytes) { let s = ''; bytes.forEach(x => s += String.fromCharCode(x)); return btoa(s); }
+
+function makePayload(tag, n) {
+  let s = '# ' + tag + ' browser test payload\n';
+  for (let i = 0; s.length < n; i++) s += tag + '-' + String(i).padStart(5, '0') + '-abcdefghijklmnopqrstuvwxyz\n';
+  return new TextEncoder().encode(s.slice(0, n));
+}
+
+async function run() {
+  document.getElementById('go').disabled = true;
+  const report = { ua: navigator.userAgent, steps: {}, akTimeouts: 0 };
+  try {
+    log('requesting MIDI access (sysex)...');
+    const access = await navigator.requestMIDIAccess({ sysex: true });
+    // Enumeration can lag behind the permission grant (WinRT backend) —
+    // retry the scan for up to 6s and always record what we saw.
+    for (let tries = 0; tries < 12 && (!inPort || !outPort); tries++) {
+      const ins = [], outs = [];
+      access.inputs.forEach(p => { ins.push(p.name); if (/amyboard/i.test(p.name)) inPort = p; });
+      access.outputs.forEach(p => { outs.push(p.name); if (/amyboard/i.test(p.name)) outPort = p; });
+      report.ports = { inputs: ins, outputs: outs };
+      if (!inPort || !outPort) await new Promise(r => setTimeout(r, 500));
+    }
+    log('port list: ' + JSON.stringify(report.ports));
+    if (!inPort || !outPort) throw new Error('AMYboard MIDI ports not found');
+    log('ports: in=' + inPort.name + ' out=' + outPort.name);
+    inPort.onmidimessage = onMidi;
+    await new Promise(r => setTimeout(r, 300));
+
+    // 1. ping
+    sendStr('zIZ');
+    const ok = await waitFrame('O', 3000);
+    report.steps.ping = !!ok;
+    log('zI ping: ' + (ok ? 'OK' : 'NO REPLY'));
+    if (!ok) throw new Error('board did not answer ping');
+
+    // 2. paced write, 12 chunks
+    const data = makePayload('BR', 2256);
+    sendStr('zT' + PATH + ',' + data.length + 'Z');
+    if (!(await waitFrame('A', 5000))) { report.akTimeouts++; log('WARN: no AK for header'); }
+    for (let off = 0; off < data.length; off += CHUNK) {
+      sendStr(b64(data.slice(off, off + CHUNK)));
+      if (!(await waitFrame('A', 5000))) { report.akTimeouts++; log('WARN: AK timeout at offset ' + off); }
+    }
+    log('sent ' + Math.ceil(data.length / CHUNK) + ' chunks, AK timeouts: ' + report.akTimeouts);
+
+    // 3. board-side CRC verify (small inbound frame — immune to input limits)
+    const code = "import binascii,tulip\nd=open('" + PATH + "','rb').read()\n" +
+      "tulip.midi_out(bytes([0xF0,0,3,0x45,86])+('C%08x,L%d'%(binascii.crc32(d)&0xffffffff,len(d))).encode()+bytes([0xF7]))";
+    sendStr('zP' + code + 'Z');
+    const crcReply = await waitFrame('V', 8000);
+    await waitFrame('A', 2000);
+    const want = 'C' + crc32(data).toString(16).padStart(8, '0') + ',L' + data.length;
+    const got = crcReply ? new TextDecoder().decode(crcReply.payload) : null;
+    report.steps.writeCrc = { want, got, ok: got === want };
+    log('WRITE verify (board CRC): want=' + want + ' got=' + got + ' -> ' + (got === want ? 'PASS' : 'FAIL'));
+
+    // 4. zD read-back — measures whether ~1KB inbound frames survive this browser
+    rxEventSizes.length = 0;
+    sendStr('zD' + PATH + 'Z');
+    let b64acc = '', readOk = false, frameSizes = [];
+    const deadline = Date.now() + 15000;
+    while (Date.now() < deadline) {
+      const f = await waitFrame('CE0', deadline - Date.now());
+      if (!f) break;
+      frameSizes.push(f.payload.length + 6);
+      let s = ''; f.payload.forEach(x => s += String.fromCharCode(x));
+      b64acc += s;
+      if (f.m === 'E' || f.m === '0') { readOk = true; break; }
+    }
+    await waitFrame('A', 2000);
+    let readMatch = false, readLen = 0, firstDiff = -1;
+    if (readOk && b64acc) {
+      const bin = atob(b64acc);
+      readLen = bin.length;
+      readMatch = (bin.length === data.length);
+      if (readMatch) for (let i = 0; i < bin.length; i++)
+        if (bin.charCodeAt(i) !== data[i]) { readMatch = false; firstDiff = i; break; }
+    }
+    report.steps.readBack = { completed: readOk, len: readLen, expected: data.length,
+      match: readMatch, firstDiff, frameSizes, eventSizes: rxEventSizes.slice(0, 40) };
+    log('READ-BACK: completed=' + readOk + ' len=' + readLen + '/' + data.length +
+        ' match=' + readMatch + ' inbound frame sizes=' + JSON.stringify(frameSizes));
+    log('raw midimessage event sizes: ' + JSON.stringify(rxEventSizes.slice(0, 40)));
+
+    const wOK = report.steps.writeCrc.ok, rOK = readMatch;
+    verdictEl.textContent = 'WRITE: ' + (wOK ? 'PASS' : 'FAIL') + '   READ-BACK: ' + (rOK ? 'PASS' : 'FAIL');
+    verdictEl.className = (wOK && rOK) ? 'pass' : (wOK ? 'warn' : 'fail');
+  } catch (e) {
+    log('ERROR: ' + e.message);
+    report.error = e.message;
+    verdictEl.textContent = 'ERROR: ' + e.message;
+    verdictEl.className = 'fail';
+  }
+  report.log = lines.slice();
+  document.getElementById('results').value = JSON.stringify(report);
+  // Local test-collector convenience (127.0.0.1:8123 rig); 404s silently on
+  // the deployed site.
+  try { await fetch('/report', { method: 'POST', body: JSON.stringify(report) }); } catch (e) {}
+  document.getElementById('go').disabled = false;
+}
+</script>
+</body></html>

--- a/tulip/amyboardweb/static/spss.js
+++ b/tulip/amyboardweb/static/spss.js
@@ -3624,7 +3624,7 @@ function reboot_to_bootloader() {
     amy_add_log_message('zBZ');
 }
 
-// Windows Chrome WebMIDI can't recover from a USB reboot within the same
+// Windows WebMIDI can't recover from a USB reboot within the same
 // document: the MIDIOutput handle stays stale, no statechange fires, and
 // sendSysex silently goes into the void. We work around this by sending
 // zB, waiting for the board to finish rebooting, then reloading the page
@@ -3632,9 +3632,14 @@ function reboot_to_bootloader() {
 // saves its post-bootloader context in sessionStorage and reloads; on the
 // new page, pageload_control_sync picks up the flag and runs the post-
 // bootloader work against the fresh handles. macOS doesn't need this.
-var _IS_WINDOWS_CHROME = typeof navigator !== 'undefined' &&
-                         /Windows/i.test(navigator.userAgent || '') &&
-                         /Chrome/i.test(navigator.userAgent || '');
+//
+// This was originally Chrome-only, but bench testing (2026-07-22, Windows
+// 11 + Firefox 153) showed Firefox has the identical failure with better
+// camouflage: its stale output keeps reporting state=connected/conn=open
+// with the pre-reboot port id while sends go nowhere, so wait_for_board_ready
+// pings a zombie until timeout. Gate on Windows for every browser.
+var _IS_WINDOWS_BROWSER = typeof navigator !== 'undefined' &&
+                          /Windows/i.test(navigator.userAgent || '');
 
 // Complete the post-bootloader portion of a sketch-upload flow. Shared
 // between the synchronous (macOS) path and the post-reload (Windows) path
@@ -3977,7 +3982,7 @@ async function wait_for_board_ready(timeout_ms) {
             // the rest of the session (prev-name matching is sticky on
             // the wrong port). Leave macOS on the connected-event path —
             // CoreMIDI does fire those reliably.
-            if (_IS_WINDOWS_CHROME && typeof _refresh_main_midi_dropdowns === 'function') {
+            if (_IS_WINDOWS_BROWSER && typeof _refresh_main_midi_dropdowns === 'function') {
                 _refresh_main_midi_dropdowns();
             }
 
@@ -5070,7 +5075,7 @@ async function _send_text_file_verified(path, text) {
         }
         if (boardCrc === null) {
             console.warn('[verify] attempt ' + attempt + ': CRC report TIMED OUT — transfer likely wedged on board');
-            if (_IS_WINDOWS_CHROME) return 'reload-needed';
+            if (_IS_WINDOWS_BROWSER) return 'reload-needed';
             if (attempt < MAX_ATTEMPTS) {
                 console.warn('[verify] rebooting board (zB) to clear wedged transfer state, then retrying…');
                 reboot_to_bootloader();
@@ -5348,7 +5353,7 @@ function show_firmware_warning(date, latest, reason, opts) {
         if (updBtn)  updBtn.onclick  = isWedged ? async function() {
             cleanup(); inst.hide();
             console.log('[fwdetect] user: reboot wedged board (zB)');
-            if (_IS_WINDOWS_CHROME) {
+            if (_IS_WINDOWS_BROWSER) {
                 // Same limitation as every zB flow: Windows Chrome WebMIDI can't
                 // survive the USB reboot in-document (see
                 // _zb_then_reload_with_upload_context). If a Write is pending,
@@ -6145,7 +6150,7 @@ async function reset_amyboard() {
         // flag and calls _reset_amyboard_send_and_cleanup() — which sends
         // zP factory_reset and resets the JS state — against a fresh
         // MIDIAccess.
-        if (_IS_WINDOWS_CHROME) {
+        if (_IS_WINDOWS_BROWSER) {
             reboot_to_bootloader();
             console.log('reset: Windows Chrome — zB sent, reloading in 4s for fresh MIDIAccess');
             sessionStorage.setItem('amyboard_post_reset_reload', '1');

--- a/tulip/amyboardweb/static/spss.js
+++ b/tulip/amyboardweb/static/spss.js
@@ -3624,6 +3624,28 @@ function reboot_to_bootloader() {
     amy_add_log_message('zBZ');
 }
 
+// Send zB, then release every WebMidi port BEFORE the board's USB device
+// disappears. Firefox holds MIDI sessions in process-wide state keyed by the
+// port's id — and the id is STABLE across the zB USB reboot. A session left
+// open when the device drops becomes a zombie that blocks every later
+// document in that tab from opening the re-enumerated port: open() fails
+// with "operation is not supported by the underlying object" and sends
+// silently vanish, surviving page reloads and even a fresh MIDIAccess
+// (verified on Firefox 153 + Windows 11 with a parallel native wire
+// monitor). Releasing the ports while the device is still alive means no
+// zombie is recorded and the post-reload document binds cleanly. Chrome
+// doesn't need this but isn't harmed — the reload rebuilds MIDI regardless.
+async function _zb_and_release_midi() {
+    reboot_to_bootloader();
+    await sleep_ms(500);   // let the zB sysex actually leave first
+    try {
+        await WebMidi.disable();
+        console.log('zB: WebMidi released before USB re-enumeration');
+    } catch (e) {
+        console.warn('zB: WebMidi release failed:', e && e.message);
+    }
+}
+
 // Windows WebMIDI can't recover from a USB reboot within the same
 // document: the MIDIOutput handle stays stale, no statechange fires, and
 // sendSysex silently goes into the void. We work around this by sending
@@ -3733,9 +3755,9 @@ async function _zb_then_reload_with_upload_context(opts) {
     } catch (e) {
         console.warn('_zb_then_reload_with_upload_context: stash failed:', e);
     }
-    reboot_to_bootloader();
-    console.log('Windows — zB sent, reloading in 9s for fresh MIDIAccess (long wait: reloading while the USB re-enumeration is still settling binds a dead endpoint instance, seen on Firefox 153)');
-    await sleep_ms(9000);
+    await _zb_and_release_midi();
+    console.log('Windows — zB sent + MIDI released, reloading in 9s for a clean rebind');
+    await sleep_ms(8500);
     console.log('reloading now');
     window.location.reload();
     // Block the caller's await in case reload is delayed — we do NOT want
@@ -5408,9 +5430,9 @@ function show_firmware_warning(date, latest, reason, opts) {
                         suppressKnobCc: true
                     });
                 } else {
-                    reboot_to_bootloader();
-                    console.log('[fwdetect] Windows — zB sent, reloading in 9s for fresh MIDIAccess (long wait: reloading while the USB re-enumeration is still settling binds a dead endpoint instance, seen on Firefox 153)');
-                    await sleep_ms(9000);
+                    await _zb_and_release_midi();
+                    console.log('[fwdetect] Windows — zB sent + MIDI released, reloading in 9s for a clean rebind');
+                    await sleep_ms(8500);
                     window.location.reload();
                 }
                 resolve(false);  // unreachable in practice — the reload unloads us
@@ -6190,10 +6212,10 @@ async function reset_amyboard() {
         // zP factory_reset and resets the JS state — against a fresh
         // MIDIAccess.
         if (_IS_WINDOWS_BROWSER) {
-            reboot_to_bootloader();
-            console.log('reset: Windows — zB sent, reloading in 9s for fresh MIDIAccess (long wait: reloading while the USB re-enumeration is still settling binds a dead endpoint instance, seen on Firefox 153)');
             sessionStorage.setItem('amyboard_post_reset_reload', '1');
-            await sleep_ms(9000);
+            await _zb_and_release_midi();
+            console.log('reset: Windows — zB sent + MIDI released, reloading in 9s for a clean rebind');
+            await sleep_ms(8500);
             console.log('reset: reloading now');
             window.location.reload();
             return;  // unreachable after reload

--- a/tulip/amyboardweb/static/spss.js
+++ b/tulip/amyboardweb/static/spss.js
@@ -3647,9 +3647,25 @@ var _IS_WINDOWS_CHROME = typeof navigator !== 'undefined' &&
 async function _upload_sketch_post_bootloader(opts) {
     if (!opts || typeof opts.sketchText !== 'string') return;
     var sketchPath = opts.sketchPath || '/user/current/sketch.py';
+    var uploadOk = false;
     try {
-        await _send_text_file_to_amyboard(sketchPath, opts.sketchText);
-        console.log('post-zb upload: sketch sent to AMYboard');
+        var result = await _send_text_file_verified(sketchPath, opts.sketchText);
+        if (result === 'reload-needed') {
+            // The transfer wedged again and we're on Windows Chrome, where
+            // the zB reboot that clears it forces a page reload. Cap the
+            // reload loop at 2 so a persistently bad link can't bounce the
+            // page forever.
+            var reloads = opts.verifyReloadCount || 0;
+            if (reloads < 2) {
+                await _zb_then_reload_with_upload_context(Object.assign({}, opts, {
+                    verifyReloadCount: reloads + 1
+                }));
+                return;  // unreachable — the reload unloads us
+            }
+            console.warn('post-zb upload: verify still failing after ' + reloads + ' reloads — giving up');
+        }
+        uploadOk = (result === 'verified');
+        if (uploadOk) console.log('post-zb upload: sketch sent to AMYboard (verified)');
         await sleep_ms(opts.restart ? 500 : 1000);
     } catch (e) {
         console.warn('post-zb upload: sketch upload to AMYboard failed', e);
@@ -3677,10 +3693,15 @@ async function _upload_sketch_post_bootloader(opts) {
         var envNameInput = document.getElementById('editor_filename');
         if (envNameInput) envNameInput.value = opts.packageName;
     }
-    if (opts.restart) {
+    if (opts.restart && uploadOk) {
         var restartFn = (opts.restart === 'transfer_done') ? 'environment_transfer_done' : 'restart_sketch';
         amy_add_log_message('zPimport amyboard; amyboard.' + restartFn + '()Z');
         console.log('post-zb upload: sketch restarted via zP (' + restartFn + ')');
+    } else if (!uploadOk) {
+        // Don't restart into a sketch we know didn't arrive intact — surface
+        // the failure instead. (Editor + knob UI above still reflect the
+        // user's sketch; only the board write failed.)
+        show_alert(_VERIFY_FAILED_ALERT);
     }
     if (opts.refreshWorldFiles && typeof refresh_amyboard_world_files === 'function') {
         try { await refresh_amyboard_world_files(); } catch (e) {}
@@ -4911,6 +4932,103 @@ async function _send_text_file_to_amyboard(path, text) {
 }
 
 // ============================================================================
+// Verified file write: send, read back, retry
+// ----------------------------------------------------------------------------
+// The zT transfer has no integrity check: if one sysex chunk is lost in
+// transit (seen in the field on Windows Chrome), the board's byte counter
+// comes up short and the transfer never completes — worse, every later sysex
+// command (zP restart, a retried zT header, ...) is base64-decoded INTO the
+// open file as binary garbage until the counter finally crosses the expected
+// size, producing the mystery "SyntaxError at line 11" / UnicodeDecodeError
+// popups. Until the firmware protocol grows sequence numbers, we verify every
+// sketch write by reading the file straight back with zD and comparing
+// byte-for-byte, resending on mismatch. A read-back TIMEOUT is the signature
+// of the wedged-transfer state above (the zD request itself got eaten as
+// transfer data); only a reboot clears it, since the board has no transfer
+// timeout. All logging is tagged [verify] so field reports can find it.
+var _verify_read_resolve = null;
+
+// Read a file off the board via zD and resolve with its raw text (before any
+// sanitizing — this is for byte-exact comparison), or null on timeout.
+function _read_back_file_from_amyboard(path, timeout_ms) {
+    if (!timeout_ms) timeout_ms = 15000;
+    return new Promise(function(resolve) {
+        // Drop stale sysex reassembly state so a fragment from an earlier
+        // interrupted op can't prepend onto our response.
+        _sysex_reasm = null;
+        _sysex_b64_accum = '';
+        var done = false;
+        var t = setTimeout(function() {
+            if (done) return;
+            done = true;
+            _verify_read_resolve = null;
+            resolve(null);
+        }, timeout_ms);
+        _verify_read_resolve = function(payloadText) {
+            if (done) return;
+            done = true;
+            clearTimeout(t);
+            resolve(payloadText);
+        };
+        amy_add_log_message('zD' + path + 'Z');
+    });
+}
+
+// Console-only diagnostic: where does the read-back first diverge from what
+// we sent? The char index maps to a sketch line, which is exactly the line
+// number users report from the on-board SyntaxError popup.
+function _log_first_difference(sent, got) {
+    var n = Math.min(sent.length, got.length);
+    var i = 0;
+    while (i < n && sent[i] === got[i]) i++;
+    var line = sent.slice(0, i).split('\n').length;
+    console.warn('[verify] first difference at char ' + i + ' (sketch line ' + line + '): sent '
+        + JSON.stringify(sent.slice(i, i + 40)) + ' got ' + JSON.stringify(got.slice(i, i + 40)));
+}
+
+// Send a text file with verify-and-retry. Returns:
+//   'verified'      — the board's file matches `text` byte-for-byte.
+//   'reload-needed' — Windows Chrome only: the transfer wedged and clearing
+//                     it needs a zB reboot, which stale WebMIDI can't survive
+//                     in-document; the caller must stash context and reload.
+//   'failed'        — attempts exhausted without a verified write.
+async function _send_text_file_verified(path, text) {
+    var MAX_ATTEMPTS = 3;
+    // Scale the read-back timeout with size: big sketches (embedded MIDI
+    // files) take a while to stream back over sysex.
+    var readback_timeout_ms = 15000 + Math.floor(text.length / 10);
+    for (var attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        console.log('[verify] write attempt ' + attempt + '/' + MAX_ATTEMPTS + ': sending '
+            + text.length + ' chars to ' + path);
+        await _send_text_file_to_amyboard(path, text);
+        var readBack = await _read_back_file_from_amyboard(path, readback_timeout_ms);
+        if (readBack === text) {
+            console.log('[verify] attempt ' + attempt + ': read-back matches (' + text.length + ' chars)');
+            return 'verified';
+        }
+        if (readBack === null) {
+            console.warn('[verify] attempt ' + attempt + ': read-back TIMED OUT — transfer likely wedged on board');
+            if (_IS_WINDOWS_CHROME) return 'reload-needed';
+            if (attempt < MAX_ATTEMPTS) {
+                console.warn('[verify] rebooting board (zB) to clear wedged transfer state, then retrying…');
+                reboot_to_bootloader();
+                await wait_for_board_ready();
+            }
+        } else {
+            console.warn('[verify] attempt ' + attempt + ': read-back MISMATCH (sent '
+                + text.length + ' chars, got ' + readBack.length + ') — resending');
+            _log_first_difference(text, readBack);
+        }
+    }
+    console.warn('[verify] giving up after ' + MAX_ATTEMPTS + ' attempts');
+    return 'failed';
+}
+
+var _VERIFY_FAILED_ALERT =
+    'Writing to your AMYboard failed: the sketch did not arrive intact over MIDI, even after retries.\n\n'
+    + 'Unplug and replug your AMYboard, then try Write again.';
+
+// ============================================================================
 // Pre-op board check: reachability, liveness, firmware version
 // ----------------------------------------------------------------------------
 // Every Write/Read in control mode first verifies the board can actually take
@@ -5240,9 +5358,27 @@ async function write_sketch_to_amyboard() {
         try {
             // zT stops the sequencer on the board during the transfer, so the
             // running sketch's loop() can't corrupt it — no reboot required.
-            await _send_text_file_to_amyboard('/user/current/sketch.py', sketchText);
-            // Restart the sketch: resets AMY, replays the knob block, runs code.
-            amy_add_log_message('zPimport amyboard; amyboard.environment_transfer_done()Z');
+            // Verified write: read the file back and resend on mismatch, so a
+            // dropped sysex chunk becomes a silent retry instead of a corrupted
+            // sketch (see _send_text_file_verified).
+            var result = await _send_text_file_verified('/user/current/sketch.py', sketchText);
+            if (result === 'verified') {
+                // Restart the sketch: resets AMY, replays the knob block, runs code.
+                amy_add_log_message('zPimport amyboard; amyboard.environment_transfer_done()Z');
+            } else if (result === 'reload-needed') {
+                // Windows Chrome with a wedged transfer: clearing it needs a zB
+                // reboot, and stale WebMIDI can't survive that in-document.
+                // Stash the sketch and reload; the fresh page resumes the write
+                // in _upload_sketch_post_bootloader (which verifies again).
+                await _zb_then_reload_with_upload_context({
+                    sketchText: sketchText,
+                    restart: 'transfer_done',
+                    suppressKnobCc: true,
+                    verifyReloadCount: 1
+                });
+            } else {
+                show_alert(_VERIFY_FAILED_ALERT);
+            }
         } catch (e) {
             console.warn('write_sketch_to_amyboard: control failed', e);
         } finally {
@@ -6136,6 +6272,15 @@ function _sanitize_sketch_text(text) {
 }
 
 function _handle_sync_sysex_payload(payload) {
+    // Verify read-back in progress (_send_text_file_verified): hand the RAW
+    // payload to the verifier before any sanitizing or self-healing — the
+    // whole point is a byte-exact comparison with what was just sent.
+    if (_verify_read_resolve) {
+        var vr = _verify_read_resolve;
+        _verify_read_resolve = null;
+        vr(payload);
+        return;
+    }
     // payload is the sketch.py text, base64-decoded.
     payload = _sanitize_sketch_text(payload);
     // Reject empty/garbage payloads — a stale sysex fragment shouldn't

--- a/tulip/amyboardweb/static/spss.js
+++ b/tulip/amyboardweb/static/spss.js
@@ -2037,6 +2037,16 @@ function _process_complete_sysex(d) {
         if (_fw_version_resolve) { var vr = _fw_version_resolve; _fw_version_resolve = null; vr(verStr); }
         return;
     }
+    // File-CRC report: F0 00 03 45 'H' <ascii "C<crc32 hex>,L<len>"> F7,
+    // produced by the zP snippet _request_board_file_crc sends (write-verify).
+    // Like 'V', intercept before the chunk-marker logic.
+    if (d[4] === 0x48 /* 'H' */) {
+        var crcStr = '';
+        for (var ci = 5; ci < d.length - 1; ci++) crcStr += String.fromCharCode(d[ci]);
+        console.log('[verify] <- H reply: ' + JSON.stringify(crcStr));
+        if (_verify_crc_resolve) { var cr = _verify_crc_resolve; _verify_crc_resolve = null; cr(crcStr); }
+        return;
+    }
     // AMY CPU overload report: F0 00 03 45 'L' <base64 load percent> F7.
     // Sent by amyboard._on_amy_overload() after AMY's failsafe reset the synth
     // and the sketch loop was stopped. Like 'V', intercept before the
@@ -4932,21 +4942,74 @@ async function _send_text_file_to_amyboard(path, text) {
 }
 
 // ============================================================================
-// Verified file write: send, read back, retry
+// Verified file write: send, verify board-side CRC, retry
 // ----------------------------------------------------------------------------
 // The zT transfer has no integrity check: if one sysex chunk is lost in
-// transit (seen in the field on Windows Chrome), the board's byte counter
+// transit (seen in the field on Windows), the board's byte counter
 // comes up short and the transfer never completes — worse, every later sysex
 // command (zP restart, a retried zT header, ...) is base64-decoded INTO the
 // open file as binary garbage until the counter finally crosses the expected
 // size, producing the mystery "SyntaxError at line 11" / UnicodeDecodeError
 // popups. Until the firmware protocol grows sequence numbers, we verify every
-// sketch write by reading the file straight back with zD and comparing
-// byte-for-byte, resending on mismatch. A read-back TIMEOUT is the signature
-// of the wedged-transfer state above (the zD request itself got eaten as
+// sketch write and resend on mismatch. A verify TIMEOUT is the signature
+// of the wedged-transfer state above (the verify request itself got eaten as
 // transfer data); only a reboot clears it, since the board has no transfer
 // timeout. All logging is tagged [verify] so field reports can find it.
+//
+// The verify primitive is a CRC32 computed ON THE BOARD (zP exec) and
+// reported in a ~20-byte 'H' sysex frame — NOT a zD read-back of the file.
+// Read-back depends on the browser/OS delivering the board's ~1KB zD dump
+// frames intact, and bench testing (2026-07, Windows 11 + AMYboard) showed
+// Windows MIDI stacks dropping inbound sysex above ~1KB (fixed-size sysex
+// input buffers) while small frames always arrive. The zD read-back is kept
+// only as a best-effort diagnostic to locate the first corrupted byte after
+// a CRC mismatch.
 var _verify_read_resolve = null;
+var _verify_crc_resolve = null;
+
+// CRC32 (IEEE — same polynomial and convention as MicroPython's
+// binascii.crc32, so the JS and board values are directly comparable).
+var _CRC32_TABLE = null;
+function _crc32_bytes(bytes) {
+    if (!_CRC32_TABLE) {
+        _CRC32_TABLE = new Uint32Array(256);
+        for (var n = 0; n < 256; n++) {
+            var c = n;
+            for (var k = 0; k < 8; k++) c = (c & 1) ? (0xEDB88320 ^ (c >>> 1)) : (c >>> 1);
+            _CRC32_TABLE[n] = c >>> 0;
+        }
+    }
+    var crc = 0xFFFFFFFF;
+    for (var i = 0; i < bytes.length; i++) crc = _CRC32_TABLE[(crc ^ bytes[i]) & 0xFF] ^ (crc >>> 8);
+    return (crc ^ 0xFFFFFFFF) >>> 0;
+}
+
+// Ask the board (via zP exec) to report "C<crc32 hex>,L<len>" of a file in a
+// small 'H' sysex frame. Resolves with that string, or null on timeout (the
+// wedged-transfer signature). binascii and tulip.midi_out exist on all
+// AMYboard firmware, so this works without a firmware update.
+function _request_board_file_crc(path, timeout_ms) {
+    if (!timeout_ms) timeout_ms = 8000;
+    return new Promise(function(resolve) {
+        var done = false;
+        var t = setTimeout(function() {
+            if (done) return;
+            done = true;
+            _verify_crc_resolve = null;
+            resolve(null);
+        }, timeout_ms);
+        _verify_crc_resolve = function(reply) {
+            if (done) return;
+            done = true;
+            clearTimeout(t);
+            resolve(reply);
+        };
+        var code = "import binascii,tulip\n"
+            + "d=open('" + path + "','rb').read()\n"
+            + "tulip.midi_out(bytes([0xF0,0,3,0x45,0x48])+('C%08x,L%d'%(binascii.crc32(d)&0xffffffff,len(d))).encode()+bytes([0xF7]))";
+        amy_add_log_message('zP' + code + 'Z');
+    });
+}
 
 // Read a file off the board via zD and resolve with its raw text (before any
 // sanitizing — this is for byte-exact comparison), or null on timeout.
@@ -4987,27 +5050,26 @@ function _log_first_difference(sent, got) {
 }
 
 // Send a text file with verify-and-retry. Returns:
-//   'verified'      — the board's file matches `text` byte-for-byte.
+//   'verified'      — the board's file matches `text` (CRC32 + length).
 //   'reload-needed' — Windows Chrome only: the transfer wedged and clearing
 //                     it needs a zB reboot, which stale WebMIDI can't survive
 //                     in-document; the caller must stash context and reload.
 //   'failed'        — attempts exhausted without a verified write.
 async function _send_text_file_verified(path, text) {
     var MAX_ATTEMPTS = 3;
-    // Scale the read-back timeout with size: big sketches (embedded MIDI
-    // files) take a while to stream back over sysex.
-    var readback_timeout_ms = 15000 + Math.floor(text.length / 10);
+    var textBytes = new TextEncoder().encode(text);
+    var expected = 'C' + _crc32_bytes(textBytes).toString(16).padStart(8, '0') + ',L' + textBytes.length;
     for (var attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
         console.log('[verify] write attempt ' + attempt + '/' + MAX_ATTEMPTS + ': sending '
-            + text.length + ' chars to ' + path);
+            + textBytes.length + ' bytes to ' + path);
         await _send_text_file_to_amyboard(path, text);
-        var readBack = await _read_back_file_from_amyboard(path, readback_timeout_ms);
-        if (readBack === text) {
-            console.log('[verify] attempt ' + attempt + ': read-back matches (' + text.length + ' chars)');
+        var boardCrc = await _request_board_file_crc(path);
+        if (boardCrc === expected) {
+            console.log('[verify] attempt ' + attempt + ': board CRC matches (' + expected + ')');
             return 'verified';
         }
-        if (readBack === null) {
-            console.warn('[verify] attempt ' + attempt + ': read-back TIMED OUT — transfer likely wedged on board');
+        if (boardCrc === null) {
+            console.warn('[verify] attempt ' + attempt + ': CRC report TIMED OUT — transfer likely wedged on board');
             if (_IS_WINDOWS_CHROME) return 'reload-needed';
             if (attempt < MAX_ATTEMPTS) {
                 console.warn('[verify] rebooting board (zB) to clear wedged transfer state, then retrying…');
@@ -5015,9 +5077,16 @@ async function _send_text_file_verified(path, text) {
                 await wait_for_board_ready();
             }
         } else {
-            console.warn('[verify] attempt ' + attempt + ': read-back MISMATCH (sent '
-                + text.length + ' chars, got ' + readBack.length + ') — resending');
-            _log_first_difference(text, readBack);
+            console.warn('[verify] attempt ' + attempt + ': board CRC MISMATCH (want '
+                + expected + ', got ' + boardCrc + ') — resending');
+            // Best-effort diagnostic: pull the file back with zD to locate the
+            // first corrupted byte. On hosts that drop the ~1KB zD frames this
+            // just times out quietly — the CRC verdict above stands regardless.
+            try {
+                var readBack = await _read_back_file_from_amyboard(path, 15000 + Math.floor(text.length / 10));
+                if (readBack !== null && readBack !== text) _log_first_difference(text, readBack);
+                else if (readBack === null) console.warn('[verify] (diagnostic zD read-back timed out — inbound large-sysex limit?)');
+            } catch (e) {}
         }
     }
     console.warn('[verify] giving up after ' + MAX_ATTEMPTS + ' attempts');

--- a/tulip/amyboardweb/static/spss.js
+++ b/tulip/amyboardweb/static/spss.js
@@ -3734,8 +3734,8 @@ async function _zb_then_reload_with_upload_context(opts) {
         console.warn('_zb_then_reload_with_upload_context: stash failed:', e);
     }
     reboot_to_bootloader();
-    console.log('Windows Chrome — zB sent, reloading in 4s for fresh MIDIAccess');
-    await sleep_ms(4000);
+    console.log('Windows — zB sent, reloading in 9s for fresh MIDIAccess (long wait: reloading while the USB re-enumeration is still settling binds a dead endpoint instance, seen on Firefox 153)');
+    await sleep_ms(9000);
     console.log('reloading now');
     window.location.reload();
     // Block the caller's await in case reload is delayed — we do NOT want
@@ -3822,6 +3822,31 @@ async function _install_raw_midi_statechange_diagnostic() {
     } catch (e) {
         console.warn('[MIDIAccess] diagnostic install failed:', e);
     }
+}
+
+// Tear the whole WebMidi session down and rebuild it from a brand-new
+// MIDIAccess. On Windows the board's MIDI endpoint keeps the SAME id across
+// a zB USB reboot, so a session opened against the pre-reboot instance looks
+// perfectly healthy (state=connected, connection=open) while every send
+// silently vanishes — verified on Firefox 153 with a wire monitor: the
+// page's zI pings never reached the board while a parallel native client
+// pinged it fine. Raw-port close()/open() cycling does NOT fix this (the
+// session still points at the dead instance); only a new MIDIAccess binds
+// the live one. Returns true if the rebind completed.
+async function _full_webmidi_rebind() {
+    if (typeof WebMidi === 'undefined' || !WebMidi || !WebMidi.supported) return false;
+    try { await WebMidi.disable(); } catch (e) { console.warn('rebind: disable failed:', e && e.message); }
+    await sleep_ms(500);
+    try {
+        await WebMidi.enable({ sysex: true });
+    } catch (e) {
+        console.warn('rebind: enable failed:', e && e.message);
+        return false;
+    }
+    console.log('rebind: WebMidi re-enabled, sysex=' + WebMidi.sysexEnabled);
+    try { if (typeof _refresh_main_midi_dropdowns === 'function') _refresh_main_midi_dropdowns(); } catch (e) {}
+    try { await setup_midi_devices(); } catch (e) { console.warn('rebind: setup_midi_devices failed:', e && e.message); }
+    return true;
 }
 
 async function wait_for_board_ready(timeout_ms) {
@@ -3926,9 +3951,23 @@ async function wait_for_board_ready(timeout_ms) {
     // on the raw MIDIPort. No-op on macOS because the happy path already
     // succeeded well before halfway.
     var did_port_cycle = false;
+    // One-shot at 1/3 of the window: full WebMidi teardown + re-enable.
+    // This is the recovery that actually works on Windows Firefox (see
+    // _full_webmidi_rebind); it runs BEFORE the raw-port cycle so the
+    // cheap-but-Firefox-ineffective cycle remains the Chrome fallback.
+    var did_full_rebind = false;
 
     try {
         while (Date.now() < deadline) {
+            if (_IS_WINDOWS_BROWSER && !did_full_rebind && (Date.now() - start_time) > timeout_ms / 3) {
+                did_full_rebind = true;
+                console.log('wait_for_board_ready: no replies at 1/3 timeout — full WebMidi rebind (new MIDIAccess)...');
+                try { await _full_webmidi_rebind(); } catch (e) { console.warn('wait_for_board_ready: rebind failed:', e); }
+                // WebMidi.disable() dropped our connected listener — re-attach.
+                _attach_connected_listener();
+                consecutive_failures = 0;
+                last_probe_time = 0;
+            }
             if (!did_port_cycle && (Date.now() - start_time) > timeout_ms / 2) {
                 did_port_cycle = true;
                 console.log('wait_for_board_ready: halfway, cycling raw ports (close → wait → open)...');
@@ -5370,8 +5409,8 @@ function show_firmware_warning(date, latest, reason, opts) {
                     });
                 } else {
                     reboot_to_bootloader();
-                    console.log('[fwdetect] Windows Chrome — zB sent, reloading in 4s for fresh MIDIAccess');
-                    await sleep_ms(4000);
+                    console.log('[fwdetect] Windows — zB sent, reloading in 9s for fresh MIDIAccess (long wait: reloading while the USB re-enumeration is still settling binds a dead endpoint instance, seen on Firefox 153)');
+                    await sleep_ms(9000);
                     window.location.reload();
                 }
                 resolve(false);  // unreachable in practice — the reload unloads us
@@ -6152,9 +6191,9 @@ async function reset_amyboard() {
         // MIDIAccess.
         if (_IS_WINDOWS_BROWSER) {
             reboot_to_bootloader();
-            console.log('reset: Windows Chrome — zB sent, reloading in 4s for fresh MIDIAccess');
+            console.log('reset: Windows — zB sent, reloading in 9s for fresh MIDIAccess (long wait: reloading while the USB re-enumeration is still settling binds a dead endpoint instance, seen on Firefox 153)');
             sessionStorage.setItem('amyboard_post_reset_reload', '1');
-            await sleep_ms(4000);
+            await sleep_ms(9000);
             console.log('reset: reloading now');
             window.location.reload();
             return;  // unreachable after reload


### PR DESCRIPTION
## The bug (field reports: Windows)

"Write to your AMYboard" intermittently pops a SyntaxError at a varying line (6, 11, 22 seen in the field), sometimes a UnicodeDecodeError — yet the file on disk later looks fine, and it only takes one user retry to "fix" it.

## Root cause

The zT transfer has **no integrity check**. The failure cascade:

1. One 188-byte sysex chunk is dropped in transit by the host MIDI stack.
2. The board's `transfer_stored_bytes` never reaches the promised size, so `transfer_flag` stays `AMY_TRANSFER_TYPE_FILE` **forever** — there is no board-side timeout.
3. While that flag is set, `amy_parse_message` routes *every* sysex-originated message to `parse_transfer_message` before command parsing — so the `zP environment_transfer_done`, liveness probes, and the retried `zT` header all get base64-decoded **into the open file** as binary garbage (`b64_decode_ex` silently stops at the first non-base64 char).
4. The retry's chunks are valid base64, so the counter finally crosses the threshold mid-retry; the file closes containing *original-minus-a-chunk + garbage + partial retry* and runs → SyntaxError at wherever the chunk went missing (chunks are ~4–7 sketch lines apart → varying line numbers), or UnicodeDecodeError from the non-UTF-8 garbage.
5. The user's *next* clean Write overwrites everything — which is why the file "looks fine" by the time anyone inspects it.

## Bench findings (Windows 11 + AMYboard on USB, python-rtmidi via the winmm compat layer)

- **Outbound (host→board) is robust**: paced, burst-4, and fully unpaced transfers up to 20KB / 107 chunks all landed byte-perfect (verified by CRC32 computed on the board). The board's 8-slot sysex ring keeps up even with zero pacing.
- **Inbound (board→host) sysex above ~1KB is silently dropped** by fixed-size sysex input buffers. The board's zD dump frames (~1030 bytes) are exactly in the kill zone; small frames (ACKs, error reports, CRC replies) always arrive.
- Chromium (Edge) on the new Windows MIDI Services stack (build 26200, `SWD\MMDEVAPI\MIDII_*` devices) enumerates **zero** Web MIDI ports — a separate compat gap worth its own FAQ entry.
- macOS/CoreMIDI: clean in both directions at every size and pacing tested.

## The fix (web-only — works with firmware users already have)

After sending the chunks, verify with a **CRC32 computed on the board** (`zP` exec of `binascii.crc32` over the written file) reported back in a ~20-byte `'H'` sysex frame, compared against the same CRC computed in JS:

- **Mismatch** → resend, up to 3 attempts. A best-effort `zD` read-back locates the first corrupted byte for the `[verify]` console diagnostic (on hosts that drop the ~1KB zD frames it just times out quietly — the CRC verdict stands regardless).
- **CRC report timeout** → the wedged-transfer signature (the request itself was eaten as transfer data). Recovery: zB reboot to clear the stuck transfer, then resend. On Windows Chrome — where WebMIDI can't survive a zB in-document — reuse the existing stash-and-reload flow, which resumes and re-verifies in `_upload_sketch_post_bootloader`; reloads capped at 2.
- `environment_transfer_done` only fires on a **verified** write; otherwise the user gets a clear alert instead of a corrupt sketch running.

Also adds **`/miditest.html`** — a self-contained field diagnostic (paced write of a scratch file, board-CRC verify, zD read-back measurement) with copyable JSON results. Hosted because Firefox only grants Web MIDI via its site-permission add-on on public https origins.

## Testing

- Stubbed-transport tests of the real code paths (synthesized sysex frames through `_process_complete_sysex`): happy path, corrupted-send (CRC mismatch caught, first-difference diagnostic at the exact corrupted char/line, verified on resend), wedged non-Windows (timeout → zB reboot → verified), wedged Windows Chrome (`reload-needed`), full Write flow (transfer_done only after verify).
- JS CRC32 parity-tested against MicroPython/CPython `binascii.crc32`.
- Hardware protocol driver (`zt_pacing_test.py`) run against a real AMYboard from macOS and Windows 11 — results above.

## Follow-ups (not in this PR)

Firmware/amy hardening: board-side transfer inactivity timeout (abort + delete partial + error sysex), chunk sequence numbers/CRC in zT, file size/CRC in the `X` error payload, and smaller zD dump frames (≤1KB incl. framing) so reads survive winmm-buffer-limited hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)