### PR TITLE
ci: namespace the ccache key per board so the two saves stop colliding

### DIFF
--- a/.github/workflows/amyboard-pr-preview.yml
+++ b/.github/workflows/amyboard-pr-preview.yml
@@ -140,12 +140,26 @@ jobs:
       # scoped to that branch -- invisible to other PRs and to main -- so
       # saving here would be upload time spent for nobody. Entries come from
       # the release workflows on main, which build these same two boards.
-      - name: Restore esp-idf ccache
+      #
+      # TWO restores, one per board, because this job builds both and the two
+      # release workflows each save only their own (they fire on the same push,
+      # so a single shared key would have them collide -- see either release
+      # workflow). Extracting both into the same .ccache unions them: ccache
+      # storage is content-addressed, so the two sets of objects live in
+      # disjoint paths and neither restore clobbers the other's entries.
+      - name: Restore esp-idf ccache (AMYBOARD)
         uses: actions/cache/restore@v4
         with:
           path: .ccache
-          key: esp-idf-ccache-v5.4.1-${{ github.sha }}
-          restore-keys: esp-idf-ccache-v5.4.1-
+          key: esp-idf-ccache-v5.4.1-AMYBOARD-${{ github.sha }}
+          restore-keys: esp-idf-ccache-v5.4.1-AMYBOARD-
+
+      - name: Restore esp-idf ccache (TULIP4_R11)
+        uses: actions/cache/restore@v4
+        with:
+          path: .ccache
+          key: esp-idf-ccache-v5.4.1-TULIP4_R11-${{ github.sha }}
+          restore-keys: esp-idf-ccache-v5.4.1-TULIP4_R11-
 
       # --- Firmware (.bin sets) ---
       # Build AMYBOARD then TULIP4_R11 in ONE esp-idf container.

--- a/.github/workflows/amyboard-release.yml
+++ b/.github/workflows/amyboard-release.yml
@@ -64,12 +64,17 @@ jobs:
       - name: Prepare ccache dir
         run: mkdir -p .ccache
 
+      # Key is namespaced by BOARD. Both release workflows fire on the same push,
+      # so a key of just <prefix>-${{ github.sha }} is identical in both jobs:
+      # whichever finishes first saves, the other collides and is silently
+      # dropped. That is deterministic, not a race -- measured on 693d29cd,
+      # where TULIP4_R11's 1562 objects were discarded every time.
       - name: Restore esp-idf ccache
         uses: actions/cache/restore@v4
         with:
           path: .ccache
-          key: esp-idf-ccache-v5.4.1-${{ github.sha }}
-          restore-keys: esp-idf-ccache-v5.4.1-
+          key: esp-idf-ccache-v5.4.1-AMYBOARD-${{ github.sha }}
+          restore-keys: esp-idf-ccache-v5.4.1-AMYBOARD-
 
       - name: Build AMYboard firmware + assemble images
         uses: espressif/esp-idf-ci-action@v1
@@ -92,16 +97,12 @@ jobs:
         if: always()
         run: sudo chown -R "$(id -u):$(id -g)" .ccache
 
-      # Shared key namespace with tulip-release on purpose: each job restores
-      # the newest entry and saves a superset, so over successive merges the one
-      # cache accumulates objects for both boards. Concurrent runs can race and
-      # one save loses the other's additions -- that self-heals on the next run.
       - name: Save esp-idf ccache
         if: always()
         uses: actions/cache/save@v4
         with:
           path: .ccache
-          key: esp-idf-ccache-v5.4.1-${{ github.sha }}
+          key: esp-idf-ccache-v5.4.1-AMYBOARD-${{ github.sha }}
 
       - name: Upload firmware artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tulip-release.yml
+++ b/.github/workflows/tulip-release.yml
@@ -56,12 +56,17 @@ jobs:
       - name: Prepare ccache dir
         run: mkdir -p .ccache
 
+      # Key is namespaced by BOARD. Both release workflows fire on the same push,
+      # so a key of just <prefix>-${{ github.sha }} is identical in both jobs:
+      # whichever finishes first saves, the other collides and is silently
+      # dropped. That is deterministic, not a race -- measured on 693d29cd,
+      # where this job's 1562 objects were the ones discarded.
       - name: Restore esp-idf ccache
         uses: actions/cache/restore@v4
         with:
           path: .ccache
-          key: esp-idf-ccache-v5.4.1-${{ github.sha }}
-          restore-keys: esp-idf-ccache-v5.4.1-
+          key: esp-idf-ccache-v5.4.1-TULIP4_R11-${{ github.sha }}
+          restore-keys: esp-idf-ccache-v5.4.1-TULIP4_R11-
 
       - name: Build TULIP4_R11 firmware + assemble images
         uses: espressif/esp-idf-ci-action@v1
@@ -84,16 +89,12 @@ jobs:
         if: always()
         run: sudo chown -R "$(id -u):$(id -g)" .ccache
 
-      # Shared key namespace with amyboard-release on purpose: each job restores
-      # the newest entry and saves a superset, so over successive merges the one
-      # cache accumulates objects for both boards. Concurrent runs can race and
-      # one save loses the other's additions -- that self-heals on the next run.
       - name: Save esp-idf ccache
         if: always()
         uses: actions/cache/save@v4
         with:
           path: .ccache
-          key: esp-idf-ccache-v5.4.1-${{ github.sha }}
+          key: esp-idf-ccache-v5.4.1-TULIP4_R11-${{ github.sha }}
 
       - name: Upload firmware artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Fixes a defect I shipped in #1249.

Both release firmware jobs keyed their cache on `esp-idf-ccache-v5.4.1-${{ github.sha }}`. Both workflows fire on the same push, so that key is **identical in both jobs** — whichever finishes first saves, the second collides and is silently dropped.

I described this in #1249 as a race that "self-heals on the next run." It is neither a race nor self-healing: same SHA every push means the collision is deterministic, and the losing job's objects are never stored at all. The restore side compounded it — each job restores at job start, before the other has saved, so neither ever accumulates the other's objects. The "saves a superset" reasoning was simply wrong.

## Measured on `693d29cd`

| Job | Objects | Save result |
|---|---|---|
| AMYboard release | 1267 | `Cache saved with key: esp-idf-ccache-v5.4.1-693d29cd…` — 33.48 MiB |
| Tulip firmware release | 1562 | finished 37s later, **no** "Cache saved" line — discarded |

`gh cache list` showed one entry, holding one board.

## The fix

Keys are namespaced per board — `…-AMYBOARD-<sha>` and `…-TULIP4_R11-<sha>` — so each release job owns its own entry and neither can clobber the other.

The PR preview builds *both* boards, so it now performs **two** restores into the same `.ccache`. That union is safe: ccache storage is content-addressed, so the two object sets land in disjoint paths and neither extraction overwrites the other's entries.

## Expectations

This PR's own preview will be a **cold build** — the existing cache sits under the old key and nothing has been saved under the new ones yet. First warm preview comes after this merges and both release workflows have run once.

#1250 (throwaway, not for merge) measures the effect against the current AMYBOARD-only cache; see the numbers there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)