### PR TITLE
ci: stop cloning 85 submodules to build 8

### DIFF
--- a/.github/actions/init-submodules/action.yml
+++ b/.github/actions/init-submodules/action.yml
@@ -1,0 +1,43 @@
+name: Init build submodules
+description: >-
+  Initialize only the submodules our builds actually use. Run this immediately
+  after actions/checkout, in place of its `submodules: recursive` input.
+
+# Why this exists: `submodules: recursive` clones 85 repositories and takes
+# ~5.5 minutes -- about 35% of a ~16-minute firmware+web job. Almost all of it
+# is micropython/lib/pico-sdk -> tinyusb -> every vendor MCU SDK (nuclei-sdk,
+# nxp/mcux-sdk, nrfx, stm32lib, ch32v307, lpcopen, ...), i.e. the RP2040 and
+# STM32 ports. We build esp32s3, macOS, Linux and WASM. None of them read a
+# single file from that tree.
+#
+# The list below is deliberately the same set as tulip/shared/grab_submodules.sh,
+# which is what a local build needs -- keep the two in sync. It is a superset of
+# any one target's needs (axtls/libffi are unix-port only; the esp-idf build gets
+# mbedtls from IDF), which is the point: one list, every target, no per-workflow
+# variants to drift.
+#
+# `tinycc` is deliberately absent. It only powers tulip.install_c_process() on
+# macOS desktop, tulip/macos/build.sh inits and builds it itself, and
+# tulip/macos/Makefile compiles the feature out when libtcc.a is missing -- which
+# is already the case in CI, since the release job runs `make` directly rather
+# than build.sh. Cloning it here would change nothing but the clock.
+#
+# --depth 1 matches what actions/checkout already passes to its own recursive
+# submodule update, so this is not a new constraint.
+
+runs:
+  using: composite
+  steps:
+    - name: Init build submodules
+      shell: bash
+      run: |
+        set -euo pipefail
+        git submodule update --init --depth 1 amy micropython
+        git -C micropython submodule update --init --depth 1 \
+          lib/axtls \
+          lib/berkeley-db-1.xx \
+          lib/libffi \
+          lib/mbedtls \
+          lib/micropython-lib \
+          lib/tinyusb
+        echo "Initialized $(git submodule status --recursive | wc -l | tr -d ' ') submodules."

--- a/.github/actions/init-submodules/action.yml
+++ b/.github/actions/init-submodules/action.yml
@@ -40,4 +40,12 @@ runs:
           lib/mbedtls \
           lib/micropython-lib \
           lib/tinyusb
-        echo "Initialized $(git submodule status --recursive | wc -l | tr -d ' ') submodules."
+        # `git submodule status --recursive` lists registered submodules, not
+        # cloned ones -- uninitialized entries are the lines starting with '-'.
+        # Report both numbers so the log can't be read as "we cloned all of them".
+        sm_status=$(git submodule status --recursive)
+        # `|| true` because grep -c exits 1 on a zero count, which set -e would
+        # turn into a failed build over a log line.
+        sm_init=$(grep -cv '^-' <<<"$sm_status" || true)
+        sm_total=$(wc -l <<<"$sm_status" | tr -d ' ')
+        echo "Initialized $sm_init of $sm_total registered submodules."

--- a/.github/workflows/amyboard-pr-preview.yml
+++ b/.github/workflows/amyboard-pr-preview.yml
@@ -23,6 +23,8 @@ on:
       # tulip-pr-preview reuses for tulip.upgrade(pr=N).
       - 'tulip/shared/**'
       - '.github/workflows/amyboard-pr-preview.yml'
+      # Decides which submodules exist at build time, so treat it as a build input.
+      - '.github/actions/init-submodules/action.yml'
 
   # Fired by shorepine/amy's amyboard-hwci-trigger.yml on an AMY PR: build this
   # pipeline with the `amy` submodule pinned to client_payload.amy_sha, then chain
@@ -97,8 +99,7 @@ jobs:
           echo "Vercel token OK for bwhitmans-projects."
 
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - uses: ./.github/actions/init-submodules
 
       # For an AMY PR, point the `amy` submodule at the PR's commit so the firmware
       # is built from THIS PR's AMY code — the whole reason for the dispatch. The

--- a/.github/workflows/amyboard-release.yml
+++ b/.github/workflows/amyboard-release.yml
@@ -55,9 +55,7 @@ jobs:
       contents: write              # create + clobber the 'amyboard' release
     steps:
       - uses: actions/checkout@v4
-        with:
-          # amy + micropython (and their nested submodules) are needed to build.
-          submodules: recursive
+      - uses: ./.github/actions/init-submodules
 
       - name: Build AMYboard firmware + assemble images
         uses: espressif/esp-idf-ci-action@v1
@@ -150,8 +148,7 @@ jobs:
       contents: write              # upload .vcvplugin assets to the release
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - uses: ./.github/actions/init-submodules
 
       - name: Generate AMY drum data
         # The gamma9001 generator is stdlib-only (no numpy). patches.h is
@@ -218,8 +215,7 @@ jobs:
       RACK_SDK_VERSION: 2.6.6
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - uses: ./.github/actions/init-submodules
 
       - name: Generate AMY drum data
         run: |
@@ -291,8 +287,7 @@ jobs:
           echo "Vercel token OK for bwhitmans-projects."
 
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - uses: ./.github/actions/init-submodules
 
       # --- Web stage/ (amy + amyboard WASM + static) ---
       - uses: actions/setup-python@v5

--- a/.github/workflows/tulip-pr-preview.yml
+++ b/.github/workflows/tulip-pr-preview.yml
@@ -18,6 +18,8 @@ on:
       - 'tulip/shared/**'
       - 'assets/**'
       - '.github/workflows/tulip-pr-preview.yml'
+      # Decides which submodules exist at build time, so treat it as a build input.
+      - '.github/actions/init-submodules/action.yml'
 
 permissions:
   contents: read
@@ -46,8 +48,7 @@ jobs:
           echo "Vercel token OK for bwhitmans-projects."
 
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - uses: ./.github/actions/init-submodules
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/tulip-release.yml
+++ b/.github/workflows/tulip-release.yml
@@ -47,9 +47,7 @@ jobs:
       contents: write                # create + clobber the 'tulip' release
     steps:
       - uses: actions/checkout@v4
-        with:
-          # amy + micropython (and nested submodules) are needed to build.
-          submodules: recursive
+      - uses: ./.github/actions/init-submodules
 
       - name: Build TULIP4_R11 firmware + assemble images
         uses: espressif/esp-idf-ci-action@v1
@@ -132,8 +130,7 @@ jobs:
       contents: write                # upload Tulip_Desktop.zip to the 'tulip' release
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - uses: ./.github/actions/init-submodules
 
       - name: Build Tulip Desktop (universal binary)
         run: |
@@ -265,8 +262,7 @@ jobs:
       contents: write              # upload Tulip_Desktop_Windows.zip to the 'tulip' release
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - uses: ./.github/actions/init-submodules
 
       - name: Generate AMY drum data
         # stdlib-only generator; the build script touches patches.h itself.

--- a/.github/workflows/tulip-web-release.yml
+++ b/.github/workflows/tulip-web-release.yml
@@ -44,8 +44,7 @@ jobs:
           echo "Vercel token OK for bwhitmans-projects."
 
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - uses: ./.github/actions/init-submodules
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Follow-up to the "why is CI slow" question. I timed a real run before changing anything — successful AMYboard preview [`30281303677`](https://github.com/shorepine/tulipcc/actions/runs/30281303677), 965s total:

| Phase | Time | Share |
|---|---|---|
| `git submodule update --init --recursive` | **340s** | **35%** |
| esp-idf build (both targets) | ~423s | 44% |
| emsdk + web stage + Vercel | ~180s | 19% |

Submodule checkout costs more than the firmware build.

## Why it's so slow

`submodules: recursive` clones **85 repositories**. The recursion walks `micropython/lib/pico-sdk` → `tinyusb` → `hw/mcu/<every vendor SDK>`. From the run log, the worst offenders:

- `nuclei-sdk` — 32s
- `nxp/mcux-sdk` — 19s
- `nxp/lpcopen` — 10s
- `nrfx`, `stm32lib` — 7s each
- …plus `ch32v307`, `infineon/mtb-xmclib-cat3`, `btstack`, and dozens more

Those are the RP2040 and STM32 ports. We build esp32s3, macOS, Linux and WASM, and don't read a single file from that tree.

## The change

A shared composite action initializing exactly the set [`tulip/shared/grab_submodules.sh`](tulip/shared/grab_submodules.sh) already uses for a local build — **8 repos instead of 85** — applied at all 10 checkout sites across the 5 workflows. Still `--depth 1`, which is what `actions/checkout` already passed to its own recursive update, so that's not a new constraint.

It has to be a separate step rather than a wrapper around `actions/checkout`: a local `./.github/actions/...` reference only resolves once the repo is on disk, so the checkout can't live inside it.

Keeping one list (rather than a minimal per-target set) is deliberate — it's a superset of any single target's needs, so there are no per-workflow variants to drift out of sync with the local build script.

## Two things I checked rather than assumed

**`tinycc` is deliberately not in the list.** It only powers `tulip.install_c_process()` on macOS desktop; `tulip/macos/build.sh` inits and builds it itself; and [`tulip/macos/Makefile:296`](tulip/macos/Makefile:296) gates the feature on `libtcc.a` existing. The desktop release job runs `make` directly rather than `build.sh`, so `libtcc.a` is never built there and the feature is *already* compiled out in CI today. Dropping the clone changes nothing but the clock. (On ESP the same feature goes through `espressif__elf_loader`, not tinycc.)

**The container does not re-run `git submodule update`.** The comment at [amyboard-pr-preview.yml:105](.github/workflows/amyboard-pr-preview.yml:105) warns that it does, which would have undone the pruning. Grepping the run log, the only `submodule update` is `actions/checkout`'s own. Left the comment alone since the `git add amy` it justifies is still correct practice.

## Testing

This PR is its own test. It touches both preview workflows, so both trigger, and between them they build AMYboard firmware, Tulip firmware, and both WASM web apps — every target that could plausibly miss a submodule. A green run **is** the verification; compare its checkout step against the 340s baseline above.

Also added the action to both PR-preview path filters, since it decides what exists at build time — without that, editing it alone would rebuild nothing.

## Not in this PR

Persisting ccache across runs. `IDF_CCACHE_ENABLE=1` is already set, so ccache works *within* a run (that's why the two firmware targets share a job) but starts cold every time. The catch is that the compile happens inside the esp-idf container as root, so `~/.ccache` is `/root/.ccache` *in the container* — an `actions/cache` on the runner's `~/.ccache` would cache an empty directory. It needs `CCACHE_DIR` pointed at a bind-mounted workspace path. Worth doing separately, on top of a known-good baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)