### PR TITLE
docs: v1.5 boards need a CV DAC range fix at boot

### DIFF
--- a/docs/amyboard/modular.md
+++ b/docs/amyboard/modular.md
@@ -26,7 +26,12 @@ Most modular synthesis units operate at 10Vpp, where an audio signal swings betw
 
 ## CV outputs
 
-AMYboard has **two CV outputs** on 3.5mm jacks, powered by a GP8413 12-bit DAC (I2C address `0x58`). The outputs range from approximately **-10V to +10V**, suitable for controlling Eurorack pitch, filter cutoff, or any CV-controlled parameter.
+AMYboard has **two CV outputs** on 3.5mm jacks, powered by a GP8413 15-bit DAC (I2C address `0x58`). The outputs range from approximately **-10V to +10V**, suitable for controlling Eurorack pitch, filter cutoff, or any CV-controlled parameter.
+
+> **v1.5 boards:** the newest production revision powers up with the CV DAC in the
+> wrong range -- all CV outputs come out half-scale and 5V low (`cv_out(0)` reads
+> about -5V) until a one-line fix is run at boot. See
+> [Troubleshooting](troubleshooting.md#cv-out-voltages-are-wrong-v15-boards).
 
 ```python
 import amyboard

--- a/docs/amyboard/troubleshooting.md
+++ b/docs/amyboard/troubleshooting.md
@@ -105,6 +105,40 @@ We've fixed a lot of USB issues recently, so [upgrade to the latest firmware](fi
    - Cut the shield at one end of a DIN MIDI cable.
  - Future board revisions will lift the MIDI in sleeve in hardware -- see [issue #1198](https://github.com/shorepine/tulipcc/issues/1198).
 
+## CV out voltages are wrong (v1.5 boards)
+
+Boards from the newest production run (revision **v1.5**) power up with the CV DAC in
+the wrong output range, so every CV out voltage comes out **half scale and 5V low**:
+`cv_out(0, 0)` measures about **-5V** at the jack, `cv_out(5, 0)` about -2.5V, and
+nothing above ~0V is reachable. Pitch CV sounds several octaves flat. Earlier boards
+(v1.4 and before) are **not** affected.
+
+**Check whether your board is affected.** Connect via [serial](python.md) and run
+`amyboard.cv_out(0, 0)`, then measure CV out 1 with a multimeter -- or patch CV out 1
+to CV in 1 and read it back:
+
+```python
+import amyboard
+amyboard.cv_out(0, 0)
+amyboard.cv_in(0)   # close to 0V: your board is fine. Close to -5V: affected.
+```
+
+**The fix** -- switch the DAC to its 10V range. The setting does not survive a power
+cycle, so run this every boot, before any CV output (the top of your `sketch.py` is a
+good place):
+
+```python
+amyboard.get_i2c().writeto_mem(88, 0x01, bytes([0x11]))
+```
+
+> **Only run this on an affected board.** On v1.4 and earlier the same command
+> *doubles* every CV output (positive voltages slam into the +11V rail) -- the two
+> revisions use different analog output stages. Use the check above if you're not
+> sure which you have.
+
+A firmware update that handles this automatically is in the works; this page will be
+updated when it ships.
+
 ## Board won't boot / crashes on startup
 
  - **Safe mode**: Hold the BOOT button while AMYboard is powering up. This skips running your `sketch.py` and also runs a hardware self-test (audio input, CV in/out). You'll hear a chime if all tests pass. Once it finishes you'll have a normal REPL where you can fix or delete your sketch.


### PR DESCRIPTION
Documentation stopgap for the v1.5 CV out bug, while we wait on the v1.5 schematics from Makerfabs to design proper firmware auto-detection.

**What it documents** (bench-confirmed on multiple v1.5 units in the [PR #1284](https://github.com/shorepine/tulipcc/pull/1284) investigation):

- v1.5 boards power up with the GP8413 in the wrong output range: CV out spans −10..0V, `cv_out(0)` sits at ~−5V, pitch CV reads octaves flat.
- A loopback/multimeter check to tell revisions apart (nothing on the I2C bus distinguishes them — scan and register readback are identical across revs).
- The per-boot workaround: `amyboard.get_i2c().writeto_mem(88, 0x01, bytes([0x11]))` — with a prominent warning that v1.4-and-earlier boards must **not** run it (their gain-4 output stage is sized for the power-up range; the write doubles every output into the rail).

New section in `troubleshooting.md`, pointer note in `modular.md`'s CV outputs section. Also corrects the GP8413's description from 12-bit to 15-bit.

Independent of #1284 (touches a different part of modular.md; merges cleanly in either order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)