### PR TITLE
AMYboard sketches: require loop(tick), and pass ticks not steps

### DIFF
--- a/AMY_AGENTS.md
+++ b/AMY_AGENTS.md
@@ -42,18 +42,29 @@ kwargs above (see the LFO section). If a name isn't in the right list, it doesn'
 
 ---
 
-## Timing & rhythm: `loop(step)` runs every 32nd note on the sequencer's bar-locked grid — use `step`, don't clock-math beats
+## Timing & rhythm: `loop(tick)` runs every 32nd note on the sequencer's bar-locked grid — use `tick`, don't clock-math beats
 
-AMY's sequencer is always running and calls `loop(step)` once per **32nd note**, starting
-on a bar downbeat. `step` is the global 32nd-note index on the sequencer's bar-locked
-grid: **`step % 32 == 0` is always a downbeat**, and it is the same grid `AMYSequence`
-events fire on, so patterns built from `step` stay in phase with AMY-sequenced patterns.
-For anything tempo- or beat-based, schedule events from `step` — **don't** keep your own
-call counter (it can drift if a callback is dropped), and **don't** convert BPM to
-milliseconds and measure the gap between beats with a wall clock (`tulip.amy_ticks_ms()`
-/ `time`). The grid is tempo-locked for you, so hand-rolled beat math is just extra code
-that drifts. (A legacy zero-argument `def loop():` still works and starts on a downbeat,
-but new sketches should take `step`.)
+AMY's sequencer is always running and calls `loop(tick)` once per **32nd note**, starting
+on a bar downbeat. **The argument is required** — `def loop():` with no argument is an
+error. `tick` is AMY's absolute sequencer tick, the very same value `amy.send(ticks=...)`
+schedules against, so you can hand it straight back to AMY (`ticks=tick + 48` is "one
+beat from now") without reading a clock or converting anything.
+
+For 32nd-note counting, divide it:
+
+```python
+step = tick // amyboard.TICKS_PER_STEP    # 6 ticks per step at AMY's 48 PPQ
+```
+
+`step` is then the global 32nd-note index on the bar-locked grid: **`step % 32 == 0` is
+always a downbeat**, and it is the same grid `AMYSequence` events fire on, so patterns
+built from it stay in phase with AMY-sequenced patterns.
+
+For anything tempo- or beat-based, schedule events from `tick`/`step` — **don't** keep
+your own call counter (it can drift if a callback is dropped), and **don't** convert BPM
+to milliseconds and measure the gap between beats with a wall clock
+(`tulip.amy_ticks_ms()` / `time`). The grid is tempo-locked for you, so hand-rolled beat
+math is just extra code that drifts.
 
 Set the tempo with **`sequencer.tempo(bpm)`** (`import sequencer`). The grid is always in
 32nd notes: 1 beat (quarter) = **8** steps, 8th = 4, 16th = 2, a 4/4 bar = 32.
@@ -69,13 +80,14 @@ sequencer.tempo(120)
 amy.send(synth=10, patch=384)
 
 KICK = 36
-def loop(step):
+def loop(tick):
+    step = tick // amyboard.TICKS_PER_STEP
     if step % 8 == 0:        # every 8 thirty-second notes = one beat -> four-on-the-floor
         amy.send(synth=10, note=KICK, vel=1)
 ```
 
 > Source of truth: `_start_sketch_loop` in `tulip/shared/amyboard-py/amyboard.py`
-> (downbeat-aligned dispatch and the `loop(step)` signature) plus
+> (downbeat-aligned dispatch and the `loop(tick)` signature) plus
 > `tulip/amyboardweb/sketches/house_generator.py`, `acid_generator.py`
 > (`sequencer.tempo(...)` + 32-steps-per-bar patterns).
 
@@ -114,9 +126,9 @@ arps, ostinatos); keep `loop()` for UI, knobs, and evolving the pattern.
 `1/divider` of a whole note (so `AMYSequence(32, 32)` = one 4/4 bar of 32nd-note slots).
 `seq.add(position, amy.send, synth=…, note=…, vel=…)` schedules a repeating note; it
 returns an event with `.update(position, amy.send, …)` to change it and `.remove()` to
-delete it. `AMYSequence` slots and `loop(step)` share the same bar-locked grid: slot
+delete it. `AMYSequence` slots and `loop(tick)` share the same bar-locked grid: slot
 `p` of a one-bar `AMYSequence(32, 32)` fires exactly when `step % 32 == p`, so a
-`loop(step)` part (bass line, chord stabs) stays in phase with an `AMYSequence` groove.
+`loop(tick)` part (bass line, chord stabs) stays in phase with an `AMYSequence` groove.
 
 ### Example — four-on-the-floor kick + 8th hats that keep time no matter what loop() does
 
@@ -132,7 +144,7 @@ for pos in (0, 8, 16, 24):
 for pos in range(0, 32, 4):
     seq.add(pos, amy.send, synth=10, note=42, vel=0.3)       # 8th-note closed hats
 
-def loop(step):
+def loop(tick):
     pass     # free for UI/display/knobs -- the pattern plays itself
 ```
 
@@ -168,7 +180,8 @@ sequencer.tempo(120)
 amy.send(synth=10, patch=384)
 d = amyboard.display
 
-def loop(step):
+def loop(tick):
+    step = tick // amyboard.TICKS_PER_STEP
     if step % 8 == 0:
         amy.send(synth=10, note=36, vel=1)       # (better: AMYSequence, see above)
     if step % 32 == 0:                           # once per bar, content changed
@@ -223,7 +236,7 @@ amy.send(synth=1, patch=0, num_voices=4)          # Juno patch (has a filter/res
 # Map CC 42 -> resonance on synth 1, linear, range 0..8:
 amy.send(synth=1, midi_cc="42,0,0,8,0,i%iR%v")
 
-def loop(step):
+def loop(tick):
     pass
 ```
 
@@ -262,7 +275,7 @@ import amy
 amy.send(synth=1, patch=0)                 # default num_voices=1 -> mono; voice stealing is automatic
 amy.send(synth=1, portamento=80)           # optional: glide between notes for a mono lead
 
-def loop(step):
+def loop(tick):
     pass
 ```
 
@@ -311,7 +324,7 @@ amy.send(synth=1, osc=0, wave=amy.PULSE,
 # CC 1 -> LFO rate, 0.1..5 Hz.  CMD i%iv1f%v == amy.send(synth=%i, osc=1, freq=%v)
 amy.send(synth=1, midi_cc="1,0,0.1,5,0,i%iv1f%v")
 
-def loop(step):
+def loop(tick):
     pass
 ```
 
@@ -348,7 +361,7 @@ amy.send(synth=1, osc=1, wave=amy.SAW_DOWN, pan=0.8,
 # osc 2: slow sine LFO.  a mod_source osc is silent, so it needs NO note-on.
 amy.send(synth=1, osc=2, wave=amy.SINE, freq=0.15, amp=1)
 
-def loop(step):
+def loop(tick):
     pass
 ```
 
@@ -383,7 +396,7 @@ amy.send(synth=18, osc=1, wave=amy.AUDIO_IN1, pan=1, amp=10)   # right
 amy.send(synth=18, vel=1, note=60)          # note-on sent to both active oscs. note number required but ignored
 amy.send(reverb="0.8,0.85,0.5")             # global: level, liveness, damping[, xover_hz]
 
-def loop(step):
+def loop(tick):
     pass
 ```
 
@@ -464,7 +477,7 @@ amy.send(synth=1, patch=0, num_voices=4)
 enc = amyboard.encoder()          # autodetect; works on any device or the simulator
 _last = [enc.read(i) for i in range(enc.encoders)]
 
-def loop(step):
+def loop(tick):
     for i in range(enc.encoders):
         pos = enc.read(i)
         delta = pos - _last[i]
@@ -571,7 +584,7 @@ tulip.install_c_process('dist', """
 """)
 tulip.c_process('dist', True)
 
-def loop(step):
+def loop(tick):
     pass
 ```
 

--- a/docs/amyboard/faq.md
+++ b/docs/amyboard/faq.md
@@ -119,7 +119,7 @@ Some panels (especially off-brand ones) come up sideways. For SH1107 you can fix
 amyboard.set_display_rotation(90)   # or 180 / 270
 ```
 
-Put the call anywhere **above** the `def loop():` line -- everything above it runs once at startup. Rotation only works on SH1107 panels (on the SSD1327 and in the web simulator it's a harmless no-op).
+Put the call anywhere **above** the `def loop(tick):` line -- everything above it runs once at startup. Rotation only works on SH1107 panels (on the SSD1327 and in the web simulator it's a harmless no-op).
 
 ### Can I connect two OLED displays at once?
 

--- a/docs/amyboard/python.md
+++ b/docs/amyboard/python.md
@@ -178,7 +178,7 @@ amy.send(synth=10, patch=384)                 # Channel 10: TR-808 GM drum kit (
 # Set CV out 1 to 0V on startup
 amyboard.cv_out(0.0, channel=0)
 
-def loop():
+def loop(tick):
     pass
 ```
 

--- a/tulip/amyboardweb/sketches/acid_generator.py
+++ b/tulip/amyboardweb/sketches/acid_generator.py
@@ -137,7 +137,7 @@ def is_16th_boundary():
     """True on every other 32nd note (= 16th note grid)."""
     return step % 2 == 0
 
-def loop():
+def loop(tick):
     global step, bar_count, bass_pattern, prev_note
     global kick_pat, snare_pat, hat_pat, ohat_pat, clap_pat, root
     step += 1

--- a/tulip/amyboardweb/sketches/arp.py
+++ b/tulip/amyboardweb/sketches/arp.py
@@ -32,7 +32,7 @@ def midi_cb(m):
 midi.add_callback(midi_cb)
 
 
-def loop():
+def loop(tick):
     global arp_idx, last_played, last_step_ms
     now = tulip.amy_ticks_ms()
     if now - last_step_ms < STEP_MS:

--- a/tulip/amyboardweb/sketches/audiopassthru.py
+++ b/tulip/amyboardweb/sketches/audiopassthru.py
@@ -20,5 +20,5 @@ amy.send(synth=18, osc=1, wave=amy.AUDIO_IN1, pan=1, amp=10)
 amy.send(synth=18, osc=0, vel=1, note=60)
 amy.send(synth=18, osc=1, vel=1, note=60)
 
-def loop():
+def loop(tick):
     pass

--- a/tulip/amyboardweb/sketches/chords.py
+++ b/tulip/amyboardweb/sketches/chords.py
@@ -43,7 +43,7 @@ def midi_cb(m):
 midi.add_callback(midi_cb)
 
 
-def loop():
+def loop(tick):
     pass
 
 # Do not edit. Set automatically by the knobs on AMYboard Online.

--- a/tulip/amyboardweb/sketches/cvfilter.py
+++ b/tulip/amyboardweb/sketches/cvfilter.py
@@ -10,7 +10,7 @@ import amy, amyboard
 # Set filter-freq to be set by ext0 (CV1) 
 amy.send(synth=1, filter_freq={'const': 300, 'ext0': 0.25}, filter_type=amy.FILTER_LPF24)
 
-def loop():
+def loop(tick):
     # During loop, see if cv2 is active and set resonance
     r = (amyboard.cv_in(1) + 10.0) / 5.0 # 0-4
     amy.send(synth=1, resonance=r)

--- a/tulip/amyboardweb/sketches/drum_machine.py
+++ b/tulip/amyboardweb/sketches/drum_machine.py
@@ -57,7 +57,7 @@ tabla_pattern = [6, 14, 22, 30]          # percussion answers on the "e"s
 
 step = -1
 
-def loop():
+def loop(tick):
     global step, kit_idx
     step += 1
     bar_step = step % STEPS_PER_BAR

--- a/tulip/amyboardweb/sketches/dx7filt.py
+++ b/tulip/amyboardweb/sketches/dx7filt.py
@@ -1,7 +1,7 @@
 # AMYboard Sketch
 # Top-level code runs once at boot. loop() is called every 32nd note.
 # DESCRIPTION: A DX7 like patch with controllable filter
-def loop():
+def loop(tick):
     pass
 
 # Do not edit. Set automatically by the knobs on AMYboard Online.

--- a/tulip/amyboardweb/sketches/dx7syx.py
+++ b/tulip/amyboardweb/sketches/dx7syx.py
@@ -28,7 +28,7 @@ amy.send(synth=1, num_voices=6, patch=1024)
 BELLS = [52, 59, 64, 68, 71, 68, 64, 59]
 count = 0
 
-def loop():
+def loop(tick):
     global count
     if count % 16 == 0:
         amy.send(synth=1, note=BELLS[(count // 16) % len(BELLS)], vel=0.8)

--- a/tulip/amyboardweb/sketches/filter_audio_in.py
+++ b/tulip/amyboardweb/sketches/filter_audio_in.py
@@ -18,5 +18,5 @@ amy.send(synth=18, osc=1, vel=1, note=60)
 amy.send(synth=18, osc=0, filter_freq={'const': 300, 'ext0': 0.25}, filter_type=amy.FILTER_LPF24)
 amy.send(synth=18, osc=1, filter_freq={'const': 300, 'ext0': 0.25}, filter_type=amy.FILTER_LPF24)
 
-def loop():
+def loop(tick):
     pass

--- a/tulip/amyboardweb/sketches/house_generator.py
+++ b/tulip/amyboardweb/sketches/house_generator.py
@@ -115,7 +115,7 @@ def get_chord_bar():
     """Which bar within the current chord (0-3)."""
     return (step % STEPS_PER_CHORD) // STEPS_PER_BAR
 
-def loop():
+def loop(tick):
     global step, bars_played, current_bass_pattern, current_piano_pattern, prog, chords
     step += 1
     if step < 5:

--- a/tulip/amyboardweb/sketches/methodical_mid.py
+++ b/tulip/amyboardweb/sketches/methodical_mid.py
@@ -115,7 +115,7 @@ def _schedule_up_to(target_tick):
 # with plenty of lead time.
 _schedule_up_to(START_TICK + BUFFER_TICKS)
 
-def loop():
+def loop(tick):
     # Once every event has been queued, AMY is handling the rest on its own.
     if _next_idx >= len(events):
         return

--- a/tulip/amyboardweb/sketches/midi2cv.py
+++ b/tulip/amyboardweb/sketches/midi2cv.py
@@ -27,7 +27,7 @@ def midi_cb(m):
 midi.add_callback(midi_cb)
 
 
-def loop():
+def loop(tick):
     pass
 
 # Do not edit. Set automatically by the knobs on AMYboard Online.

--- a/tulip/amyboardweb/sketches/piano.py
+++ b/tulip/amyboardweb/sketches/piano.py
@@ -4,5 +4,5 @@
 
 import amy
 amy.send(synth=1,patch=256,num_voices=6)
-def loop():
+def loop(tick):
     pass

--- a/tulip/amyboardweb/sketches/preset_selector.py
+++ b/tulip/amyboardweb/sketches/preset_selector.py
@@ -42,7 +42,7 @@ def load_preset(idx):
 
 draw()
 
-def loop():
+def loop(tick):
     global current_index, prev_btn
     raw = enc_offset - amyboard.read_encoder(seesaw_dev=SEESAW)
     idx = raw % NUM_PRESETS

--- a/tulip/amyboardweb/sketches/sampler.py
+++ b/tulip/amyboardweb/sketches/sampler.py
@@ -60,7 +60,7 @@ def midi_cb(m):
 midi.add_callback(midi_cb)
 
 
-def loop():
+def loop(tick):
     pass
 
 # Do not edit. Set automatically by the knobs on AMYboard Online.

--- a/tulip/amyboardweb/sketches/sineclock.py
+++ b/tulip/amyboardweb/sketches/sineclock.py
@@ -64,7 +64,7 @@ vel = 0.1
 start_sine_clock(hour=hour, minute=minute, second=second, vel=vel)
 
 
-def loop():
+def loop(tick):
     pass
 
 # Do not edit. Set automatically by the knobs on AMYboard Online.

--- a/tulip/amyboardweb/sketches/spacey.py
+++ b/tulip/amyboardweb/sketches/spacey.py
@@ -1,7 +1,7 @@
 # AMYboard Sketch
 # Code put here runs first, then loop() is called every 32nd note.
 # DESCRIPTION: A spacey-like patch with reverb and echo
-def loop():
+def loop(tick):
     pass
 
 # Do not edit. Set automatically by the knobs on AMYboard Online.

--- a/tulip/amyboardweb/sketches/universal_hair.py
+++ b/tulip/amyboardweb/sketches/universal_hair.py
@@ -38,7 +38,7 @@ def rand_perm(n):
 
 tick = 0
 
-def loop():
+def loop(_tick):   # sketch keeps its own `tick` counter below
     global current_notes, target_notes, pan_values, root, root_offsets, next_notes_to_change
     global tick
     if tick >= 40:

--- a/tulip/amyboardweb/sketches/wavetable.py
+++ b/tulip/amyboardweb/sketches/wavetable.py
@@ -2,7 +2,7 @@
 # Top-level code runs once at boot. loop() is called every 32nd note.
 # DESCRIPTION: Use the wavetable oscillator
 
-def loop():
+def loop(tick):
     pass
 
 # Do not edit. Set automatically by the knobs on AMYboard Online.

--- a/tulip/amyboardweb/sketches/wavfile.py
+++ b/tulip/amyboardweb/sketches/wavfile.py
@@ -13,7 +13,7 @@ amy.load_sample(WAV_PATH, preset=PRESET)
 amy.send(synth=1, oscs_per_voice=1, num_voices=4, wave=amy.PCM, preset=PRESET)
 
 
-def loop():
+def loop(tick):
     pass
 
 # Do not edit. Set automatically by the knobs on AMYboard Online.

--- a/tulip/amyboardweb/sketches/woodpiano.py
+++ b/tulip/amyboardweb/sketches/woodpiano.py
@@ -22,5 +22,5 @@ amy.send(synth=1, osc=0, wave=amy.ALGO, algorithm=5, algo_source=',,4,3,2,1', bp
 
 count = 0
 
-def loop():
+def loop(tick):
 	pass

--- a/tulip/amyboardweb/sketches/xanadu.py
+++ b/tulip/amyboardweb/sketches/xanadu.py
@@ -171,7 +171,7 @@ chord_iterator = iter(chords)
 next_chord = next(chord_iterator)
 base_time = amy.millis()
 
-def loop():
+def loop(tick):
     global base_time, next_chord, chord_iterator
     time_ms = amy.millis()
     if next_chord and time_ms >= base_time + next_chord['start_time']:

--- a/tulip/amyboardweb/static/spss.js
+++ b/tulip/amyboardweb/static/spss.js
@@ -92,7 +92,7 @@ var AMYBOARD_DEFAULT_SKETCH =
   "# starting on a bar downbeat. step counts 32nd notes on the sequencer's\n" +
   "# bar-locked grid, so step % 32 == 0 is always a downbeat.\n" +
   "import amyboard, amy\n\n" +
-  "def loop(step):\n    pass\n\n" +
+  "def loop(tick):\n    pass\n\n" +
   "# Do not edit. Set automatically by the knobs on AMYboard Online.\n" +
   "_auto_generated_knobs = \"\"\"\n\"\"\"\n";
 function _get_default_sketch() {
@@ -5893,7 +5893,7 @@ async function _reset_amyboard_send_and_cleanup() {
     console.log('reset: zP factory_reset sent');
     await sleep_ms(2000);
     // Set JS state to defaults.
-    var defaultSketch = "# AMYboard Sketch\n# Code put here runs first, then loop(step) is called every 32nd note,\n# starting on a bar downbeat. step counts 32nd notes on the sequencer's\n# bar-locked grid, so step % 32 == 0 is always a downbeat.\nimport amyboard, amy\n\ndef loop(step):\n    pass\n\n# Do not edit. Set automatically by the knobs on AMYboard Online.\n_auto_generated_knobs = \"\"\"\n\"\"\"\n";
+    var defaultSketch = "# AMYboard Sketch\n# Code put here runs first, then loop(tick) is called every 32nd note,\n# starting on a bar downbeat. tick is AMY's sequencer tick, so it can go\n# straight into amy.send(ticks=...). For 32nd-note counting divide it:\n# step = tick // amyboard.TICKS_PER_STEP  (step % 32 == 0 on a downbeat).\nimport amyboard, amy\n\ndef loop(tick):\n    pass\n\n# Do not edit. Set automatically by the knobs on AMYboard Online.\n_auto_generated_knobs = \"\"\"\n\"\"\"\n";
     // SYNC 2: clear the knob log so a later Write doesn't re-emit the old
     // session's knobs (the default sketch has an empty knobs block).
     if (window.knob_log && typeof window.knob_log.clear === 'function') window.knob_log.clear();

--- a/tulip/server/amyboardworld_db_api.py
+++ b/tulip/server/amyboardworld_db_api.py
@@ -1365,7 +1365,7 @@ OUTPUT CONTRACT (strict):
 - Respond with ONLY the contents of sketch.py as plain MicroPython source.
 - No Markdown, no code fences, no explanation before or after the code.
 - Begin with comment lines, including one line of the form: # DESCRIPTION: <short summary>
-- You MUST define a top-level loop(step) function. It may just `pass`. loop(step) is called once per 32nd note while the sketch runs, starting on a bar downbeat; use it for sequencing, timing, and reading inputs. step is the global 32nd-note index on the sequencer's bar-locked grid: step % 32 == 0 is always a downbeat, 8 steps = one beat, and it is the same grid AMYSequence events fire on, so derive all rhythm from step (never keep your own call counter and never do BPM-to-milliseconds math).
+- You MUST define a top-level loop(tick) function taking exactly one argument. It may just `pass`. A zero-argument loop() is an ERROR and the sketch will not run. loop(tick) is called once per 32nd note while the sketch runs, starting on a bar downbeat; use it for sequencing, timing, and reading inputs. tick is AMY's absolute sequencer tick -- the same value amy.send(ticks=...) schedules against, so you can pass it straight back (ticks=tick + 48 is one beat later) with no clock read and no conversion. For 32nd-note counting divide it: step = tick // amyboard.TICKS_PER_STEP (import amyboard), where step % 32 == 0 is always a downbeat, 8 steps = one beat, and it is the same grid AMYSequence events fire on. Derive all rhythm from tick/step (never keep your own call counter and never do BPM-to-milliseconds math).
 - Top-level code runs once at boot (set up synths, effects, callbacks there).
 - Only use the APIs documented below. Do NOT invent functions, modules, or parameters.
 - Keep sketches self-contained and runnable in the web simulator: no network, no filesystem, no SD card, no long blocking loops, and never call time.sleep() inside loop().
@@ -1410,9 +1410,9 @@ THE amyboard MODULE (import amyboard) -- physical I/O (present on hardware; safe
 
 OTHER MODULES
 - import midi: midi.add_callback(fn) registers fn(msg) for incoming MIDI. msg is a 3-byte sequence [status, data1, data2]; note-on is (status & 0xF0)==0x90 with vel>0, note-off is 0x80 (or 0x90 with vel==0).
-- import tulip: tulip.amy_ticks_ms() returns a millisecond clock. Only for non-musical timing (UI debounce etc.) -- musical timing should always come from loop(step).
+- import tulip: tulip.amy_ticks_ms() returns a millisecond clock. Only for non-musical timing (UI debounce etc.) -- musical timing should always come from loop(tick).
 - from music import Chord, Key: Chord("C:maj").annotations is a list of semitone offsets; Key("A:min") for scales. Root note names are 'C','C#','D','D#','E','F','F#','G','G#','A','A#','B'.
-- import sequencer: sequencer.tempo(bpm) sets the sketch tempo (the loop(step) grid follows it).
+- import sequencer: sequencer.tempo(bpm) sets the sketch tempo (the loop(tick) grid follows it).
 - Standard library available: random, math.
 
 CONVENTIONS
@@ -1426,12 +1426,12 @@ EXAMPLES (each is a complete, valid sketch.py)
 import amy
 amy.send(synth=1, patch=256, num_voices=6)
 
-def loop(step):
+def loop(tick):
     pass
 
 # AMYboard Sketch
 # DESCRIPTION: Each MIDI key triggers a major chord rooted at that key.
-import amy, midi
+import amy, midi, amyboard
 from music import Chord
 
 amy.send(synth=1, grab_midi_notes=0)
@@ -1461,7 +1461,7 @@ def midi_cb(m):
 
 midi.add_callback(midi_cb)
 
-def loop(step):
+def loop(tick):
     pass
 
 # AMYboard Sketch
@@ -1487,8 +1487,9 @@ def midi_cb(m):
 
 midi.add_callback(midi_cb)
 
-def loop(step):
+def loop(tick):
     global arp_idx, last_played
+    step = tick // amyboard.TICKS_PER_STEP
     if step % 4:            # an 8th note is 4 steps on the 32nd-note grid
         return
     if last_played is not None:
@@ -1510,7 +1511,7 @@ import amy, amyboard
 
 amy.send(synth=1, filter_freq={'const': 300, 'ext0': 0.25}, filter_type=amy.FILTER_LPF24)
 
-def loop(step):
+def loop(tick):
     r = (amyboard.cv_in(1) + 10.0) / 5.0  # map CV2 to roughly 0-4
     amy.send(synth=1, resonance=r)
 """
@@ -1543,6 +1544,7 @@ def _validate_sketch(code: str) -> tuple[bool, str]:
         return False, f"syntax error: {exc}"
     imports_amy = False
     defines_loop = False
+    loop_arity_ok = False
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             if any(alias.name.split(".")[0] in ("amy", "amyboard") for alias in node.names):
@@ -1552,10 +1554,16 @@ def _validate_sketch(code: str) -> tuple[bool, str]:
                 imports_amy = True
         elif isinstance(node, ast.FunctionDef) and node.name == "loop":
             defines_loop = True
+            # The sketch runner calls loop(tick) unconditionally, so a
+            # zero-argument loop() is a hard error at run time. Catch it here
+            # rather than letting it reach a board and fail every 32nd note.
+            loop_arity_ok = len(node.args.args) == 1 or node.args.vararg is not None
     if not imports_amy:
         return False, "does not import amy or amyboard"
     if not defines_loop:
         return False, "does not define a loop() function"
+    if not loop_arity_ok:
+        return False, "loop() must take exactly one argument: def loop(tick)"
     return True, ""
 
 

--- a/tulip/server/migrate_world_loop_arg.py
+++ b/tulip/server/migrate_world_loop_arg.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Migrate Tulip World / AMYboard World sketches to the mandatory loop(tick).
+
+AMYboard's sketch runner used to accept either `def loop():` or `def loop(step):`,
+deciding which by calling loop(step) and catching TypeError. That guess is not
+decidable -- MicroPython binds arguments before running the body, so an arity
+error and a TypeError raised *inside* a one-argument loop look identical at the
+call site, and a sketch whose first loop() happened to raise was permanently
+misfiled as zero-argument. The runner now always calls loop(tick), and the
+argument is AMY's absolute sequencer tick rather than a 32nd-note step index.
+
+So two things changed, and a sketch can need either or both:
+
+  1. the argument is now REQUIRED   -- `def loop():` no longer runs at all
+  2. the argument is now TICKS      -- a sketch that used the old `step` value
+                                       must divide by amyboard.TICKS_PER_STEP
+
+Usage:
+    python3 migrate_world_loop_arg.py --report              # scan only, no writes
+    python3 migrate_world_loop_arg.py --report --verbose    # + per-sketch detail
+    python3 migrate_world_loop_arg.py --write-diffs DIR     # dump before/after files
+    WORLD_ADMIN_TOKEN=xxx python3 migrate_world_loop_arg.py --apply
+
+`--apply` re-uploads each rewritten sketch as a new version under the original
+username/filename/description. Both worlds are versioned, so the previous
+version stays in history.
+
+Only the latest version of each (scope, username, filename) is considered.
+
+No external dependencies -- standard library only.
+"""
+
+import argparse
+import ast
+import io
+import json
+import os
+import sys
+import uuid
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+DEFAULT_URL = "https://tulipcc-production.up.railway.app"
+MAX_LIMIT = 5000
+SCOPES = ("amyboardworld", "tulipworld")
+
+# Preferred name for the new parameter, and the constant a rescaled sketch uses.
+TICK_NAME = "tick"
+STEP_EXPR = "%s // amyboard.TICKS_PER_STEP"
+
+# ── Classification ────────────────────────────────────────────────────────────
+#
+# ADD_ARG   `def loop():`  ->  `def loop(tick):`
+#           Body untouched: it never had the argument, so nothing to rescale.
+#
+# RENAME    `def loop(step):` where the parameter is never read.
+#           Only the name is a lie now (it receives ticks), so rename it.
+#           Body untouched.
+#
+# RESCALE   `def loop(step):` where the parameter IS read. The value it gets is
+#           now 6x larger (ticks, not 32nd-note steps), so every use would be
+#           wrong. Rename the parameter to `tick` and insert
+#           `step = tick // amyboard.TICKS_PER_STEP` as the first statement,
+#           which leaves the body's arithmetic exactly as the author wrote it.
+#           Adds `import amyboard` if the sketch doesn't already have it.
+#
+# SKIP      No top-level `def loop`, or already migrated, or unparseable.
+CLASSES = ("ADD_ARG", "RENAME", "RESCALE", "SKIP")
+
+
+# ── API helpers (same shapes as migrate_world_ticks.py) ───────────────────────
+
+def api_get(url, binary=False, timeout=90):
+    with urlopen(Request(url), timeout=timeout) as r:
+        return r.read() if binary else json.load(r)
+
+
+def list_items(api_url, scope):
+    url = (f"{api_url}/api/{scope}/files?limit={MAX_LIMIT}"
+           f"&latest_per_user_env=true")
+    d = api_get(url)
+    return d.get("items", d.get("files", []))
+
+
+def download(api_url, scope, item_id):
+    return api_get(f"{api_url}/api/{scope}/files/{item_id}/download", binary=True)
+
+
+def upload(api_url, scope, username, filename, description, blob, admin_token=None):
+    boundary = uuid.uuid4().hex
+    body = b""
+    for key, val in (("username", username), ("description", description)):
+        body += f"--{boundary}\r\n".encode()
+        body += f'Content-Disposition: form-data; name="{key}"\r\n\r\n'.encode()
+        body += f"{val}\r\n".encode()
+    body += f"--{boundary}\r\n".encode()
+    body += (f'Content-Disposition: form-data; name="file"; '
+             f'filename="{filename}"\r\n').encode()
+    body += b"Content-Type: application/octet-stream\r\n\r\n"
+    body += blob + f"\r\n--{boundary}--\r\n".encode()
+    req = Request(f"{api_url}/api/{scope}/upload", data=body, method="POST")
+    req.add_header("Content-Type", f"multipart/form-data; boundary={boundary}")
+    if admin_token:
+        req.add_header("X-Admin-Token", admin_token)
+    with urlopen(req, timeout=60) as r:
+        return json.load(r)
+
+
+# ── Source analysis and rewriting ─────────────────────────────────────────────
+
+def _loop_def(tree):
+    """The last top-level `def loop`, matching Python's own rebinding."""
+    fns = [n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "loop"]
+    return fns[-1] if fns else None
+
+
+def _free_name(src, preferred=TICK_NAME):
+    """A parameter name not already used anywhere in the sketch.
+
+    A blind rename to `tick` is not safe: a sketch can already have its own
+    module-level `tick` (universal_hair.py did), and shadowing it inside loop
+    would silently change behaviour -- or, with a `global tick`, not even
+    compile.
+    """
+    names = set()
+    try:
+        for node in ast.walk(ast.parse(src)):
+            if isinstance(node, ast.Name):
+                names.add(node.id)
+            elif isinstance(node, ast.arg):
+                names.add(node.arg)
+            elif isinstance(node, (ast.FunctionDef, ast.ClassDef)):
+                names.add(node.name)
+    except SyntaxError:
+        return preferred
+    if preferred not in names:
+        return preferred
+    cand = "_" + preferred
+    i = 2
+    while cand in names:
+        cand = "_%s%d" % (preferred, i)
+        i += 1
+    return cand
+
+
+def _imports_amyboard(tree):
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            if any(a.name.split(".")[0] == "amyboard" for a in node.names):
+                return True
+        elif isinstance(node, ast.ImportFrom):
+            if (node.module or "").split(".")[0] == "amyboard":
+                return True
+    return False
+
+
+def _first_body_line(fn, lines):
+    """Line index (0-based) to insert at: after any docstring and any leading
+    global/nonlocal declarations, which must keep preceding their own uses."""
+    idx = 0
+    for stmt in fn.body:
+        is_doc = (idx == 0 and isinstance(stmt, ast.Expr)
+                  and isinstance(stmt.value, ast.Constant)
+                  and isinstance(stmt.value.value, str))
+        if is_doc or isinstance(stmt, (ast.Global, ast.Nonlocal)):
+            idx += 1
+            continue
+        return stmt.lineno - 1
+    # Body was nothing but docstring/global declarations.
+    return fn.body[-1].end_lineno if fn.body else fn.lineno
+
+
+def classify_and_rewrite(src):
+    """Return (cls, new_src, note). new_src is None when nothing changes."""
+    try:
+        tree = ast.parse(src)
+    except SyntaxError as e:
+        return "SKIP", None, "unparseable: %s" % e
+    fn = _loop_def(tree)
+    if fn is None:
+        return "SKIP", None, "no top-level def loop"
+    args = fn.args
+    if args.vararg is not None:
+        return "SKIP", None, "loop(*args) already accepts the tick"
+    if len(args.args) > 1:
+        return "SKIP", None, "loop() takes %d args -- needs a human" % len(args.args)
+
+    lines = src.split("\n")
+    def_i = fn.lineno - 1
+    def_line = lines[def_i]
+
+    if not args.args:
+        # ADD_ARG: `def loop():` -> `def loop(tick):`
+        name = _free_name(src)
+        if "loop()" not in def_line:
+            return "SKIP", None, "unexpected def line: %r" % def_line
+        lines[def_i] = def_line.replace("loop()", "loop(%s)" % name, 1)
+        return "ADD_ARG", "\n".join(lines), "added parameter %r" % name
+
+    param = args.args[0].arg
+    reads = [n for n in ast.walk(fn)
+             if isinstance(n, ast.Name) and n.id == param and isinstance(n.ctx, ast.Load)]
+    name = _free_name(src)
+
+    # Rewrite the parameter in the def line only (the body keeps `param`).
+    old_sig = "loop(%s)" % param
+    if old_sig not in def_line:
+        return "SKIP", None, "unexpected def line: %r" % def_line
+
+    if not reads:
+        # RENAME: the parameter is never read, so only the name was misleading.
+        lines[def_i] = def_line.replace(old_sig, "loop(%s)" % name, 1)
+        return "RENAME", "\n".join(lines), "%r -> %r (unused)" % (param, name)
+
+    # RESCALE: keep the body verbatim; recreate `param` from the tick.
+    lines[def_i] = def_line.replace(old_sig, "loop(%s)" % name, 1)
+    ins_i = _first_body_line(fn, lines)
+    indent = " " * (len(lines[ins_i]) - len(lines[ins_i].lstrip())) if ins_i < len(lines) else "    "
+    if not indent:
+        indent = "    "
+    lines.insert(ins_i, "%s%s = %s" % (indent, param, STEP_EXPR % name))
+    new_src = "\n".join(lines)
+
+    if not _imports_amyboard(tree):
+        new_src = _add_amyboard_import(new_src)
+    return "RESCALE", new_src, "%r now derived from %r (%d use%s)" % (
+        param, name, len(reads), "" if len(reads) == 1 else "s")
+
+
+def _add_amyboard_import(src):
+    """Insert `import amyboard` before the first import, else after the leading
+    comment block (sketches start with `# AMYboard Sketch` / `# DESCRIPTION:`)."""
+    lines = src.split("\n")
+    try:
+        tree = ast.parse(src)
+        firsts = [n.lineno - 1 for n in tree.body if isinstance(n, (ast.Import, ast.ImportFrom))]
+        if firsts:
+            lines.insert(min(firsts), "import amyboard")
+            return "\n".join(lines)
+    except SyntaxError:
+        pass
+    i = 0
+    while i < len(lines) and (not lines[i].strip() or lines[i].lstrip().startswith("#")):
+        i += 1
+    lines.insert(i, "import amyboard")
+    return "\n".join(lines)
+
+
+def verify(new_src):
+    """The rewrite must parse and leave loop taking exactly one argument."""
+    try:
+        tree = ast.parse(new_src)
+    except SyntaxError as e:
+        return False, "rewrite does not parse: %s" % e
+    fn = _loop_def(tree)
+    if fn is None:
+        return False, "rewrite lost def loop"
+    if len(fn.args.args) != 1 and fn.args.vararg is None:
+        return False, "rewrite left arity %d" % len(fn.args.args)
+    return True, ""
+
+
+# ── Driver ────────────────────────────────────────────────────────────────────
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url", default=DEFAULT_URL)
+    ap.add_argument("--report", action="store_true", help="scan only, no writes")
+    ap.add_argument("--verbose", action="store_true")
+    ap.add_argument("--write-diffs", metavar="DIR", help="dump before/after files")
+    ap.add_argument("--apply", action="store_true", help="re-upload rewritten sketches")
+    ap.add_argument("--scope", choices=SCOPES, help="limit to one world")
+    opts = ap.parse_args()
+    if not (opts.report or opts.write_diffs or opts.apply):
+        opts.report = True
+
+    token = os.environ.get("WORLD_ADMIN_TOKEN")
+    if opts.apply and not token:
+        sys.exit("--apply needs WORLD_ADMIN_TOKEN in the environment")
+
+    counts = dict.fromkeys(CLASSES, 0)
+    failures = []
+    rewritten = []
+
+    for scope in (opts.scope,) if opts.scope else SCOPES:
+        for item in list_items(opts.url, scope):
+            fname = item.get("filename") or ""
+            if not fname.endswith(".py"):
+                continue
+            try:
+                src = download(opts.url, scope, item["id"]).decode("utf-8", "replace")
+            except Exception as e:
+                failures.append((scope, item, "download failed: %s" % e))
+                continue
+            cls, new_src, note = classify_and_rewrite(src)
+            counts[cls] += 1
+            if new_src is None:
+                if opts.verbose and cls == "SKIP":
+                    print("  SKIP     %s/%s: %s" % (item["username"], fname, note))
+                continue
+            ok, why = verify(new_src)
+            if not ok:
+                failures.append((scope, item, why))
+                continue
+            rewritten.append((scope, item, src, new_src))
+            if opts.verbose:
+                print("  %-8s %s/%s: %s" % (cls, item["username"], fname, note))
+
+    print("\n%-9s %s" % ("CLASS", "COUNT"))
+    for c in CLASSES:
+        print("%-9s %d" % (c, counts[c]))
+    print("%-9s %d" % ("TO WRITE", len(rewritten)))
+    if failures:
+        print("\n%d FAILURE(S) -- not rewritten:" % len(failures))
+        for scope, item, why in failures:
+            print("  %s %s/%s: %s" % (scope, item["username"], item["filename"], why))
+
+    if opts.write_diffs:
+        os.makedirs(opts.write_diffs, exist_ok=True)
+        for scope, item, old, new in rewritten:
+            base = "%s_%s_%s" % (scope, item["username"], item["filename"][:-3])
+            with open(os.path.join(opts.write_diffs, base + ".before.py"), "w") as f:
+                f.write(old)
+            with open(os.path.join(opts.write_diffs, base + ".after.py"), "w") as f:
+                f.write(new)
+        print("\nwrote %d before/after pairs to %s" % (len(rewritten), opts.write_diffs))
+
+    if opts.apply:
+        done = 0
+        for scope, item, _old, new in rewritten:
+            try:
+                upload(opts.url, scope, item["username"], item["filename"],
+                       item.get("description") or "", new.encode("utf-8"), token)
+                done += 1
+            except HTTPError as e:
+                print("  upload failed %s/%s: HTTP %s %s"
+                      % (item["username"], item["filename"], e.code, e.read()[:200]))
+            except Exception as e:
+                print("  upload failed %s/%s: %s" % (item["username"], item["filename"], e))
+        print("\nre-uploaded %d/%d sketches" % (done, len(rewritten)))
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tulip/server/test_hardware_tags.py
+++ b/tulip/server/test_hardware_tags.py
@@ -28,50 +28,50 @@ def tags(code: str) -> list[str]:
 
 
 # --- nothing hardware-y ---
-check("plain synth sketch has no tags", tags("import amy\namy.send(synth=1, patch=256)\ndef loop():\n    pass\n") == [])
+check("plain synth sketch has no tags", tags("import amy\namy.send(synth=1, patch=256)\ndef loop(tick):\n    pass\n") == [])
 check("empty code has no tags", tags("") == [])
-check("comment mentions don't count", tags("# use the display and encoder for this\nimport amy\ndef loop():\n    pass\n") == [])
-check("description line doesn't count", tags("# DESCRIPTION: encoder controls the display brightness\nimport amy\ndef loop():\n    pass\n") == [])
+check("comment mentions don't count", tags("# use the display and encoder for this\nimport amy\ndef loop(tick):\n    pass\n") == [])
+check("description line doesn't count", tags("# DESCRIPTION: encoder controls the display brightness\nimport amy\ndef loop(tick):\n    pass\n") == [])
 
 # --- display ---
 check("init_display", tags("import amyboard\namyboard.init_display()\namyboard.display.text('hi',0,0,255)\namyboard.display_refresh()") == ["display"])
 check("display.fill_rect", tags("import amyboard\namyboard.display.fill_rect(0,0,10,10,255)\namyboard.display.show()") == ["display"])
-check("draw_waveform helper", tags("import amyboard\ndef loop():\n    amyboard.draw_waveform()") == ["display"])
-check("set_display_rotation", tags("import amyboard\namyboard.set_display_rotation(180)\ndef loop(step):\n    pass\n") == ["display"])
+check("draw_waveform helper", tags("import amyboard\ndef loop(tick):\n    amyboard.draw_waveform()") == ["display"])
+check("set_display_rotation", tags("import amyboard\namyboard.set_display_rotation(180)\ndef loop(tick):\n    pass\n") == ["display"])
 
 # --- encoder (unified API) ---
-check("amyboard.encoder()", tags("import amyboard\nenc = amyboard.encoder()\ndef loop():\n    v = enc.read(0)") == ["encoder"])
-check("legacy read_encoder", tags("import amyboard\ndef loop():\n    v = amyboard.read_encoder()") == ["encoder"])
-check("legacy m5_8encoder module", "8encoder" in tags("import m5_8encoder\ndef loop():\n    pass"))
+check("amyboard.encoder()", tags("import amyboard\nenc = amyboard.encoder()\ndef loop(tick):\n    v = enc.read(0)") == ["encoder"])
+check("legacy read_encoder", tags("import amyboard\ndef loop(tick):\n    v = amyboard.read_encoder()") == ["encoder"])
+check("legacy m5_8encoder module", "8encoder" in tags("import m5_8encoder\ndef loop(tick):\n    pass"))
 
 # --- encoder count evidence ---
-check("index 1-3 means quad", tags("import amyboard\nenc = amyboard.encoder()\ndef loop():\n    a = enc.read(0)\n    b = enc.read(3)") == ["encoder", "quad-encoder"])
-check("range(4) loop means quad", tags("import amyboard\nenc = amyboard.encoder()\ndef loop():\n    for i in range(4):\n        enc.read(i)") == ["encoder", "quad-encoder"])
-check("forced adafruit_quad means quad", tags("import amyboard\nenc = amyboard.encoder(type='adafruit_quad')\ndef loop():\n    pass") == ["encoder", "quad-encoder"])
-check("index 4-7 means 8encoder", tags("import amyboard\nenc = amyboard.encoder()\ndef loop():\n    enc.led(7, 255, 0, 0)") == ["encoder", "8encoder"])
-check("range(8) loop means 8encoder", tags("import amyboard\nenc = amyboard.encoder()\ndef loop():\n    for i in range(8):\n        enc.read(i)") == ["encoder", "8encoder"])
-check("forced m5stack means 8encoder", tags("import amyboard\nenc = amyboard.encoder(type=\"m5stack\")\ndef loop():\n    pass") == ["encoder", "8encoder"])
-check("switch() means 8encoder", tags("import amyboard\nenc = amyboard.encoder()\ndef loop():\n    if enc.switch():\n        pass") == ["encoder", "8encoder"])
-check("8 evidence beats 4 evidence", tags("import amyboard\nenc = amyboard.encoder()\ndef loop():\n    enc.read(2)\n    enc.read(6)") == ["encoder", "8encoder"])
-check("adaptive enc.encoders loop stays plain #encoder", tags("import amyboard\nenc = amyboard.encoder()\ndef loop():\n    for i in range(enc.encoders):\n        enc.read(i)") == ["encoder"])
+check("index 1-3 means quad", tags("import amyboard\nenc = amyboard.encoder()\ndef loop(tick):\n    a = enc.read(0)\n    b = enc.read(3)") == ["encoder", "quad-encoder"])
+check("range(4) loop means quad", tags("import amyboard\nenc = amyboard.encoder()\ndef loop(tick):\n    for i in range(4):\n        enc.read(i)") == ["encoder", "quad-encoder"])
+check("forced adafruit_quad means quad", tags("import amyboard\nenc = amyboard.encoder(type='adafruit_quad')\ndef loop(tick):\n    pass") == ["encoder", "quad-encoder"])
+check("index 4-7 means 8encoder", tags("import amyboard\nenc = amyboard.encoder()\ndef loop(tick):\n    enc.led(7, 255, 0, 0)") == ["encoder", "8encoder"])
+check("range(8) loop means 8encoder", tags("import amyboard\nenc = amyboard.encoder()\ndef loop(tick):\n    for i in range(8):\n        enc.read(i)") == ["encoder", "8encoder"])
+check("forced m5stack means 8encoder", tags("import amyboard\nenc = amyboard.encoder(type=\"m5stack\")\ndef loop(tick):\n    pass") == ["encoder", "8encoder"])
+check("switch() means 8encoder", tags("import amyboard\nenc = amyboard.encoder()\ndef loop(tick):\n    if enc.switch():\n        pass") == ["encoder", "8encoder"])
+check("8 evidence beats 4 evidence", tags("import amyboard\nenc = amyboard.encoder()\ndef loop(tick):\n    enc.read(2)\n    enc.read(6)") == ["encoder", "8encoder"])
+check("adaptive enc.encoders loop stays plain #encoder", tags("import amyboard\nenc = amyboard.encoder()\ndef loop(tick):\n    for i in range(enc.encoders):\n        enc.read(i)") == ["encoder"])
 
 # --- 8angle ---
-check("m58angle module", tags("import m58angle\ndef loop():\n    v = m58angle.get(0)") == ["8angle"])
+check("m58angle module", tags("import m58angle\ndef loop(tick):\n    v = m58angle.get(0)") == ["8angle"])
 
 # --- cv ---
-check("cv_in", tags("import amy, amyboard\ndef loop():\n    r = amyboard.cv_in(1)") == ["cv"])
-check("cv_out", tags("import amy, amyboard\ndef loop():\n    amyboard.cv_out(5.0, channel=0)") == ["cv"])
-check("set_cv_out", tags("import amy, amyboard\namyboard.set_cv_out(0, synth=2)\ndef loop():\n    pass") == ["cv"])
-check("ext0 modulation routing", tags("import amy\namy.send(synth=1, filter_freq={'const': 300, 'ext0': 0.25})\ndef loop():\n    pass") == ["cv"])
-check("ext1 modulation routing", tags('import amy\namy.send(synth=1, amp={"const": 1, "ext1": 0.5})\ndef loop():\n    pass') == ["cv"])
+check("cv_in", tags("import amy, amyboard\ndef loop(tick):\n    r = amyboard.cv_in(1)") == ["cv"])
+check("cv_out", tags("import amy, amyboard\ndef loop(tick):\n    amyboard.cv_out(5.0, channel=0)") == ["cv"])
+check("set_cv_out", tags("import amy, amyboard\namyboard.set_cv_out(0, synth=2)\ndef loop(tick):\n    pass") == ["cv"])
+check("ext0 modulation routing", tags("import amy\namy.send(synth=1, filter_freq={'const': 300, 'ext0': 0.25})\ndef loop(tick):\n    pass") == ["cv"])
+check("ext1 modulation routing", tags('import amy\namy.send(synth=1, amp={"const": 1, "ext1": 0.5})\ndef loop(tick):\n    pass') == ["cv"])
 
 # --- audio-in ---
-check("AUDIO_IN0 wave", tags("import amy\namy.send(synth=18, osc=0, wave=amy.AUDIO_IN0, amp=10)\ndef loop():\n    pass") == ["audio-in"])
-check("start_sample from audio-in bus", tags("import amy\namy.start_sample(preset=30, max_frames=44100, bus=2, midinote=60)\ndef loop():\n    pass") == ["audio-in"])
-check("start_sample from another bus is not audio-in", tags("import amy\namy.start_sample(preset=30, max_frames=44100, bus=0, midinote=60)\ndef loop():\n    pass") == [])
+check("AUDIO_IN0 wave", tags("import amy\namy.send(synth=18, osc=0, wave=amy.AUDIO_IN0, amp=10)\ndef loop(tick):\n    pass") == ["audio-in"])
+check("start_sample from audio-in bus", tags("import amy\namy.start_sample(preset=30, max_frames=44100, bus=2, midinote=60)\ndef loop(tick):\n    pass") == ["audio-in"])
+check("start_sample from another bus is not audio-in", tags("import amy\namy.start_sample(preset=30, max_frames=44100, bus=0, midinote=60)\ndef loop(tick):\n    pass") == [])
 
 # --- combinations ---
-check("display + encoder", tags("import amyboard\namyboard.init_display()\nenc = amyboard.encoder()\ndef loop():\n    amyboard.display.text(str(enc.read(0)),0,0,255)\n    amyboard.display.show()") == ["display", "encoder"])
+check("display + encoder", tags("import amyboard\namyboard.init_display()\nenc = amyboard.encoder()\ndef loop(tick):\n    amyboard.display.text(str(enc.read(0)),0,0,255)\n    amyboard.display.show()") == ["display", "encoder"])
 
 # --- against the bundled example sketches ---
 SKETCHES = Path(__file__).resolve().parents[1] / "amyboardweb" / "sketches"

--- a/tulip/server/test_reference_tools.py
+++ b/tulip/server/test_reference_tools.py
@@ -108,7 +108,7 @@ check("cache: string content tolerated", _count_cc(_msgs_str) == 0)
 # --- agentic loop control flow (mocked Anthropic client, no network) ---
 import types  # noqa: E402
 
-_VALID_SKETCH = "import amy\namy.send(synth=1, patch=0, num_voices=1)\ndef loop():\n    pass\n"
+_VALID_SKETCH = "import amy\namy.send(synth=1, patch=0, num_voices=1)\ndef loop(tick):\n    pass\n"
 
 
 def _ns(**kw):

--- a/tulip/shared/amyboard-py/amyboard.py
+++ b/tulip/shared/amyboard-py/amyboard.py
@@ -5,6 +5,18 @@ from tulip import wifi, upgrade
 i2c = None
 display = None # Display instance (unified interface for all display types)
 
+# A sketch's loop(tick) is called every 32nd note and receives the AMY
+# sequencer's absolute tick.  This is the tick span of one of those calls, so
+# `step = tick // amyboard.TICKS_PER_STEP` recovers the bar-locked 32nd-note
+# index (step % 32 == 0 on a downbeat).  Derived from AMY's PPQ rather than
+# hardcoded: 4 quarter notes per bar / 32 steps per bar * PPQ = 6 at 48 PPQ.
+TICKS_PER_STEP = int((4.0 / 32.0) * amy.AMY_SEQUENCER_PPQ)
+
+# Consecutive loop() exceptions before the sketch loop gives up. It fires
+# every 32nd note, so a persistently broken loop() would otherwise flood the
+# console and starve the REPL.
+_MAX_LOOP_FAILS = 8
+
 # Web encoder emulation state (used when running on AMYBOARD_WEB)
 _web_encoder_pos = 0      # cumulative encoder position
 _web_encoder_button = False  # current button state
@@ -207,12 +219,13 @@ class Display:
 
 DEFAULT_SKETCH_SOURCE = """\
 # AMYboard Sketch
-# Code put here runs first, then loop(step) is called every 32nd note,
-# starting on a bar downbeat. step counts 32nd notes on the sequencer's
-# bar-locked grid, so step % 32 == 0 is always a downbeat.
+# Code put here runs first, then loop(tick) is called every 32nd note,
+# starting on a bar downbeat. tick is AMY's sequencer tick, so it can go
+# straight into amy.send(ticks=...). For 32nd-note counting divide it:
+# step = tick // amyboard.TICKS_PER_STEP  (step % 32 == 0 on a downbeat).
 import amyboard, amy
 
-def loop(step):
+def loop(tick):
     pass
 
 # Do not edit. Set automatically by the knobs on AMYboard Online.
@@ -671,24 +684,35 @@ def run_sketch():
 def _start_sketch_loop(loop_fn):
     """Schedule loop_fn via TulipSequence (every 32nd note).
 
-    Sketch loops ride the AMY sequencer's absolute tick count -- the same
-    clock AMYSequence events fire on. The first call is held until a bar
-    boundary (4 beats), so a sketch that keeps its own step counter starts
-    on the downbeat, in phase with any AMY-sequenced patterns. A sketch can
-    instead declare loop(step): step is the global 32nd-note index on that
-    bar-locked grid (step % 32 == 0 is always a downbeat), which stays in
-    phase even if a callback is ever dropped.
+    A sketch MUST declare loop(tick).  tick is the AMY sequencer's absolute
+    tick count -- the same clock AMYSequence events and `ticks=` scheduling
+    use, so it can be passed straight back to amy.send(ticks=...) without
+    any conversion or clock read.  The first call is held until a bar
+    boundary (4 beats), so a sketch starts on the downbeat in phase with any
+    AMY-sequenced patterns.
+
+    For 32nd-note counting, divide: `step = tick // amyboard.TICKS_PER_STEP`
+    gives the old bar-locked step index, where step % 32 == 0 is a downbeat.
+
+    The argument is not optional.  This used to accept a zero-argument
+    loop() as well, deciding which by calling loop(step) and catching
+    TypeError -- but MicroPython binds arguments before running the body
+    (objfun.c: INIT_CODESTATE precedes mp_execute_bytecode), so an arity
+    error and a TypeError raised *inside* a one-argument loop are
+    indistinguishable at the call site.  A sketch whose first loop() happened
+    to raise TypeError was permanently misfiled as zero-argument and then
+    failed on every subsequent call.  Requiring the argument removes the
+    guess rather than making it cleverer.
     """
     import sequencer
     global _sketch_seq
-    ticks_per_step = int((4.0 / 32.0) * sequencer.PPQ)  # one 32nd note
     ticks_per_bar = 4 * sequencer.PPQ
     _busy = False
     _started = False
-    _takes_step = None
+    _fails = 0
 
     def _guarded_loop(tick):
-        nonlocal _busy, _started, _takes_step
+        nonlocal _busy, _started, _fails
         if _busy:
             return
         _busy = True
@@ -697,23 +721,27 @@ def _start_sketch_loop(loop_fn):
                 if tick % ticks_per_bar:
                     return  # hold loop() until the next downbeat
                 _started = True
-            step = tick // ticks_per_step
-            if _takes_step is None:
-                # First call decides the signature: prefer loop(step), fall
-                # back to loop() for sketches that don't take an argument.
-                try:
-                    loop_fn(step)
-                    _takes_step = True
-                except TypeError:
-                    _takes_step = False
-                    loop_fn()
-            elif _takes_step:
-                loop_fn(step)
-            else:
-                loop_fn()
+            loop_fn(tick)
+            _fails = 0
         except Exception as e:
+            # Uniform for every exception type -- deliberately no special
+            # case for TypeError.  An un-migrated `def loop():` raises one,
+            # but so does a real bug inside a correct loop(tick), and (see
+            # above) the two are indistinguishable here.  The traceback
+            # already says "function takes 0 positional arguments but 1 were
+            # given" when that is what happened.
+            _fails += 1
             print("sketch.loop() error:")
             sys.print_exception(e)
+            if _fails == _MAX_LOOP_FAILS:  # exactly once, not on every later call
+                # Failing every 32nd note floods the console and starves the
+                # REPL. Nothing has succeeded in _MAX_LOOP_FAILS calls, so
+                # stop rather than keep retrying.
+                print("sketch.loop() failed %d times in a row -- stopping the "
+                      "sketch loop. If loop() takes no argument, it now must: "
+                      "`def loop(tick):` (step = tick // amyboard.TICKS_PER_STEP)"
+                      % _fails)
+                stop_sketch()
         finally:
             _busy = False
 


### PR DESCRIPTION
> [!IMPORTANT]
> **Breaking change for AMYboard sketches.** `def loop():` no longer runs. Every sketch must take the argument: `def loop(tick):`. All 22 bundled sketches are updated here; the 538 World sketches that need it are handled by the migration script below, which has **not** been applied yet.

## Why

The sketch runner accepted either `def loop():` or `def loop(step):`, deciding which by calling `loop(step)` and catching `TypeError`. That guess isn't decidable.

MicroPython binds arguments *before* running the body (`objfun.c`: `INIT_CODESTATE` precedes `mp_execute_bytecode`), so an arity error and a `TypeError` raised **inside** a one-argument loop are identical at the call site. And the misdiagnosis was sticky — a sketch whose first `loop()` happened to raise `TypeError` was latched as zero-argument and then failed on *every* subsequent call, permanently.

There's no escape via introspection either: this MicroPython enables `MICROPY_PY_FUNCTION_ATTRS`, but that exposes only `__name__` and `__globals__` — no `__code__`, no `co_argcount` anywhere in the tree.

So the fix is to stop asking the question rather than to guess more cleverly.

## What changed

**`loop(tick)` is mandatory, and the argument is now AMY's absolute sequencer tick** rather than a 32nd-note step index. That's the same value `amy.send(ticks=...)` schedules against, so a sketch can hand it straight back — `ticks=tick + 48` is one beat later — with no clock read and no conversion. It removes the reason sketches reach for `amy.sequencer_ticks()` at all, and the injected value is *better* than a clock read: it's the tick the callback was scheduled **for**, not whenever MicroPython got round to running it.

**`amyboard.TICKS_PER_STEP`** (6 at AMY's 48 PPQ, derived rather than hardcoded) recovers the old index:

```python
step = tick // amyboard.TICKS_PER_STEP     # step % 32 == 0 is still a downbeat
```

**Error handling is uniform for every exception type**, with deliberately *no* special case for `TypeError` — an un-migrated `def loop():` raises one, but so does a real bug in a correct `loop(tick)`, and those are exactly as indistinguishable as before. The traceback already says "function takes 0 positional arguments but 1 were given" when that's what happened. What's new is a cutoff: **eight consecutive failures stops the sketch loop**, since failing every 32nd note otherwise floods the console and starves the REPL.

## Two server changes that matter beyond cosmetics

- **The AI sketch-generator prompt** told the model to emit `loop(step)`. Left alone, every newly generated sketch would have been born broken.
- **`_validate_sketch` only checked that a function named `loop` exists.** It now requires exactly one parameter, so a bad generation or upload is caught at the server instead of failing every 32nd note on someone's board. (`loop(*args)` is accepted; `loop()` and `loop(a, b)` are rejected.)

## Migration script

`tulip/server/migrate_world_loop_arg.py`, modelled on `migrate_world_ticks.py` (`--report` / `--write-diffs` / `--apply`). Dry run over the 649 live sketches, **zero failures**:

| class | n | action |
|---|---|---|
| `ADD_ARG` | 393 | `def loop():` → `def loop(tick):`, body untouched |
| `RENAME` | 71 | parameter declared but never read — rename only |
| `RESCALE` | 74 | parameter used — rename, then insert the derivation |
| `SKIP` | 69 | no top-level `def loop`, or `loop(*args)`, or unparseable |

`RESCALE` is the only class that touches a body, and it's deliberately minimal-diff — one inserted line, everything else byte-identical, so the author's `% 32` / `// 32` arithmetic keeps its exact meaning:

```diff
-def loop(step):
+def loop(tick):
+    step = tick // amyboard.TICKS_PER_STEP
     s = step % 32
     bar = (step // 32) % 4
```

Edges it handles, each found in the real corpus:

- The derivation is inserted **after** any leading `global`/`nonlocal` declarations — an assignment above them is bad form and can fail to compile.
- **11 sketches already use the identifier `tick`** (e.g. one has `def seq_tick(tick):`), so the parameter falls back to `_tick` rather than shadowing.
- **5 sketches gain `import amyboard`**, inserted before their first existing import.

Every rewrite is verified to parse and to leave `loop` at arity 1 before it would ever be uploaded.

The same collision bit the repo: `universal_hair.py` keeps its own module-global `tick` with a `global tick` inside `loop`, so shadowing it doesn't even compile — it's `loop(_tick)` here.

## Not done in this PR

- **The World migration hasn't been applied.** Run `WORLD_ADMIN_TOKEN=… python3 tulip/server/migrate_world_loop_arg.py --apply` once this merges. Until then, un-migrated World sketches will hit the new error and stop after 8 failed calls.
- `test_hardware_tags.py` couldn't be run locally (no `fastapi` in this environment) — its fixtures are updated but unexecuted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
