### PR TITLE
TEST ONLY — do not merge: measure the ccache from #1249

### DIFF
--- a/tulip/shared/tsequencer.c
+++ b/tulip/shared/tsequencer.c
@@ -39,7 +39,7 @@ void tulip_amy_sequencer_hook(uint32_t tick_count) {
 
 void tsequencer_init() {
     for(uint8_t i=0;i<SEQUENCER_SLOTS;i++) { sequencer_callbacks[i] = NULL; sequencer_period[i] = 0; sequencer_tick[i] = 0; }
-    for(uint8_t i=0;i<DEFER_SLOTS;i++) { defer_callbacks[i] = NULL; defer_sysclock[i] = 0; }
+    for(uint8_t i=0;i<DEFER_SLOTS;i++) { defer_callbacks[i] = NULL; defer_sysclock[i] = 0; defer_args[i] = NULL; }
     #ifndef AMY_IS_EXTERNAL
     amy_global.config.amy_external_sequencer_hook = tulip_amy_sequencer_hook;
     #endif


### PR DESCRIPTION
**Throwaway PR. Not for merge** — it exists to measure the cross-run ccache from #1249 against a real C change.

Changes exactly one line in one leaf `.c` file, so the build has a single genuine cache miss to work with. The change is real but inert: `tsequencer_init()` cleared `defer_callbacks` and `defer_sysclock` but not `defer_args`, while the cleanup path in `tulip_amy_sequencer_hook()` clears all three. Harmless today (the array is zero-initialized, and `defer_args[i]` is only read when `defer_callbacks[i]` is non-NULL). Picked because it's one line in one translation unit and defensible rather than noise.

## This run is an unintended A/B, because I shipped a bug in #1249

Both release firmware jobs key their cache on `esp-idf-ccache-v5.4.1-${{ github.sha }}`. On a push that triggers both, that is the **same SHA**, so the second save always collides with the first and is dropped. Not the occasional race I described in #1249 — a guaranteed one, every push. From the release runs on `693d29cd`:

- **AMYboard release** — `Cache saved with key: esp-idf-ccache-v5.4.1-693d29cd…` (33.48 MiB, 1267 objects)
- **Tulip firmware release** — finished 37s later, **no** "Cache saved" line; its 1562 objects were discarded

So the only cache in the repo holds **AMYBOARD objects only**. Which means this one preview run builds:

- **AMYBOARD** — against a warm cache
- **TULIP4_R11** — against nothing

Same runner, same commit, back to back. That's a cleaner isolation of the ccache effect than a before/after across two runs would have given, so I'm taking the measurement before fixing the key.

Fix (per-board key namespaces, and the preview restoring both) goes up separately.