### PR TITLE
Clamp touch coordinates at screen edges instead of dropping them

### DIFF
--- a/tulip/esp32s3/esp_lcd_touch_gt911.c
+++ b/tulip/esp32s3/esp_lcd_touch_gt911.c
@@ -475,6 +475,7 @@ static esp_err_t touch_gt911_reset(esp_lcd_touch_handle_t tp)
 static esp_err_t touch_gt911_read_cfg(esp_lcd_touch_handle_t tp)
 {
     uint8_t buf[4];
+    uint8_t range[4];
 
     assert(tp != NULL);
 
@@ -483,6 +484,15 @@ static esp_err_t touch_gt911_read_cfg(esp_lcd_touch_handle_t tp)
 
     ESP_LOGI(TAG, "TouchPad_ID:0x%02x,0x%02x,0x%02x", buf[0], buf[1], buf[2]);
     ESP_LOGI(TAG, "TouchPad_Config_Version:%d", buf[3]);
+
+    // Log the coordinate range the panel's burned-in config reports over. Panels have
+    // shipped with a y range larger than V_RES (e.g. 750 vs 600) -- that is what the
+    // touch_y_scale calibration compensates for, so this tells us what a given unit needs.
+    if (touch_gt911_i2c_read(tp, ESP_LCD_TOUCH_GT911_CONFIG_REG + 1, range, 4) == ESP_OK) {
+        ESP_LOGI(TAG, "TouchPad_Output_Range:%dx%d",
+                 (uint16_t)range[0] | ((uint16_t)range[1] << 8),
+                 (uint16_t)range[2] | ((uint16_t)range[3] << 8));
+    }
 
     return ESP_OK;
 }

--- a/tulip/esp32s3/gt911_touchscreen.c
+++ b/tulip/esp32s3/gt911_touchscreen.c
@@ -137,13 +137,21 @@ void run_gt911(void *param) {
             if(esp_lcd_touch_get_coordinates(tp, touch_x, touch_y, touch_strength, &touch_cnt, 3)) {
                 //fprintf(stderr, "TP pressed %d,%d str %d count %d\n", touch_x[0], touch_y[0], touch_strength[0], touch_cnt);
                 for(uint8_t i=0;i<touch_cnt;i++) {
-                    last_touch_x[i] = touch_x[i] + touch_x_delta;
+                    int16_t tx = touch_x[i] + touch_x_delta;
                     #ifdef TDECK
                         // tdeck has swapped y that mirror_y doesn't fix
-                        last_touch_y[i] = ((V_RES-touch_y[i]) + touch_y_delta)*touch_y_scale;
+                        int16_t ty = ((V_RES-touch_y[i]) + touch_y_delta)*touch_y_scale;
                     #else
-                        last_touch_y[i] = (touch_y[i] + touch_y_delta)*touch_y_scale;
+                        int16_t ty = (touch_y[i] + touch_y_delta)*touch_y_scale;
                     #endif
+                    // The calibration delta/scale can push edge touches just outside the
+                    // screen; clamp so they land on the edge instead of getting dropped
+                    if(tx < 0) tx = 0;
+                    if(tx >= H_RES) tx = H_RES-1;
+                    if(ty < 0) ty = 0;
+                    if(ty >= V_RES) ty = V_RES-1;
+                    last_touch_x[i] = tx;
+                    last_touch_y[i] = ty;
                 }
                 for(uint8_t i=touch_cnt;i<3;i++) {
                     last_touch_x[i] = -1;

--- a/tulip/shared/display.c
+++ b/tulip/shared/display.c
@@ -1029,11 +1029,18 @@ void lvgl_input_kb_read_cb(lv_indev_t * indev, lv_indev_data_t*data) {
 
 void lvgl_input_read_cb(lv_indev_t * indev, lv_indev_data_t*data) {
     if(touch_held) {
-        if(last_touch_x[0] >= 0 && last_touch_x[0] < H_RES && last_touch_y[0] >= 0 && last_touch_y[0] < V_RES) {
-            data->point.x = last_touch_x[0];
-            data->point.y = last_touch_y[0];
-            data->state = LV_INDEV_STATE_PRESSED;
-        }
+        // Clamp to the screen instead of dropping the point -- touch calibration can
+        // map edge touches slightly out of range, and dropping them makes the
+        // launcher / app switcher buttons at the screen corners miss taps
+        int16_t x = last_touch_x[0];
+        int16_t y = last_touch_y[0];
+        if(x < 0) x = 0;
+        if(x >= H_RES) x = H_RES-1;
+        if(y < 0) y = 0;
+        if(y >= V_RES) y = V_RES-1;
+        data->point.x = x;
+        data->point.y = y;
+        data->state = LV_INDEV_STATE_PRESSED;
     } else {
         data->state = LV_INDEV_STATE_RELEASED;
     }


### PR DESCRIPTION
Users report taps near screen edges (bottom-right app launch, top-right app switcher) not registering on Tulip 4, while mid-screen taps work fine. A paint.py photo showed touches along the top edge only registering once the finger moved down.

## Root cause

The GT911 calibration map `x' = x + touch_x_delta`, `y' = (y + touch_y_delta) * touch_y_scale` (defaults `-2, -12, 0.8`) pushes touches near the edges just outside the screen bounds: the top ~12 raw pixels map to **negative y**, and the bottom edge overshoots `V_RES` (with 0.8 scale, the bottom edge lives at raw y ≈ 762).

Two consumers then discarded those points entirely instead of clamping:

1. **`run_gt911`** stored them unclamped into `last_touch_x/y`, so `tulip.touch()` / `touch_callback` apps saw off-screen coordinates. paint.py's own `x>0 and y>0` guard then skips the dot — exactly the top-edge gap in the photo. (The older FT5x06 path already clamped; the GT911 path never did.)
2. **`lvgl_input_read_cb`** dropped out-of-range points without setting the pressed state, so LVGL never saw the tap at all — which is why the launcher and app-switcher buttons sitting exactly in the screen corners miss taps.

## Fix

- Clamp calibrated coordinates to `[0, H_RES) x [0, V_RES)` in `run_gt911` (parity with FT5x06), fixing the raw-touch path for all apps.
- Clamp instead of drop in `lvgl_input_read_cb`, fixing LVGL widgets (also helps desktop, where the mouse can drag outside the viewport mid-press).
- Log the GT911's burned-in config output range (`TouchPad_Output_Range`) at init. The magic 0.8 default is exactly 600/750, suggesting panels ship configured for a 750-px y range — this log line will show per-batch differences and could later drive auto-calibration instead of the hardcoded delta/scale.

Verified: TULIP4_R11 firmware builds clean.

## Follow-up worth considering (not in this PR)

- `calibrate.py` never computes `touch_y_scale` (TODO in the file) and computes deltas from already-calibrated readings without inverting the old calibration, so re-running it compounds errors. A two-point fit would make it actually correct per-unit skew.
- If the `TouchPad_Output_Range` log confirms per-batch config differences, the driver could derive the default y scale from the chip config at boot instead of hardcoding 0.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)