### PR TITLE
Restore /sys/ex/my_*.py editable app copies in continuous builds

### DIFF
--- a/.github/workflows/tulip-release.yml
+++ b/.github/workflows/tulip-release.yml
@@ -30,6 +30,7 @@ on:
       - 'tulip/esp32s3/**'
       - 'tulip/shared/**'
       - 'tulip/fs/tulip/**'
+      - 'tulip/fs_create.py'
       - 'tulip/macos/**'
       - 'tulip/windows/**'
       - '.github/workflows/tulip-release.yml'

--- a/tulip/fs_create.py
+++ b/tulip/fs_create.py
@@ -8,6 +8,15 @@ if(len(sys.argv)<2):
     print("Usage: python fs_create.py (amyboard,tulip) [flash]")
 
 distro = sys.argv[1]
+
+# Ship editable copies of the built-in apps as /sys/ex/my_*.py -- the frozen
+# originals are read-only, and the docs point users at these copies to edit.
+# They are gitignored (tulip/fs/tulip/ex/my_*), so regenerate them per build.
+if(distro=='tulip'):
+    import shutil
+    for app in ('drums', 'juno6', 'voices', 'worldui'):
+        shutil.copyfile('shared/py/%s.py' % (app), 'fs/tulip/ex/my_%s.py' % (app))
+
 if(distro=='tulip'):
     os.chdir('esp32s3')
 else:

--- a/tulip/release.sh
+++ b/tulip/release.sh
@@ -18,11 +18,8 @@ die() { echo "$*" 1>&2 ; exit 1; }
 RELEASE=$1
 TYPE=$2
 
-# Copy over some known examples to tulip's /sys/ex before creating image
-cp shared/py/drums.py fs/tulip/ex/my_drums.py
-cp shared/py/juno6.py fs/tulip/ex/my_juno6.py
-cp shared/py/worldui.py fs/tulip/ex/my_worldui.py
-cp shared/py/voices.py fs/tulip/ex/my_voices.py
+# The editable /sys/ex/my_*.py copies of the built-in apps are created by
+# fs_create.py (run below), so every image build gets them -- no copy needed here.
 
 # Make sure the submodules are fresh
 rm ../.submodules_ok

--- a/tulip/web/build.sh
+++ b/tulip/web/build.sh
@@ -26,6 +26,15 @@ if [ -z "${SKIP_AMY_WEB:-}" ]; then
   #make docs/amy-audioin.js
   cd ../tulip/web
 fi
+
+# Ship editable copies of the built-in apps as /sys/ex/my_*.py (baked into
+# micropython.data via the Makefile's --preload-file of ../fs/tulip). The
+# frozen originals are read-only; the docs point users at these copies.
+# Gitignored (tulip/fs/tulip/ex/my_*); fs_create.py does the same for ESP images.
+for app in drums juno6 voices worldui; do
+  cp ../shared/py/$app.py ../fs/tulip/ex/my_$app.py
+done
+
 make
 
 # Now modify the static html and copy everything to a stage area 


### PR DESCRIPTION
## Problem

docs/getting_started.md, docs/tulip_api.md (x2) and docs/music.md tell users to edit `/sys/ex/my_drums.py`, `my_juno6.py`, `my_voices.py` — editable copies of the frozen built-in apps. Those copies were only created by the legacy monthly `tulip/release.sh` (`cp shared/py/drums.py fs/tulip/ex/my_drums.py` …), which the continuous release (`tulip-release.yml`) never runs. So current firmware and Tulip Web ship without them, and the docs' walkthrough (`edit('/sys/ex/my_drums.py')`) fails.

## Fix

Restore the copy step in the continuous builds instead of weakening the docs — the editable copies are an intended, documented feature:

- **`tulip/fs_create.py`**: for the `tulip` distro, copy `drums`/`juno6`/`voices`/`worldui` from `shared/py/` into `fs/tulip/ex/my_*.py` before building the sys littlefs image. This covers the CI firmware release, local `idf.py` + `fs_create.py` builds, and the full-flash images. (Files are already gitignored via `tulip/fs/tulip/ex/my_*`.)
- **`tulip/web/build.sh`**: same copies before `make`, so the WASM `--preload-file ../fs/tulip@tulip4/sys` bakes them into Tulip Web too.
- **`tulip/release.sh`**: drop the now-redundant `cp` lines (it calls `fs_create.py`, which does the copy).
- **`tulip-release.yml`**: add `tulip/fs_create.py` to the push path filter so changes to the image builder trigger a firmware release (this PR's merge will then ship the files).

## Not fixed here

Tulip Desktop has a separate pre-existing bug: since the March 2025 `tulip/fs/{tulip,amyboard}` reorg (a2e8a26f), the desktop builds copy the whole `fs/` tree into `sys/`, leaving `/sys/ex` one level too deep (`sys/tulip/ex/...`) — so desktop won't see these files until that layout bug is fixed (flagged separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)