### PR TITLE
Make callbacks GC roots

### DIFF
--- a/tulip/shared/amy_connector.c
+++ b/tulip/shared/amy_connector.c
@@ -49,8 +49,6 @@ void midi_out(uint8_t * bytes, uint16_t len) {
 // A queue to store the AMY midi messages coming IN
 uint8_t last_midi[MIDI_QUEUE_DEPTH][MAX_MIDI_BYTES_PER_MESSAGE];
 uint8_t last_midi_len[MIDI_QUEUE_DEPTH];
-extern mp_obj_t midi_callback;
-extern mp_obj_t amy_overload_callback;
 
 int16_t midi_queue_head = 0;
 int16_t midi_queue_tail = 0;
@@ -59,8 +57,8 @@ int16_t midi_queue_tail = 0;
 // (it has already reset the synth and played its bleep). Hand off to Python
 // with the load as a percent -- a small int, so no cross-task heap allocation.
 void tulip_amy_overload_hook(float load) {
-    if (amy_overload_callback != NULL)
-        mp_sched_schedule(amy_overload_callback, MP_OBJ_NEW_SMALL_INT((mp_int_t)(load * 100.0f)));
+    if (MP_STATE_PORT(amy_overload_callback) != NULL)
+        mp_sched_schedule(MP_STATE_PORT(amy_overload_callback), MP_OBJ_NEW_SMALL_INT((mp_int_t)(load * 100.0f)));
 }
 
 
@@ -226,7 +224,7 @@ void tulip_midi_input_hook(uint8_t * data, uint16_t len, uint8_t is_sysex) {
             }
             sysex_len = len;
         }
-        if(midi_callback!=NULL) mp_sched_schedule(midi_callback, mp_const_true);
+        if(MP_STATE_PORT(midi_callback)!=NULL) mp_sched_schedule(MP_STATE_PORT(midi_callback), mp_const_true);
     } else {
         for(uint32_t i = 0; i < (uint32_t)len; i++) {
             if(i < MAX_MIDI_BYTES_PER_MESSAGE) {
@@ -243,7 +241,7 @@ void tulip_midi_input_hook(uint8_t * data, uint16_t len, uint8_t is_sysex) {
         }
 
         // We tell Python that a MIDI message has been received
-        if(midi_callback!=NULL) mp_sched_schedule(midi_callback, mp_const_false);
+        if(MP_STATE_PORT(midi_callback)!=NULL) mp_sched_schedule(MP_STATE_PORT(midi_callback), mp_const_false);
     }
 }
 

--- a/tulip/shared/keyscan.c
+++ b/tulip/shared/keyscan.c
@@ -426,20 +426,19 @@ uint16_t scan_ascii(uint8_t code, uint32_t modifier) {
 }
 
 extern int16_t lvgl_is_repl;
-extern mp_obj_t keyboard_callback, ui_quit_callback, ui_switch_callback;
 
 void send_key_to_micropython(uint16_t c) {
     // handle the global system hotkeys before anything else. we have two, ctrl-tab and ctrl-q 
     if(c==17) {
-        if(ui_quit_callback != NULL) 
-            mp_sched_schedule(ui_quit_callback, NULL);
+        if(MP_STATE_PORT(ui_quit_callback) != NULL) 
+            mp_sched_schedule(MP_STATE_PORT(ui_quit_callback), NULL);
     } else if (c==263) {
-        if(ui_switch_callback != NULL) 
-            mp_sched_schedule(ui_switch_callback, NULL);
+        if(MP_STATE_PORT(ui_switch_callback) != NULL) 
+            mp_sched_schedule(MP_STATE_PORT(ui_switch_callback), NULL);
     } else {
         // Call the callback if set
-        if(keyboard_callback != NULL)  {
-            mp_sched_schedule(keyboard_callback, mp_obj_new_int(c));
+        if(MP_STATE_PORT(keyboard_callback) != NULL)  {
+            mp_sched_schedule(MP_STATE_PORT(keyboard_callback), mp_obj_new_int(c));
         }
 
         // If something is taking in chars from LVGL (text area etc), don't send the char to MP

--- a/tulip/shared/modtulip.c
+++ b/tulip/shared/modtulip.c
@@ -103,20 +103,20 @@ extern mp_obj_t tulip_win_http_fetch(size_t n_args, const mp_obj_t *args);
 extern const mp_obj_fun_builtin_var_t tulip_win_http_fetch_obj;
 #endif
 
-mp_obj_t midi_callback = NULL;
+MP_REGISTER_ROOT_POINTER(mp_obj_t midi_callback);
 
 STATIC mp_obj_t tulip_midi_callback(size_t n_args, const mp_obj_t *args) {
-    midi_callback = args[0];
+    MP_STATE_PORT(midi_callback) = args[0];
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(tulip_midi_callback_obj, 1, 1, tulip_midi_callback);
 
 // Called (via mp_sched_schedule from the AMY render task) when AMY's CPU
 // overload failsafe trips, with the render load percent as a small int.
-mp_obj_t amy_overload_callback = NULL;
+MP_REGISTER_ROOT_POINTER(mp_obj_t amy_overload_callback);
 
 STATIC mp_obj_t tulip_amy_overload_callback(size_t n_args, const mp_obj_t *args) {
-    amy_overload_callback = (args[0] == mp_const_none) ? NULL : args[0];
+    MP_STATE_PORT(amy_overload_callback) = (args[0] == mp_const_none) ? NULL : args[0];
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(tulip_amy_overload_callback_obj, 1, 1, tulip_amy_overload_callback);
@@ -175,13 +175,13 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(tulip_set_cv_synth_obj, 2, 2, tulip_s
 STATIC mp_obj_t tulip_defer(size_t n_args, const mp_obj_t *args) {
     int8_t index = -1;
     for(uint8_t slot=0;slot<DEFER_SLOTS;slot++) {
-        if(defer_callbacks[slot]==NULL) {
+        if(MP_STATE_PORT(defer_callbacks)[slot]==NULL) {
             index = slot; slot = DEFER_SLOTS+1;
         }
     }
     if(index>=0) {
-        defer_callbacks[index] = args[0];
-        defer_args[index] = args[1];
+        MP_STATE_PORT(defer_callbacks)[index] = args[0];
+        MP_STATE_PORT(defer_args)[index] = args[1];
         defer_sysclock[index] = get_time_ms() + mp_obj_get_int(args[2]);
 
     } else {
@@ -196,12 +196,12 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(tulip_defer_obj, 3, 3, tulip_defer);
 STATIC mp_obj_t tulip_seq_add_callback(size_t n_args, const mp_obj_t *args) {
     int8_t index = -1;
     for(uint8_t slot=0;slot<SEQUENCER_SLOTS;slot++) {
-        if(sequencer_callbacks[slot]==NULL) {
+        if(MP_STATE_PORT(sequencer_callbacks)[slot]==NULL) {
             index = slot; slot = SEQUENCER_SLOTS+1;
         }
     }
     if(index>=0) {
-        sequencer_callbacks[index] = args[0];
+        MP_STATE_PORT(sequencer_callbacks)[index] = args[0];
         sequencer_tick[index] = mp_obj_get_int(args[1]);
         sequencer_period[index] = mp_obj_get_int(args[2]);
     } else {
@@ -214,7 +214,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(tulip_seq_add_callback_obj, 3, 3, tul
 STATIC mp_obj_t tulip_seq_remove_callback(size_t n_args, const mp_obj_t *args) {
     int8_t index = mp_obj_get_int(args[0]);
     if(index>=0 && index <SEQUENCER_SLOTS) {
-        sequencer_callbacks[index] = NULL;
+        MP_STATE_PORT(sequencer_callbacks)[index] = NULL;
         sequencer_period[index] = 0;
         sequencer_tick[index] = 0;
     }
@@ -225,7 +225,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(tulip_seq_remove_callback_obj, 1, 1, 
 
 STATIC mp_obj_t tulip_seq_remove_callbacks(size_t n_args, const mp_obj_t *args) {
     for(uint8_t i=0;i<SEQUENCER_SLOTS;i++) {
-        sequencer_callbacks[i] = NULL;
+        MP_STATE_PORT(sequencer_callbacks)[i] = NULL;
         sequencer_period[i] = 0;
         sequencer_tick[i] = 0;
     }
@@ -1136,12 +1136,12 @@ STATIC mp_obj_t tulip_screen_size(size_t n_args, const mp_obj_t *args) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(tulip_screen_size_obj, 0, 0, tulip_screen_size);
 
 
-mp_obj_t frame_callback = NULL; 
-mp_obj_t frame_arg = NULL; 
-mp_obj_t touch_callback = NULL; 
-mp_obj_t keyboard_callback = NULL;
-mp_obj_t ui_quit_callback = NULL;
-mp_obj_t ui_switch_callback = NULL;
+MP_REGISTER_ROOT_POINTER(mp_obj_t frame_callback);
+MP_REGISTER_ROOT_POINTER(mp_obj_t frame_arg);
+MP_REGISTER_ROOT_POINTER(mp_obj_t touch_callback);
+MP_REGISTER_ROOT_POINTER(mp_obj_t keyboard_callback);
+MP_REGISTER_ROOT_POINTER(mp_obj_t ui_quit_callback);
+MP_REGISTER_ROOT_POINTER(mp_obj_t ui_switch_callback);
 
 
 STATIC mp_obj_t mp_lv_task_handler(mp_obj_t arg)
@@ -1163,10 +1163,10 @@ void mp_schedule_lv() {
 
 void tulip_frame_isr() {
     mp_schedule_lv();
-    if(frame_callback != NULL) {
+    if(MP_STATE_PORT(frame_callback) != NULL) {
         // Schedule the python callback given to run asap
-        //fprintf(stderr, "calling function %p with arg %p at frame %d\n", frame_callback, frame_arg, vsync_count);
-        mp_sched_schedule(frame_callback, frame_arg);
+        //fprintf(stderr, "calling function %p with arg %p at frame %d\n", MP_STATE_PORT(frame_callback), MP_STATE_PORT(frame_arg), vsync_count);
+        mp_sched_schedule(MP_STATE_PORT(frame_callback), MP_STATE_PORT(frame_arg));
 #ifdef ESP_PLATFORM
         //mp_hal_wake_main_task_from_isr();
 #endif
@@ -1175,8 +1175,8 @@ void tulip_frame_isr() {
 
 
 void tulip_touch_isr(uint8_t up) {
-    if(touch_callback != NULL) {
-        mp_sched_schedule(touch_callback, mp_obj_new_int(up)); 
+    if(MP_STATE_PORT(touch_callback) != NULL) {
+        mp_sched_schedule(MP_STATE_PORT(touch_callback), mp_obj_new_int(up)); 
     }
 }
 
@@ -1187,12 +1187,12 @@ void tulip_touch_isr(uint8_t up) {
 // tulip.frame_callback() -- stops 
 STATIC mp_obj_t tulip_frame_callback(size_t n_args, const mp_obj_t *args) {
     if(n_args == 0) {
-        frame_callback = NULL;
+        MP_STATE_PORT(frame_callback) = NULL;
     } else {
-        frame_callback = args[0];
+        MP_STATE_PORT(frame_callback) = args[0];
     }
     if(n_args > 1) {
-        frame_arg = args[1];
+        MP_STATE_PORT(frame_arg) = args[1];
     }
     return mp_const_none;
 }
@@ -1203,9 +1203,9 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(tulip_frame_callback_obj, 0, 2, tulip
 
 STATIC mp_obj_t tulip_touch_callback(size_t n_args, const mp_obj_t *args) {
     if(n_args == 0) {
-        touch_callback = NULL;
+        MP_STATE_PORT(touch_callback) = NULL;
     } else {
-        touch_callback = args[0];
+        MP_STATE_PORT(touch_callback) = args[0];
     }
     return mp_const_none;
 }
@@ -1213,9 +1213,9 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(tulip_touch_callback_obj, 0, 1, tulip
 
 STATIC mp_obj_t tulip_keyboard_callback(size_t n_args, const mp_obj_t *args) {
     if(n_args == 0) {
-        keyboard_callback = NULL;
+        MP_STATE_PORT(keyboard_callback) = NULL;
     } else {
-        keyboard_callback = args[0];
+        MP_STATE_PORT(keyboard_callback) = args[0];
     }
     return mp_const_none;
 }
@@ -1225,9 +1225,9 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(tulip_keyboard_callback_obj, 0, 1, tu
 
 STATIC mp_obj_t tulip_ui_quit_callback(size_t n_args, const mp_obj_t *args) {
     if(n_args == 0) {
-        ui_quit_callback = NULL;
+        MP_STATE_PORT(ui_quit_callback) = NULL;
     } else {
-        ui_quit_callback = args[0];
+        MP_STATE_PORT(ui_quit_callback) = args[0];
     }
     return mp_const_none;
 }
@@ -1235,9 +1235,9 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(tulip_ui_quit_callback_obj, 0, 1, tul
 
 STATIC mp_obj_t tulip_ui_switch_callback(size_t n_args, const mp_obj_t *args) {
     if(n_args == 0) {
-        ui_switch_callback = NULL;
+        MP_STATE_PORT(ui_switch_callback) = NULL;
     } else {
-        ui_switch_callback = args[0];
+        MP_STATE_PORT(ui_switch_callback) = args[0];
     }
     return mp_const_none;
 }

--- a/tulip/shared/tsequencer.c
+++ b/tulip/shared/tsequencer.c
@@ -2,12 +2,12 @@
 #include "tsequencer.h"
 #include <inttypes.h>
 
-mp_obj_t sequencer_callbacks[SEQUENCER_SLOTS];
+MP_REGISTER_ROOT_POINTER(mp_obj_t sequencer_callbacks[8]);
 uint32_t sequencer_period[SEQUENCER_SLOTS];
 uint32_t sequencer_tick[SEQUENCER_SLOTS];
 
-mp_obj_t defer_callbacks[DEFER_SLOTS];
-mp_obj_t defer_args[DEFER_SLOTS];
+MP_REGISTER_ROOT_POINTER(mp_obj_t defer_callbacks[32]);
+MP_REGISTER_ROOT_POINTER(mp_obj_t defer_args[32]);
 int64_t defer_sysclock[DEFER_SLOTS];
 
 #ifdef AMY_IS_EXTERNAL
@@ -19,10 +19,10 @@ void tulip_amy_sequencer_hook(uint32_t tick_count) {
         sequencer_tick_count = tick_count;
     #endif
     for(uint8_t i=0;i<DEFER_SLOTS;i++) {
-        if(defer_callbacks[i] != NULL && get_time_ms() > defer_sysclock[i]) {
+        if(MP_STATE_PORT(defer_callbacks)[i] != NULL && get_time_ms() > defer_sysclock[i]) {
             //fprintf(stderr, "calling defer with sysclock %" PRId64 " and actual %" PRId64"\n", defer_sysclock[i], get_time_ms() );
-            mp_sched_schedule(defer_callbacks[i], defer_args[i]);
-            defer_callbacks[i] = NULL; defer_sysclock[i] = 0; defer_args[i] = NULL;
+            mp_sched_schedule(MP_STATE_PORT(defer_callbacks)[i], MP_STATE_PORT(defer_args)[i]);
+            MP_STATE_PORT(defer_callbacks)[i] = NULL; defer_sysclock[i] = 0; MP_STATE_PORT(defer_args)[i] = NULL;
         }
     }
 
@@ -30,16 +30,23 @@ void tulip_amy_sequencer_hook(uint32_t tick_count) {
         if(sequencer_period[i]!=0) {
             uint32_t offset = tick_count % sequencer_period[i];
             if(offset == sequencer_tick[i]) {
-                mp_sched_schedule(sequencer_callbacks[i], mp_obj_new_int(tick_count));
+                mp_sched_schedule(MP_STATE_PORT(sequencer_callbacks)[i], mp_obj_new_int(tick_count));
             }
         }
     }
 }
 
 
+// The array sizes in MP_REGISTER_ROOT_POINTER above must be literals: that
+// macro is collected into genhdr/root_pointers.h, which mpstate.h includes
+// long before tsequencer.h is visible. Make any drift a build error rather
+// than a silently under-scanned root.
+MP_STATIC_ASSERT(SEQUENCER_SLOTS == 8);
+MP_STATIC_ASSERT(DEFER_SLOTS == 32);
+
 void tsequencer_init() {
-    for(uint8_t i=0;i<SEQUENCER_SLOTS;i++) { sequencer_callbacks[i] = NULL; sequencer_period[i] = 0; sequencer_tick[i] = 0; }
-    for(uint8_t i=0;i<DEFER_SLOTS;i++) { defer_callbacks[i] = NULL; defer_sysclock[i] = 0; }
+    for(uint8_t i=0;i<SEQUENCER_SLOTS;i++) { MP_STATE_PORT(sequencer_callbacks)[i] = NULL; sequencer_period[i] = 0; sequencer_tick[i] = 0; }
+    for(uint8_t i=0;i<DEFER_SLOTS;i++) { MP_STATE_PORT(defer_callbacks)[i] = NULL; defer_sysclock[i] = 0; }
     #ifndef AMY_IS_EXTERNAL
     amy_global.config.amy_external_sequencer_hook = tulip_amy_sequencer_hook;
     #endif

--- a/tulip/shared/tsequencer.h
+++ b/tulip/shared/tsequencer.h
@@ -14,16 +14,13 @@
 extern uint32_t sequencer_tick_count;
 #define AMY_SEQUENCER_PPQ 48
 #endif
-extern mp_obj_t sequencer_callbacks[SEQUENCER_SLOTS];
 extern uint32_t sequencer_period[SEQUENCER_SLOTS];
 extern uint32_t sequencer_tick[SEQUENCER_SLOTS];
 
-extern mp_obj_t defer_callbacks[DEFER_SLOTS];
 // 64-bit absolute deadline (get_time_ms()). This was uint32_t off the 32-bit
 // tick, so a defer straddling the 49.7-day rollover either fired instantly or
 // waited another 49.7 days.
 extern int64_t defer_sysclock[DEFER_SLOTS];
-extern mp_obj_t defer_args[DEFER_SLOTS];
 
 
 void tsequencer_init();


### PR DESCRIPTION
# Make callbacks GC roots

## The bug

Every callback Tulip stores is a plain C global, and none is declared as a GC
root:

| Global | File |
|---|---|
| `midi_callback`, `amy_overload_callback` | `tulip/shared/modtulip.c:106,116` |
| `frame_callback`, `frame_arg`, `touch_callback`, `keyboard_callback`, `ui_quit_callback`, `ui_switch_callback` | `tulip/shared/modtulip.c:1139-1144` |
| `sequencer_callbacks[]`, `defer_callbacks[]`, `defer_args[]` | `tulip/shared/tsequencer.c:5,9,10` |

`MICROPY_PORT_ROOT_POINTERS` does not appear anywhere in the tree, and
`gc_collect()` on the esp32 port scans **registers and the stack only**
(`ports/esp32/gccollect.c`). A C global is therefore invisible to the collector.

So this — the ordinary way to use the API, and what `tulip/fs/tulip/ex/`,
`shared/py/voices.py` and the docs all do — is a use-after-free:

```python
tulip.touch_callback(self.on_touch)
```

`self.on_touch` builds a **new bound-method object** on every evaluation.
Handed straight over, the C global holds the only reference to an object
nothing else can reach, so a collection frees it. The pointer survives; the
object does not.

Whether anything then breaks depends on **when that block is reallocated**,
which is what makes this so unpleasant to diagnose:

- silent — the pointer is still non-NULL, nothing raises;
- delayed — it needs a collection *and* a reuse;
- unreproducible — it depends on heap churn;
- and re-registering the same handler fixes it instantly, because that
  makes a fresh object.

I hit this as a touchscreen that died after **3.5 hours** of a running
sequencer, with no error logged, on a Tulip CC v4r11. Re-registering fixed it
immediately every time. I had it mitigated with a 30-second re-assertion for
weeks before reading the source. It is also the most plausible explanation for
a one-off spontaneous reset I never accounted for: scheduling a freed object.

Note that the sequencer callbacks have the same defect, so a long-running
`seq_add_callback` is on the same footing — it simply tends to get luckier
about reallocation.

## Reproduction

⚠️ This may hang or reset the device. That is the bug.

```python
import gc, time, tulip

fired = []

def install():
    # A closure whose ONLY reference will be tulip's C global.
    def cb(*a):
        fired.append(1)
    tulip.frame_callback(cb)

install()
time.sleep(1)
print("firing before gc:", len(fired) > 0)

n = len(fired)
gc.collect()
# Churn the heap so the freed block gets reused.
junk = [bytearray(96) for _ in range(3000)]
time.sleep(1)
print("still firing after gc + churn:", len(fired) > n)
```

Without the patch the callback object is collectable at `gc.collect()` and the
allocation loop reuses its memory. With the patch it stays reachable.

## The fix

Register each with `MP_REGISTER_ROOT_POINTER` and access through
`MP_STATE_PORT`, matching the existing use in `proxy_c.c` and for
`native_code_pointers`. Same globals, same NULL semantics, same call sites —
only their storage moves into the root-pointer section.

The array sizes have to be literals: `MP_REGISTER_ROOT_POINTER` is collected
into `genhdr/root_pointers.h`, which `mpstate.h` includes long before
`tsequencer.h` is visible. `MP_STATIC_ASSERT` keeps them honest against
`SEQUENCER_SLOTS` and `DEFER_SLOTS`.

## What I have and have not verified

**Verified:** the analysis above, from source at the commit my board runs
(`a2c981c4`) and the pinned MicroPython (`82e69df33`). And the mechanism, on
hardware: holding a strong Python-side reference to every callback made the
failure go away, confirmed across 40 forced `gc.collect()` calls with ticks,
frames, touch and MIDI all still live afterwards.

**Not verified:** I have not compiled this. I do not have an ESP-IDF toolchain
set up, so the patch is offered for CI and review rather than as something I
have run. It is mechanical and I have checked every call site converted, but
please treat the build as unproven.

## Related, deliberately not fixed here

These globals are also **not cleared on soft reset** — `tsequencer_init()` is
called once from `app_main`, outside the `soft_reset:` loop, and nothing zeroes
the root-pointer section. So a callback registered before a soft reset survives
as a dangling pointer into a heap that has since been re-created. That is
pre-existing and orthogonal; this PR does not change it either way, but it
probably wants its own fix.

## Workaround for anyone hitting this today

Keep your own reference to the exact object you hand over:

```python
self._cb_touch = self.on_touch          # reachable from something live
tulip.touch_callback(self._cb_touch)
```

Not `tulip.touch_callback(self.on_touch)`, which creates an object only the C
global will hold.
