### PR TITLE
Put sequencer callbacks back on ticks=t; document the fs/ flash step

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,27 @@ The easiest ways to test `tulipcc` are:
 
 `webdev.py` builds AMY once, builds each app's `stage/`, serves each at its own document root (so absolute `/img`, `/editor/`, `/run/` paths match production), and rebuilds an app when its `static/`, `site/` or the shared `assets/` change. To work on a single app instead: `python3 dev.py` in `tulip/amyboardweb` (AMYboard Web, live file-watching — see its `CLAUDE.md`), or `./build.sh` in `tulip/web` to build Tulip Web's `stage/` (what CI runs).
 
+### Python reaches the device by two different routes
+
+Only one of them is a firmware flash, and mixing them up looks exactly like a
+runtime bug:
+
+- `tulip/shared/py/*.py` (`synth.py`, `arpegg.py`, `sequencer.py`, `midi.py`, …)
+  are **frozen into the firmware**, so a normal build + flash picks them up.
+- `tulip/fs/**` (the bundled examples in `tulip/fs/tulip/ex/`, etc.) live on the
+  **device filesystem** and are **not** part of a firmware flash. They need a
+  separate step, run from `tulip/`:
+
+  ```
+  python fs_create.py tulip flash
+  ```
+
+Forget the second one and an edited example silently keeps running its *old*
+copy on device while your firmware-side edits appear to work — which reads as a
+mysterious behavioral bug in code you just changed. When on-device behavior
+contradicts the source in front of you, check which of these two routes the file
+takes before debugging the code.
+
 ## ESP-IDF Build Commands (Required)
 
 If the user asks to build `amyboard`, or asks to build `tulip cc` / `tulip esp32s3`, first run:

--- a/docs/music.md
+++ b/docs/music.md
@@ -213,7 +213,7 @@ syn = synth.PatchSynth(num_voices=1, patch=143)  # DX7 BASS 2
 seq = None
 
 def note(t):
-    syn.note_on(random.choice(chord), 0.6)
+    syn.note_on(random.choice(chord), 0.6, ticks=t)
 
 def start():
     global seq
@@ -247,7 +247,7 @@ import tulip, midi, music, random, sequencer, synth
 
 def note(t):
     global app
-    app.syn.note_on(random.choice(app.chord), 0.6)
+    app.syn.note_on(random.choice(app.chord), 0.6, ticks=t)
 
 def start(app):
     app.seq = sequencer.TulipSequence(8, note)

--- a/tulip/shared/py/arpegg.py
+++ b/tulip/shared/py/arpegg.py
@@ -63,13 +63,12 @@ class ArpeggiatorSynth:
 
     def arp_step(self,t):
         if(self.running):
-            # t is the AMY tick this step fired on, but tsequencer.c hands us
-            # to mp_sched_schedule, so we always run a little after it. AMY
-            # drops a one-off ticks= whose tick has already passed, so we
-            # can't schedule for t -- play now instead. (Matches what the old
-            # time=t did: t was a tick count fed to a milliseconds parameter,
-            # i.e. always in the past, i.e. always played immediately.)
-            self.next_note()
+            # t is the AMY tick this step fired on. tsequencer.c hands us to
+            # mp_sched_schedule, so we run a little after it -- scheduling for
+            # t anyway pins the note to the beat whenever we're punctual, and
+            # AMY plays a tick that's already gone rather than dropping it, so
+            # running late costs a fraction of a tick instead of the note.
+            self.next_note(ticks=t)
 
     def run(self):
         # Prepare to start a new sequence at the first note.

--- a/tulip/web/static/examples.js
+++ b/tulip/web/static/examples.js
@@ -1202,14 +1202,14 @@ prev_midi_val = 60
 def beat_callback(t):
     global app, cnt, prev_midi_val
     
-    # t is the tick this step fired on, but the callback runs just after it,
-    # and AMY drops a one-off ticks= that's already in the past -- so play now.
+    # t is the tick this step fired on; scheduling for it keeps the note on
+    # the beat even though this callback runs a moment later.
     midi_val = app.grid.get_note_in_column(cnt)
     if midi_val > 0:
-        app.synth.note_on(midi_val, 0.6)
+        app.synth.note_on(midi_val, 0.6, ticks=t)
         prev_midi_val = midi_val
     else:
-        app.synth.note_off(prev_midi_val)
+        app.synth.note_off(prev_midi_val, ticks=t)
 
     cnt += 1
     if cnt > NoteGrid.TIMES - 1:


### PR DESCRIPTION
Two loose ends from the `ticks=` migration.

## Sequencer callbacks go back to `ticks=t`

A sequencer callback is handed the AMY tick it fired on, but `tsequencer.c` dispatches it via `mp_sched_schedule`, so it always runs a moment *after* that tick. Back when AMY dropped a one-off `ticks=` whose tick had already passed, scheduling for `t` meant silence — that's what made the arpeggiator play nothing, and why `arpegg.py`, the web note-grid example and two `docs/music.md` snippets were changed to drop the kwarg and just play at dispatch time.

shorepine/amy#1036 made a due-or-overdue one-off play immediately instead of dropping it, so passing the tick back is now strictly better:

- a punctual callback puts the note exactly on the beat;
- a late one costs a fraction of a tick, instead of the entire note.

This needs the amy currently pinned here (`a0f74f50`), which includes it — verified directly: `ticks=t` with `t` 103 ticks in the past now sounds (peak 0.1178) where it was silent before.

Restored in `tulip/shared/py/arpegg.py`, `tulip/web/static/examples.js` (`beat_callback`), and the two `docs/music.md` sequencer examples.

## Document the `tulip/fs/` flash step

Python reaches the device by two routes and only one of them is a firmware flash:

- `tulip/shared/py/*.py` is **frozen into the firmware** — a normal build + flash picks it up.
- `tulip/fs/**` lives on the **device filesystem** and needs `python fs_create.py tulip flash` separately.

Missing the second one is genuinely nasty to debug: an edited example silently keeps running its *old* copy on device while firmware-side edits appear to work, so it presents as a mysterious bug in code you just changed. That's exactly what happened with `xanadu.py` while chasing this migration — the arpeggiator fix rode along in firmware, the example didn't. Now written down in `AGENTS.md` (which `CLAUDE.md` symlinks to).

## Testing

`tulip/macos/build.sh` builds clean. `arpegg.py` and the edited `examples.js` snippet both parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
