### PR TITLE
amyboard: select CV DAC output range at every boot (fixes v1.5 boards)

### DIFF
--- a/docs/amyboard/modular.md
+++ b/docs/amyboard/modular.md
@@ -28,10 +28,10 @@ Most modular synthesis units operate at 10Vpp, where an audio signal swings betw
 
 AMYboard has **two CV outputs** on 3.5mm jacks, powered by a GP8413 15-bit DAC (I2C address `0x58`). The outputs range from approximately **-10V to +10V**, suitable for controlling Eurorack pitch, filter cutoff, or any CV-controlled parameter.
 
-> **v1.5 boards:** the newest production revision powers up with the CV DAC in the
-> wrong range -- all CV outputs come out half-scale and 5V low (`cv_out(0)` reads
-> about -5V) until a one-line fix is run at boot. See
-> [Troubleshooting](troubleshooting.md#cv-out-voltages-are-wrong-v15-boards).
+> **v1.5 boards:** the newest production revision uses a DAC chip batch that powers
+> up half-scale. Firmware from August 2026 onward corrects this automatically at
+> every boot; on older firmware CV out spans only -10V..0V (`cv_out(0)` reads about
+> -5V). See [Troubleshooting](troubleshooting.md#cv-out-voltages-are-wrong-v15-boards).
 
 ```python
 import amyboard

--- a/docs/amyboard/troubleshooting.md
+++ b/docs/amyboard/troubleshooting.md
@@ -107,37 +107,26 @@ We've fixed a lot of USB issues recently, so [upgrade to the latest firmware](fi
 
 ## CV out voltages are wrong (v1.5 boards)
 
-Boards from the newest production run (revision **v1.5**) power up with the CV DAC in
-the wrong output range, so every CV out voltage comes out **half scale and 5V low**:
-`cv_out(0, 0)` measures about **-5V** at the jack, `cv_out(5, 0)` about -2.5V, and
-nothing above ~0V is reachable. Pitch CV sounds several octaves flat. Earlier boards
-(v1.4 and before) are **not** affected.
+Boards from the newest production run (revision **v1.5**) shipped with a newer
+date-code batch of the GP8413 CV DAC that powers up in a half-scale output range:
+every CV out voltage comes out **half scale and 5V low** -- `cv_out(0, 0)` measures
+about **-5V** at the jack, and nothing above ~0V is reachable, so pitch CV sounds
+several octaves flat. The board circuits are identical across revisions; only the DAC
+chip batch changed. v1.4 and earlier boards are not affected.
 
-**Check whether your board is affected.** Connect via [serial](python.md) and run
-`amyboard.cv_out(0, 0)`, then measure CV out 1 with a multimeter -- or patch CV out 1
-to CV in 1 and read it back:
+**Fix: [upgrade your firmware](firmware.md).** Firmware from August 2026 onward
+selects the correct DAC range at every boot, on all board revisions.
+
+If you can't upgrade yet, run this once per boot before any CV output (the top of
+your `sketch.py` is a good place):
 
 ```python
 import amyboard
-amyboard.cv_out(0, 0)
-amyboard.cv_in(0)   # close to 0V: your board is fine. Close to -5V: affected.
-```
-
-**The fix** -- switch the DAC to its 10V range. The setting does not survive a power
-cycle, so run this every boot, before any CV output (the top of your `sketch.py` is a
-good place):
-
-```python
 amyboard.get_i2c().writeto_mem(88, 0x01, bytes([0x11]))
 ```
 
-> **Only run this on an affected board.** On v1.4 and earlier the same command
-> *doubles* every CV output (positive voltages slam into the +11V rail) -- the two
-> revisions use different analog output stages. Use the check above if you're not
-> sure which you have.
-
-A firmware update that handles this automatically is in the works; this page will be
-updated when it ships.
+It's safe on every revision (a no-op on v1.4-era DACs, which already power up in the
+correct range), but it does not survive a power cycle, so it must run each boot.
 
 ## Board won't boot / crashes on startup
 

--- a/tulip/shared/amyboard-py/amyboard.py
+++ b/tulip/shared/amyboard-py/amyboard.py
@@ -493,6 +493,7 @@ def start_amy():
             sys.print_exception(e)
         return
     init_pcm9211()
+    init_gp8413()  # newer GP8413 batches (v1.5 boards) power up half-scale
     # AMY binds its MIDI UART TX to this pin at start; set_midi_type() right after is
     # the single MIDI OUT init sequence (it also holds the unused TRS leg high). It
     # needs AMY's UART driver, which amy_start() installs, so it must come second.
@@ -872,6 +873,17 @@ def init_pcm9211(addr=0x40):
         else:
             print("Write 0x%02x to 0x%02x returned 0x%02x" % (val, reg, r))
 
+def init_gp8413(addr=88):
+    """Select the CV DAC's 5V full-scale output range (register 0x01 = 0x11).
+
+    GP8413 date-code batches differ in their power-up range: 25+ parts
+    (v1.4 boards) default to the 5V full scale the output stage expects,
+    but 26+ parts (v1.5 boards) default to half that, leaving CV out
+    spanning only -10v..0v. 0x11 selects the correct range on both
+    batches (bench-verified a no-op on 25+). The setting is volatile, so
+    this must run every boot before any CV output."""
+    get_i2c().writeto_mem(addr, 0x01, bytes([0x11]))
+
 def set_cv_out(channel=0, synth=1):
     """Route a synth's audio output to a CV channel instead of speakers.
 
@@ -910,9 +922,9 @@ def cv_out(volts, channel=0):
     addr = 88 # GP8413
     # With rev1 scaling, 0x0000 -> -10v, 0x7fff -> +10v.
     # The output stage (TL074, 30K/10K from A3V3) is gain 4 offset -9.9v,
-    # sized for the GP8413's power-up 0-5V range: jack = 4*dac - 9.9.
-    # Never write the DAC range register (0x01) to 10V mode -- it would
-    # double every output and clip positive voltages at the op-amp rail.
+    # sized for a 5V-full-scale DAC: jack = 4*dac - 9.9. Newer GP8413
+    # batches (v1.5 boards) power up at half that full scale, so
+    # init_gp8413() must have selected the range before writing values.
     val = int(((volts + 10)/20.0) * 0x8000)
     if(val < 0):
         val = 0


### PR DESCRIPTION
Closes out the v1.5 CV out investigation ([#1284](https://github.com/shorepine/tulipcc/pull/1284), [#1287](https://github.com/shorepine/tulipcc/pull/1287), [#1298](https://github.com/shorepine/tulipcc/pull/1298)).

## The fix

`start_amy()` now calls a new `init_gp8413()` which writes `0x11` to the GP8413's range register at every boot (the setting is volatile — confirmed by power-cycle test). One unconditional line, **no board-rev detection needed**.

## Why unconditional is safe — the key bench result

v1.5 boards shipped with a 26+ date-code GP8413 batch that powers up at **half** the full-scale the (unchanged, per the Makerfabs v1.5 schematic) gain-4 output stage expects → CV out spanned −10..0V, `cv_out(0)` at ~−5V. Bench-verified on both revisions:

- **v1.5** + `0x11`: loopback snaps to exact ±5V — fixed.
- **v1.4** + `0x11`: `cv_out(0,0)` still reads 0V — **a no-op**. The 25+ batch evidently shares the same range semantics with a different power-up default, rather than being a true 5V/10V part.

So the write is correct on every known board. (Register readback is non-functional on this chip — returns a constant `0x11` regardless of state on both batches — so behavioral verification was the only way to establish this.)

## Docs

Updates the troubleshooting entry and modular.md callout: the fix now ships in firmware; the manual register write remains documented for older firmware and is marked **safe on all revisions**, replacing the earlier warning (added when we believed the revs had different analog stages — disproven by the schematic + the v1.4 no-op test).

## Verification

- v1.5 bench: post-`0x11` loopback exact ±5.0V (this PR automates that write).
- v1.4 bench: `0x11` no-op, CV out unchanged.
- `py_compile` on amyboard.py; PR firmware build via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)