### PR TITLE
ci: persist the esp-idf ccache across runs

### DIFF
--- a/.github/workflows/amyboard-pr-preview.yml
+++ b/.github/workflows/amyboard-pr-preview.yml
@@ -148,10 +148,24 @@ jobs:
           restore-keys: esp-idf-ccache-v5.4.1-
 
       # --- Firmware (.bin sets) ---
-      # Build AMYBOARD then TULIP4_R11 in ONE esp-idf container: the two targets
-      # share most sources, so the second build hits ccache for the common units
-      # (we enable IDF_CCACHE_ENABLE) instead of recompiling from scratch. The
-      # Tulip firmware is what the HW CI bench flashes onto the physical Tulip
+      # Build AMYBOARD then TULIP4_R11 in ONE esp-idf container.
+      #
+      # This comment used to claim the second target hits ccache for the units
+      # the two boards share. Measured on the cold run of #1249, that is false:
+      # 14 hits out of 2829 cacheable calls (0.49%). The boards share sources but
+      # not compile *flags* -- different -D sets (AMYBOARD/GAMMA9001/MAKERFABS vs
+      # the TULIP4_R11 set), different build/config include paths, different
+      # -fmacro-prefix-map -- and any of those changes the hash. So there is
+      # effectively no cross-board reuse, and the real ccache win is cross-RUN
+      # (same board, same flags), which is what the cache steps above are for.
+      #
+      # The single job still earns its keep for other reasons: both firmwares
+      # have to land in one workspace to be bundled into stage/ and deployed, and
+      # splitting would pay checkout + submodule init twice. Worth revisiting as
+      # parallel jobs if firmware time dominates again -- the ccache rationale
+      # for keeping them together no longer holds.
+      #
+      # The Tulip firmware is what the HW CI bench flashes onto the physical Tulip
       # (it shares the AMYboard bench); see tulip/amyboard/hwci/tulip_hwci.py.
       - name: Build AMYboard + Tulip firmware
         uses: espressif/esp-idf-ci-action@v1

--- a/.github/workflows/amyboard-pr-preview.yml
+++ b/.github/workflows/amyboard-pr-preview.yml
@@ -127,6 +127,26 @@ jobs:
           # `git submodule update` can't revert amy to main's pin.
           git add amy
 
+      # ccache has to live in the workspace, not ~/.ccache: the compile below
+      # runs as root INSIDE the esp-idf container, where $HOME is the
+      # container's own /root. Only the bind-mounted workspace comes back to
+      # the runner, so that is the only place actions/cache can see.
+      # Pre-create it as the runner so a cache miss doesn't leave ccache to
+      # create it as root with 0700, which the post-job steps couldn't read.
+      - name: Prepare ccache dir
+        run: mkdir -p .ccache
+
+      # Restore-only on PRs, deliberately. A cache saved from a PR branch is
+      # scoped to that branch -- invisible to other PRs and to main -- so
+      # saving here would be upload time spent for nobody. Entries come from
+      # the release workflows on main, which build these same two boards.
+      - name: Restore esp-idf ccache
+        uses: actions/cache/restore@v4
+        with:
+          path: .ccache
+          key: esp-idf-ccache-v5.4.1-${{ github.sha }}
+          restore-keys: esp-idf-ccache-v5.4.1-
+
       # --- Firmware (.bin sets) ---
       # Build AMYBOARD then TULIP4_R11 in ONE esp-idf container: the two targets
       # share most sources, so the second build hits ccache for the common units
@@ -141,6 +161,8 @@ jobs:
           path: tulip/amyboard
           command: >-
             export IDF_CCACHE_ENABLE=1 &&
+            export CCACHE_DIR="$(cd ../.. && pwd)/.ccache" &&
+            export CCACHE_MAXSIZE=800M &&
             python -m pip install littlefs-python &&
             idf.py -DMICROPY_BOARD=AMYBOARD build &&
             cd .. &&
@@ -148,7 +170,8 @@ jobs:
             cd esp32s3 &&
             idf.py -DMICROPY_BOARD=TULIP4_R11 build &&
             cd .. &&
-            python fs_create.py tulip
+            python fs_create.py tulip &&
+            (ccache -s || true)
 
       - name: Upload AMYboard firmware artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/amyboard-release.yml
+++ b/.github/workflows/amyboard-release.yml
@@ -57,6 +57,20 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/init-submodules
 
+      # See amyboard-pr-preview.yml for why ccache lives in the workspace
+      # rather than ~/.ccache. This job runs on main, so unlike the PR previews
+      # it also SAVES -- PR runs can only read caches from the default branch,
+      # so main is the only place that can populate one for them.
+      - name: Prepare ccache dir
+        run: mkdir -p .ccache
+
+      - name: Restore esp-idf ccache
+        uses: actions/cache/restore@v4
+        with:
+          path: .ccache
+          key: esp-idf-ccache-v5.4.1-${{ github.sha }}
+          restore-keys: esp-idf-ccache-v5.4.1-
+
       - name: Build AMYboard firmware + assemble images
         uses: espressif/esp-idf-ci-action@v1
         with:
@@ -64,10 +78,30 @@ jobs:
           target: esp32s3
           path: tulip/amyboard
           command: >-
+            export IDF_CCACHE_ENABLE=1 &&
+            export CCACHE_DIR="$(cd ../.. && pwd)/.ccache" &&
+            export CCACHE_MAXSIZE=800M &&
             python -m pip install littlefs-python &&
             idf.py -DMICROPY_BOARD=AMYBOARD build &&
             cd .. &&
-            python fs_create.py amyboard
+            python fs_create.py amyboard &&
+            (ccache -s || true)
+
+      # The container wrote these as root; actions/cache runs as the runner.
+      - name: Reclaim ccache ownership after the root container build
+        if: always()
+        run: sudo chown -R "$(id -u):$(id -g)" .ccache
+
+      # Shared key namespace with tulip-release on purpose: each job restores
+      # the newest entry and saves a superset, so over successive merges the one
+      # cache accumulates objects for both boards. Concurrent runs can race and
+      # one save loses the other's additions -- that self-heals on the next run.
+      - name: Save esp-idf ccache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: .ccache
+          key: esp-idf-ccache-v5.4.1-${{ github.sha }}
 
       - name: Upload firmware artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tulip-release.yml
+++ b/.github/workflows/tulip-release.yml
@@ -49,6 +49,20 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/init-submodules
 
+      # See amyboard-pr-preview.yml for why ccache lives in the workspace
+      # rather than ~/.ccache. This job runs on main, so unlike the PR previews
+      # it also SAVES -- PR runs can only read caches from the default branch,
+      # so main is the only place that can populate one for them.
+      - name: Prepare ccache dir
+        run: mkdir -p .ccache
+
+      - name: Restore esp-idf ccache
+        uses: actions/cache/restore@v4
+        with:
+          path: .ccache
+          key: esp-idf-ccache-v5.4.1-${{ github.sha }}
+          restore-keys: esp-idf-ccache-v5.4.1-
+
       - name: Build TULIP4_R11 firmware + assemble images
         uses: espressif/esp-idf-ci-action@v1
         with:
@@ -56,10 +70,30 @@ jobs:
           target: esp32s3
           path: tulip/esp32s3
           command: >-
+            export IDF_CCACHE_ENABLE=1 &&
+            export CCACHE_DIR="$(cd ../.. && pwd)/.ccache" &&
+            export CCACHE_MAXSIZE=800M &&
             python -m pip install littlefs-python &&
             idf.py -DMICROPY_BOARD=TULIP4_R11 build &&
             cd .. &&
-            python fs_create.py tulip
+            python fs_create.py tulip &&
+            (ccache -s || true)
+
+      # The container wrote these as root; actions/cache runs as the runner.
+      - name: Reclaim ccache ownership after the root container build
+        if: always()
+        run: sudo chown -R "$(id -u):$(id -g)" .ccache
+
+      # Shared key namespace with amyboard-release on purpose: each job restores
+      # the newest entry and saves a superset, so over successive merges the one
+      # cache accumulates objects for both boards. Concurrent runs can race and
+      # one save loses the other's additions -- that self-heals on the next run.
+      - name: Save esp-idf ccache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: .ccache
+          key: esp-idf-ccache-v5.4.1-${{ github.sha }}
 
       - name: Upload firmware artifacts
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,7 @@ _autosave-*
 *-save.kicad_pcb
 fp-info-cache
 *.lck
+
+# CI ccache dir (see .github/workflows/amyboard-pr-preview.yml) -- lives in the
+# workspace because the esp-idf build runs as root inside a container.
+.ccache/


### PR DESCRIPTION
Follow-up to #1248. That one killed the 340s submodule clone; this goes after the other half — the ~420s esp-idf compile.

`IDF_CCACHE_ENABLE=1` was already set on the preview build (that's *why* the two firmware targets share one job — the second hits the warm cache). But it started cold every run, because nothing carried the cache between runs.

## Two traps this had to avoid

**1. `~/.ccache` is the wrong path, and would have failed silently.** The compile runs as root *inside* the esp-idf container, where `$HOME` is the container's own `/root`. An `actions/cache` on the runner's `~/.ccache` would have archived an empty directory, reported success, and shown a 0% hit rate forever with nothing obviously wrong.

`CCACHE_DIR` now points into the bind-mounted workspace, computed as `$(cd ../.. && pwd)/.ccache` from the build directory — relative, so it doesn't depend on where `esp-idf-ci-action` chooses to mount things (currently `/app/shorepine/tulipcc`, which is not what you'd guess).

**2. Cache scope.** A cache saved from a PR branch is visible only to that branch — not to other PRs, not to main. PR runs saving their own would be pure upload time for nobody. But PR runs *can* read the default branch's caches. So:

- **PR previews restore only** (`actions/cache/restore`)
- **The two release firmware jobs restore and save** — they run on `main`, so they're the only ones that can populate a cache PRs will actually see

Both release jobs share one key namespace deliberately: each restores the newest entry and saves a superset, so the single cache accumulates objects for both boards over successive merges. Concurrent runs can race and one save drops the other's additions — self-heals on the next run.

## Also

- `.ccache` is pre-created as the runner, so a cache miss doesn't leave ccache to create it root-owned `0700` and break the save.
- Chowned back before saving, since the container wrote as root.
- `ccache -s` at the end of each build so the hit rate is visible in the log. Wrapped in `|| true` — a stats command should never be able to fail a build.
- `CCACHE_MAXSIZE=800M`, comfortably above the ~200-300MB two board configs should produce, while keeping the cache upload/download quick.

## What to expect from *this* PR's run

**Roughly nothing, and that's the expected result.** No cache exists under the new key yet, and this PR can't create one PRs can read — only a merge to `main` can. So the preview here should be a normal-speed cold build; what it proves is that the plumbing doesn't break anything and that `ccache -s` reports sane numbers.

The payoff shows up on the *next* PR after this merges and one release run has populated the cache. Most of the ~1400 objects in a firmware build are IDF components (mbedtls, lwip, freertos, esp_wifi) that don't change between PRs, so the hit rate should be high for anything not touching `tulip/shared`.

I'd suggest merging on the strength of a green run plus the `ccache -s` output, then checking the *following* PR's build time to see the actual win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)