### PR TITLE
amyboard: recalibrate cv_in (removes -0.6V offset), document +6.3V input clip

### DIFF
--- a/docs/amyboard/modular.md
+++ b/docs/amyboard/modular.md
@@ -68,7 +68,7 @@ amyboard.set_cv_out(channel=0, synth=0)  # clear the CV mapping
 
 ## CV inputs
 
-AMYboard has **two CV inputs** on 3.5mm jacks, powered by an ADS1015 12-bit ADC (I2C address `0x48`). They accept **-10V to +10V**.
+AMYboard has **two CV inputs** on 3.5mm jacks, powered by an ADS1015 12-bit ADC (I2C address `0x48`). The jacks are safe with **-10V to +10V**, but the ADC can only resolve **-10V to about +6.3V** — voltages above +6.3V read as +6.3V.
 
 ```python
 import amyboard

--- a/tulip/amyboard/amyboard_support.c
+++ b/tulip/amyboard/amyboard_support.c
@@ -273,8 +273,11 @@ float cv_input_hook(uint16_t channel) {
 #ifdef ESP_PLATFORM
 // FreeRTOS task: reads both ADS1015 channels in a loop, updates cv_cached_value.
 void cv_read_task(void *pvParameter) {
-    int32_t min = 1058;  // -5V
-    int32_t max = 21312; // 5V
+    // Bench-calibrated (loopback vs multimeter, 2026-08-07): raw = 20080 + 2003*V.
+    // The ADC saturates at raw 32752 / raw 0, so the readable window is about
+    // -10V to +6.3V -- inputs above +6.3V clip (the jack itself is fine to ±10V).
+    int32_t min = 10064; // -5V
+    int32_t max = 30096; // +5V
     // Scan both CV channels once per AMY audio block (AMY_BLOCK_SIZE / AMY_SAMPLE_RATE,
     // ~5.8ms at 256/44100) so CV tracks the audio block cadence. Expressed in RTOS ticks,
     // rounded to nearest, so it follows the audio rate regardless of tick rate; clamped to
@@ -288,11 +291,12 @@ void cv_read_task(void *pvParameter) {
         for(uint8_t ch = 0; ch < 2; ch++) {
             if(!cv_local_override[ch]) {
                 int32_t raw = read_ads1015_raw(ch);  // Put uint16_t into int32_t.
+                // Map [min, max] -> [-5v, +5v]
                 cv_cached_value[ch] = (
                     (((float)(raw - min))
                      / ((float)(max - min)))
                     * 10.0
-                ) - 10.0;
+                ) - 5.0;
             }
         }
         xTaskDelayUntil(&last_wake, cv_period);

--- a/tulip/shared/amyboard-py/amyboard.py
+++ b/tulip/shared/amyboard-py/amyboard.py
@@ -908,7 +908,11 @@ def cv_out(volts, channel=0):
         tulip.vcv_cv_out(channel, volts)
         return
     addr = 88 # GP8413
-    # With rev1 scaling, 0x0000 -> -10v, 0x7fff -> +10v
+    # With rev1 scaling, 0x0000 -> -10v, 0x7fff -> +10v.
+    # The output stage (TL074, 30K/10K from A3V3) is gain 4 offset -9.9v,
+    # sized for the GP8413's power-up 0-5V range: jack = 4*dac - 9.9.
+    # Never write the DAC range register (0x01) to 10V mode -- it would
+    # double every output and clip positive voltages at the op-amp rail.
     val = int(((volts + 10)/20.0) * 0x8000)
     if(val < 0):
         val = 0


### PR DESCRIPTION
**Substantially revised after bench data — earlier revisions of this PR were wrong twice; see history below.**

## What bench loopback showed (cv_out 0 → cv_in 1, cv_out verified exact on a multimeter)

| commanded out | cv_in read (current main) | implied raw |
|---|---|---|
| -5V | -5.553 | 10064 |
| 0V | -0.600 | 20096 |
| +5V | +4.337 | 30096 |

The real ADC transfer is linear: **raw = 20080 + 2003·V**. Two conclusions:

1. The shipped constants (`min=1058`, `max=21312`) don't describe the hardware, **and** the formula offset was wrong (3a1dc56c halved the span for the 2.048V PGA but kept `-10.0`). The two errors nearly cancel: current `cv_in` ≈ `0.99·V − 0.61` — roughly right, off by a constant −0.6V. This PR replaces both with bench-derived constants (`min=10064` ↔ -5V, `max=30096` ↔ +5V) and the matching `[-5,+5]` mapping, zeroing the offset.
2. The ADC saturates at raw 32752 ≈ **+6.3V**. Pitch CV above that reads clipped (~+5.65 on current firmware) — very likely the original "quantizer output is several volts low" report, since a 1V/oct quantizer routinely sees 7–10V. Documented in `cv_read_task` and `modular.md` (the jack itself is fine to ±10V; only the reading clips).

## cv_out is correct as-is — never touch the DAC range register

Bench (±10V exact) + v1.0–v1.4 schematics: the TL074 stage is gain 4, offset −9.9V (30K feedback / 10K to A3V3), i.e. **jack = 4·V_DAC − 9.9**, sized for the GP8413's power-up 0–5V range. A comment in `cv_out()` now records that switching the DAC to 10V range would double every output and clip positives at the op-amp rail.

## Revision history (for the record)

- **rev 1** claimed cv_in read 5V low and initialized the DAC to 10V range — the range init would have broken cv_out (see above).
- **rev 2** kept only the formula offset fix (`-10.0` → `-5.0`) with the old constants — that alone would have made cv_in read ~4.4V *high*, since the old constants and old offset were cancelling.
- **rev 3 (this one)** fixes constants + formula together from measured data.

## Caveats

- Constants derived from one board, one channel (cv_in 1). A quick check of cv_in 0 and a second board (or `cv_cal()`) before merge would be prudent; per-board spread just shows up as a small residual offset either way.
- The remaining mystery from the original report is the standalone −4.8V cv_out measurement, which no firmware version reproduces (all revs' cv_out is accurate). Worth asking the reporter for board rev + `cv_out(10,0)`/`cv_out(-10,0)` multimeter readings — if they see ~+5 / ~−10.5 (clipped), their board's offset network is on a 5V rail instead of A3V3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)