### PR TITLE
vcv: drop the removed time argument from amy_event_midi_message_received

### DIFF
--- a/tulip/vcvrack/src/AmyBoard.cpp
+++ b/tulip/vcvrack/src/AmyBoard.cpp
@@ -158,7 +158,7 @@ struct AmyModule : Module {
             uint8_t sysex = (msg.bytes[0] == 0xF0);
             if (sysex && amyboard_vcv_shorepine_frame(msg.bytes.data(), (int)len))
                 continue;
-            amy_event_midi_message_received(msg.bytes.data(), len, sysex, amy_sysclock());
+            amy_event_midi_message_received(msg.bytes.data(), len, sysex);
         }
 
         // AMY/firmware MIDI OUT (AKs, zI OK, zD dumps, tulip.midi_out) ->

--- a/tulip/vcvrack/src/vcv_midi.c
+++ b/tulip/vcvrack/src/vcv_midi.c
@@ -32,7 +32,7 @@
 #include <pthread.h>
 
 extern void convert_midi_bytes_to_messages(uint8_t *data, size_t len, uint8_t usb);
-extern void amy_event_midi_message_received(uint8_t *data, uint32_t len, uint8_t sysex, uint32_t time);
+extern void amy_event_midi_message_received(uint8_t *data, uint32_t len, uint8_t sysex);
 extern uint32_t amy_sysclock(void);
 void midi_out(uint8_t *bytes, uint16_t len);
 // mp_embed.c: queue a shorepine control payload for the MP thread (which
@@ -70,7 +70,7 @@ static void handle_sysex_frame(uint8_t *frame, int len) {
         return;
     }
     // Non-shorepine sysex: hand to the firmware's Python midi callback path.
-    amy_event_midi_message_received(frame, (uint32_t)len, 1, amy_sysclock());
+    amy_event_midi_message_received(frame, (uint32_t)len, 1);
 }
 
 // Feed raw MIDI 1.0 bytes (possibly containing partial sysex across calls).

--- a/tulip/vcvrack/test/board_smoke.c
+++ b/tulip/vcvrack/test/board_smoke.c
@@ -59,10 +59,10 @@ int main(void) {
     render_seconds("boot + default sketch", 2.0f);
 
     uint8_t note_on[3] = {0x90, 60, 100};
-    amy_event_midi_message_received(note_on, 3, 0, amy_sysclock());
+    amy_event_midi_message_received(note_on, 3, 0);
     render_seconds("juno note on ch1", 1.0f);
     uint8_t note_off[3] = {0x80, 60, 0};
-    amy_event_midi_message_received(note_off, 3, 0, amy_sysclock());
+    amy_event_midi_message_received(note_off, 3, 0);
 
     // CV in visible from Python?
     amyboard_vcv_cv_in[0] = 3.25f;


### PR DESCRIPTION
Fixes the broken `AMYboard release` on main — [run 30830406291](https://github.com/shorepine/tulipcc/actions/runs/30830406291) (`vcv-lin-win` and `vcv-mac` both fail; `web` and `firmware` pass).

## Cause

amy [`7e77017`](https://github.com/shorepine/amy/commit/7e770179efaed2b4077004c9d66fc541cb49ff9f) ("midi: drop the dead time argument") removed the trailing `uint32_t time` parameter from `amy_event_midi_message_received()`. That commit's message says *"Nothing outside `src/` called these at all"* — but the VCV plugin does, so the amy pin bump (#1278) merged green and broke main:

```
src/AmyBoard.cpp:161:44: error: too many arguments to function
  'void amy_event_midi_message_received(uint8_t*, uint32_t, uint8_t)'
```

Three call sites, all in `tulip/vcvrack/`. Only `AmyBoard.cpp` errored because it includes `amy.h` and therefore sees the real declaration; `vcv_midi.c` declares its **own** 4-arg `extern`, so it compiled and linked while quietly passing an argument the callee no longer takes. Fixed here as well, along with the `board_smoke.c` test harness (not built by `make dist`, so it wasn't part of the CI failure).

The removed parameter was already dead — `amy_midi.c` declared it `AMY_UNSET_VALUE(time)` and never reassigned it — so dropping the argument is behaviour-preserving.

## Verification

Built the mac-arm64 plugin locally with the same steps as the `vcv-mac` job (Rack SDK 2.6.6): builds clean with zero errors, both changed translation units compiled, produces `AMYboard-2.0.0-mac-arm64.vcvplugin`. The lin/win jobs failed with the identical error in the same file, so the same fix applies; those cross-build inside the docker toolchain and will be covered when this runs on main.

## Worth noting separately

**The VCV plugin is only built on push to `main`** (`amyboard-release.yml`) — `amyboard-pr-preview.yml` doesn't build it. So no PR, including the automated amy-pin PRs, can catch this class of break before it lands. Adding a compile-only VCV job to the PR preview workflow would close that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)