### PR TITLE
methodical_mid: keep the song in ticks, not milliseconds

### DIFF
--- a/tulip/amyboardweb/sketches/methodical_mid.py
+++ b/tulip/amyboardweb/sketches/methodical_mid.py
@@ -27,19 +27,21 @@ song = umidiparser.MidiFile(song_fn)
 # Parse the whole file once into (amy_tick, note, velocity) triples.
 #
 # The song is kept in AMY sequencer TICKS, not milliseconds. A MIDI file times
-# events in "miditicks", its own subdivision of a quarter note, so the
-# conversion to AMY's 48-ticks-per-quarter grid is a pure musical ratio with no
-# tempo term in it at all:
+# events in "miditicks", its own subdivision of a quarter note, so converting
+# to AMY's 48-ticks-per-quarter grid is a plain integer divide -- Methodical.MID
+# is 96 PPQ, so it is a divide by 2, with no tempo term and no rounding.
 #
-#     amy_tick = miditicks * AMY_SEQUENCER_PPQ / miditicks_per_quarter
+# Nothing is lost to that divide: the file is quantized to 32nd notes (3107 of
+# its 3122 note events sit exactly on a 12-miditick boundary) and exactly one
+# event lands on an odd miditick, where the truncation moves it 5 ms earlier.
 #
-# That is the whole reason to work in ticks. Speed is then AMY's business: the
-# song plays at whatever `amy.send(tempo=...)` says, and changing tempo mid-song
-# stretches it correctly. Converting to ms here instead would bake one tempo
-# into every timestamp, and every later tempo change would desynchronise the
-# song from anything else AMY is sequencing.
+# Working in ticks is what makes tempo a real control: ticks carry musical
+# position and AMY's tempo decides the speed, so `amy.send(tempo=...)` stretches
+# the song correctly. Converting to ms here instead would bake one tempo into
+# every timestamp and desynchronise the song from anything else AMY sequences.
 AMY_PPQ = amy.AMY_SEQUENCER_PPQ    # 48
-mtpq = song.miditicks_per_quarter
+mtpq = song.miditicks_per_quarter  # 96 for Methodical.MID
+MIDITICKS_PER_AMY_TICK = mtpq // AMY_PPQ   # 2
 
 events = []
 miditicks = 0
@@ -57,16 +59,18 @@ for event in song:
     if event.status == umidiparser.NOTE_ON or event.status == umidiparser.NOTE_OFF:
         # Methodical.MID encodes all note-offs as vel=0 note-ons; keep that.
         vel = 0 if event.status == umidiparser.NOTE_OFF else event.velocity / 256.0
-        # Round to nearest tick rather than truncating: at 48 PPQ a tick is a
-        # 32nd-note triplet, so consistently rounding down would drag the beat.
-        events.append(((miditicks * AMY_PPQ + mtpq // 2) // mtpq,
+        events.append((miditicks // MIDITICKS_PER_AMY_TICK,
                        event.note + 12, vel))
 
-# Play at the file's own tempo by default, so this sounds like the recording
-# rather than like whatever AMY happened to be set to. Everything above is in
-# ticks, so this is now a single knob: set a different tempo here, or send
-# `amy.send(tempo=...)` while it plays, and the song follows.
-amy.send(tempo=60000000.0 / song_tempo_us)   # us per quarter -> BPM
+# Setting the tempo is what preserves the file's original timing: pick the BPM
+# that makes one AMY tick last exactly MIDITICKS_PER_AMY_TICK miditicks, and the
+# wall-clock schedule comes out identical to the file by construction. Here that
+# is 120 BPM -- an AMY quarter (48 ticks) spans 96 miditicks, one file quarter.
+#
+# It is also the only knob now: change it here, or send `amy.send(tempo=...)`
+# while the song plays, and everything retimes together.
+amy.send(tempo=60000000.0 * mtpq
+               / (song_tempo_us * AMY_PPQ * MIDITICKS_PER_AMY_TICK))
 
 # Schedule notes ahead using AMY's `ticks=` parameter instead of dispatching
 # them live from loop(). AMY's delta queue plays events with sample-accurate

--- a/tulip/amyboardweb/sketches/methodical_mid.py
+++ b/tulip/amyboardweb/sketches/methodical_mid.py
@@ -24,64 +24,103 @@ for cmd in setup.split('\n'):
 song_fn = tulip.root_dir() + "sys/ex/Methodical.MID"
 song = umidiparser.MidiFile(song_fn)
 
-# Parse the whole file once into (time_offset_ms, note, velocity) triples.
-# We keep OFFSETS from song-start rather than absolute times so we can
-# anchor playback to our actual boot time below.
+# Parse the whole file once into (amy_tick, note, velocity) triples.
+#
+# The song is kept in AMY sequencer TICKS, not milliseconds. A MIDI file times
+# events in "miditicks", its own subdivision of a quarter note, so the
+# conversion to AMY's 48-ticks-per-quarter grid is a pure musical ratio with no
+# tempo term in it at all:
+#
+#     amy_tick = miditicks * AMY_SEQUENCER_PPQ / miditicks_per_quarter
+#
+# That is the whole reason to work in ticks. Speed is then AMY's business: the
+# song plays at whatever `amy.send(tempo=...)` says, and changing tempo mid-song
+# stretches it correctly. Converting to ms here instead would bake one tempo
+# into every timestamp, and every later tempo change would desynchronise the
+# song from anything else AMY is sequencing.
+AMY_PPQ = amy.AMY_SEQUENCER_PPQ    # 48
+mtpq = song.miditicks_per_quarter
+
 events = []
-utic = 0
+miditicks = 0
+# Microseconds per quarter note. 500000 (120 BPM) is the MIDI default for a
+# file that never sends SET_TEMPO -- which Methodical.MID doesn't, so this is
+# the value it actually plays at. Don't drop this default: leaving the tempo
+# alone would play the song at AMY's 108 BPM, 10% slow.
+song_tempo_us = 500000
+_got_tempo = False
 for event in song:
-    utic += event.delta_us
+    miditicks += event.delta_miditicks
+    if not _got_tempo and event.status == umidiparser.SET_TEMPO:
+        song_tempo_us = event.tempo
+        _got_tempo = True
     if event.status == umidiparser.NOTE_ON or event.status == umidiparser.NOTE_OFF:
         # Methodical.MID encodes all note-offs as vel=0 note-ons; keep that.
         vel = 0 if event.status == umidiparser.NOTE_OFF else event.velocity / 256.0
-        events.append((utic // 1000, event.note + 12, vel))
+        # Round to nearest tick rather than truncating: at 48 PPQ a tick is a
+        # 32nd-note triplet, so consistently rounding down would drag the beat.
+        events.append(((miditicks * AMY_PPQ + mtpq // 2) // mtpq,
+                       event.note + 12, vel))
+
+# Play at the file's own tempo by default, so this sounds like the recording
+# rather than like whatever AMY happened to be set to. Everything above is in
+# ticks, so this is now a single knob: set a different tempo here, or send
+# `amy.send(tempo=...)` while it plays, and the song follows.
+amy.send(tempo=60000000.0 / song_tempo_us)   # us per quarter -> BPM
 
 # Schedule notes ahead using AMY's `ticks=` parameter instead of dispatching
 # them live from loop(). AMY's delta queue plays events with sample-accurate
 # timing on the audio worklet, so MicroPython scheduler hiccups (heavy loop()
-# workloads, GC pauses, sysex traffic in control mode, etc.) can't stretch
-# the music out. loop() becomes a queue-refiller: it just has to run often
-# enough to keep ~BUFFER_MS of future events queued.
+# workloads, GC pauses, sysex traffic in control mode, etc.) can't stretch the
+# music out. loop() becomes a queue-refiller: it just has to run often enough
+# to keep BUFFER_TICKS of future events queued.
 #
-# `ticks=` schedules by AMY sequencer tick, not wall-clock ms, so ms offsets
-# are converted using AMY's default tempo (108 BPM, 48 PPQ), anchored to a
-# single (SONG_START_MS, SONG_START_TICKS) reference pair taken at song start.
-TICKS_PER_MS = 108 * 48 / 60000.0
-BUFFER_MS = 2000    # how far ahead of "now" we keep events queued
-LOW_WATER_MS = 500  # refill when the queue gets this shallow
+# Resetting the timebase makes tick 0 the start of the song, so an event's
+# stored tick IS the tick to schedule it at -- no anchor pair, no arithmetic
+# against a clock read. Note this is a global reset: it re-phases any other
+# sequence already running and defers any pending one-off, which is fine for a
+# sketch that owns the machine at boot but is worth knowing if you paste this
+# into something larger.
+amy.send(reset=amy.RESET_TIMEBASE)
 
-SONG_START_MS = tulip.amy_ticks_ms() + 200  # small head-start so the first notes don't miss
-SONG_START_TICKS = amy.sequencer_ticks()
-_next_idx = 0            # index into `events` of the next unscheduled note
-_last_scheduled_ms = SONG_START_MS
+# Both in ticks, i.e. musical time: at 48 PPQ that is one 4/4 bar of lead,
+# refilling when less than a quarter note remains queued (2.0 s and 0.5 s at
+# this song's 120 BPM). Being musical rather than ms, the lead scales with
+# tempo -- slow the song down and you get proportionally more slack.
+BUFFER_TICKS = 192
+LOW_WATER_TICKS = 48
+# Small head start so the opening notes aren't already due when they're queued.
+START_TICK = 8
 
-def _schedule_up_to(target_ms):
-    """Queue every event whose play time is <= target_ms."""
-    global _next_idx, _last_scheduled_ms
+_next_idx = 0                    # index into `events` of the next unscheduled note
+_last_scheduled_tick = START_TICK
+
+def _schedule_up_to(target_tick):
+    """Queue every event due at or before target_tick."""
+    global _next_idx, _last_scheduled_tick
     while _next_idx < len(events):
-        offset_ms, note, vel = events[_next_idx]
-        play_time = SONG_START_MS + offset_ms
-        if play_time > target_ms:
+        tick, note, vel = events[_next_idx]
+        play_tick = START_TICK + tick
+        if play_tick > target_tick:
             return
-        ticks = round(SONG_START_TICKS + (play_time - SONG_START_MS) * TICKS_PER_MS)
-        amy.send(synth=1, note=note, vel=vel, ticks=ticks)
-        _last_scheduled_ms = play_time
+        amy.send(synth=1, note=note, vel=vel, ticks=play_tick)
+        _last_scheduled_tick = play_tick
         _next_idx += 1
 
-# Prime the queue with the first BUFFER_MS of events so playback starts
+# Prime the queue with the first BUFFER_TICKS of events so playback starts
 # with plenty of lead time.
-_schedule_up_to(SONG_START_MS + BUFFER_MS)
+_schedule_up_to(START_TICK + BUFFER_TICKS)
 
 def loop():
     # Once every event has been queued, AMY is handling the rest on its own.
     if _next_idx >= len(events):
         return
-    now = tulip.amy_ticks_ms()
+    now = amy.sequencer_ticks()
     # Only refill when the queue is getting shallow — each schedule call
     # sends multiple amy.send() messages, so we don't want to do it every
     # loop() tick.
-    if _last_scheduled_ms - now < LOW_WATER_MS:
-        _schedule_up_to(now + BUFFER_MS)
+    if _last_scheduled_tick - now < LOW_WATER_TICKS:
+        _schedule_up_to(now + BUFFER_TICKS)
 
 # Do not edit. Set automatically by the knobs on AMYboard Online.
 _auto_generated_knobs = """


### PR DESCRIPTION
The sketch parsed `Methodical.MID` into millisecond offsets, then converted each one back into a sequencer tick at schedule time:

```python
TICKS_PER_MS = 108 * 48 / 60000.0
ticks = round(SONG_START_TICKS + (play_time - SONG_START_MS) * TICKS_PER_MS)
```

That needs an anchor pair captured at boot (`SONG_START_MS` from the ms clock, `SONG_START_TICKS` from the tick clock), a subtraction across the two domains, and a hardcoded constant asserting AMY's default tempo.

## Ticks are the natural unit

A MIDI file already times events in its own subdivision of a quarter note. Methodical.MID is 96 PPQ and AMY is 48, so the conversion is a plain integer divide by 2 — **no tempo term, no rounding**:

```python
MIDITICKS_PER_AMY_TICK = mtpq // AMY_PPQ     # 2
amy_tick = miditicks // MIDITICKS_PER_AMY_TICK
```

Nothing meaningful is lost to that divide. The file is quantized to 32nd notes — 3107 of its 3122 note events sit exactly on a 12-miditick boundary — and **exactly one** event (miditick 12625) lands on an odd miditick, where truncation moves it 5.2 ms earlier. Every other event is bit-exact, zero drift.

Resetting the timebase at song start then makes tick 0 the start of the song, so a stored tick *is* the tick to schedule at. The anchor pair, the `TICKS_PER_MS` constant, the cross-domain subtraction and every ms clock read are gone — the refiller compares against `amy.sequencer_ticks()` and nothing else.

The payoff is that **tempo works**. Ticks carry musical position and AMY's tempo decides the speed, so `amy.send(tempo=...)` retimes the song correctly, where before it would have desynchronised it (the ms→tick conversion had 108 BPM baked in).

## The trap, which is worth reading before reviewing

That cuts the other way too. `Methodical.MID` sends **no `SET_TEMPO`**, so it runs at the MIDI default of 500000 µs/quarter — 120 BPM, not AMY's 108.

The old code hid this completely: `delta_us` folded the tempo in, and converting ms→ticks at 108 BPM was *exactly inverted* by AMY playing back at 108 BPM, so wall-clock timing came out right by construction.

Under ticks the tempo is what preserves the original timing, so it's derived from the same divisor rather than left to coincidence — pick the BPM that makes one AMY tick last exactly `MIDITICKS_PER_AMY_TICK` miditicks and the wall-clock schedule is identical to the file:

```python
amy.send(tempo=60000000.0 * mtpq / (song_tempo_us * AMY_PPQ * MIDITICKS_PER_AMY_TICK))
```

That gives 120 BPM here — an AMY quarter (48 ticks) spans 96 miditicks, one file quarter — and it generalises to files whose PPQ isn't a multiple of 48. Without it the piece plays at AMY's 108 BPM: 10% slow, 72 s stretched to 80.

`BUFFER_TICKS` / `LOW_WATER_TICKS` are also ticks now (one 4/4 bar, one quarter note), so lead time scales with tempo rather than being fixed in ms. Slower song, proportionally more slack.

## Verified against the real file

- 96 miditicks/quarter, 3122 note events, 6912 AMY ticks.
- At the derived 120 BPM one AMY tick is **10.4167 ms = exactly 2 miditicks**, and the song is **72.00 s against the file's 72.00 s**.
- Exact positional check: **1 of 3122** events is moved by the divide (5.2 ms early); the other 3121 are bit-exact.
- Dry-run against stubbed `amy`/`tulip`/`amyboard`: reset and 120 BPM sent, all 3122 events scheduled, ticks monotonic 8..6920.
- With a simulated 60-tick GC stall mid-song, **no event is ever queued already-overdue** (min lead 8 ticks, median 116) — the property the look-ahead buffer exists for.

## Notes

- The timebase reset is global: it re-phases any other running sequence and defers pending one-offs. Fine for a sketch that owns the machine at boot, and called out in a comment for anyone pasting this into something larger.
- Uses `amy.AMY_SEQUENCER_PPQ` rather than `amy.constants.AMY_SEQUENCER_PPQ` — `from .constants import *` binds it directly, which is more robust on MicroPython.
- The AMYboard World copy (`shorepine/methodical_mid.py`) still has the old version and would need a separate re-upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
