### PR TITLE
Make the loop migration idempotent (missed by #1310's merge)

### DIFF
--- a/tulip/amyboardweb/sketches/arp.py
+++ b/tulip/amyboardweb/sketches/arp.py
@@ -1,20 +1,22 @@
 # AMYboard Sketch
-# Top-level code runs once at boot. loop() is called every 32nd note.
+# Top-level code runs once at boot. loop(tick) is called every 32nd note.
 # DESCRIPTION: Hold MIDI keys; plays them in order as 8th-note arpeggios.
 # In simulate mode, you have to use MIDI input, not the onscreen keyboard.
 
-import amy, midi, tulip
+import amy, midi, amyboard
 
 # Tell synth 1 to not grab midi notes - we'll play them from this sketch.
 amy.send(synth=1, grab_midi_notes=0)
 
-# 8th note at 120 BPM = 250 ms per step.
-STEP_MS = 250
+# Advance the arp every 8th note. loop() runs on the sequencer's 32nd-note
+# grid, so an 8th note is 4 of those steps -- no wall clock, and it follows
+# the tempo instead of assuming one (this used to be a hardcoded 250 ms,
+# i.e. an 8th note only while the tempo happened to be 120 BPM).
+STEP_STEPS = 4
 
 held = set()           # midi note numbers currently held down
 arp_idx = 0            # next index into the sorted held list to play
 last_played = None     # most recently triggered note (so we can release it)
-last_step_ms = 0       # last time we advanced the arp
 
 
 def midi_cb(m):
@@ -33,11 +35,9 @@ midi.add_callback(midi_cb)
 
 
 def loop(tick):
-    global arp_idx, last_played, last_step_ms
-    now = tulip.amy_ticks_ms()
-    if now - last_step_ms < STEP_MS:
+    global arp_idx, last_played
+    if (tick // amyboard.TICKS_PER_STEP) % STEP_STEPS:
         return
-    last_step_ms = now
 
     # Release the previous step's note before triggering the next one.
     if last_played is not None:

--- a/tulip/server/migrate_world_loop_arg.py
+++ b/tulip/server/migrate_world_loop_arg.py
@@ -67,6 +67,19 @@ STEP_EXPR = "%s // amyboard.TICKS_PER_STEP"
 # SKIP      No top-level `def loop`, or already migrated, or unparseable.
 CLASSES = ("ADD_ARG", "RENAME", "RESCALE", "SKIP")
 
+# Which classes are safe to publish BEFORE the firmware that requires the
+# argument has shipped -- see --classes.
+#
+# ADD_ARG and RENAME run correctly on both firmwares. The old runner senses
+# the signature and calls loop(step); these sketches now accept an argument
+# and ignore it, so nothing changes for them. The new runner calls
+# loop(tick). Either way they behave exactly as before.
+#
+# RESCALE does NOT survive that: it divides the argument by TICKS_PER_STEP,
+# which is right when the argument is a tick and 6x too slow when the old
+# runner passes a step. So it has to land with the firmware, not ahead of it.
+FIRMWARE_AGNOSTIC = ("ADD_ARG", "RENAME")
+
 
 # ── API helpers (same shapes as migrate_world_ticks.py) ───────────────────────
 
@@ -170,6 +183,31 @@ def _first_body_line(fn, lines):
     return fn.body[-1].end_lineno if fn.body else fn.lineno
 
 
+def _already_migrated(fn):
+    """True if loop's body already starts with the derivation this script inserts.
+
+    Without this the script is not idempotent: after a successful run the
+    parameter IS read (by the derivation itself), so a second pass would
+    re-classify the sketch as RESCALE, rename `tick` to `_tick` (because
+    `tick` now appears in the source) and insert a SECOND derivation line.
+    Re-running would quietly corrupt every rescaled sketch.
+    """
+    for stmt in fn.body:
+        if isinstance(stmt, (ast.Global, ast.Nonlocal)):
+            continue
+        if (isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Constant)
+                and isinstance(stmt.value.value, str)):
+            continue
+        if (isinstance(stmt, ast.Assign)
+                and isinstance(stmt.value, ast.BinOp)
+                and isinstance(stmt.value.op, ast.FloorDiv)
+                and isinstance(stmt.value.right, ast.Attribute)
+                and stmt.value.right.attr == "TICKS_PER_STEP"):
+            return True
+        return False
+    return False
+
+
 def classify_and_rewrite(src):
     """Return (cls, new_src, note). new_src is None when nothing changes."""
     try:
@@ -184,6 +222,8 @@ def classify_and_rewrite(src):
         return "SKIP", None, "loop(*args) already accepts the tick"
     if len(args.args) > 1:
         return "SKIP", None, "loop() takes %d args -- needs a human" % len(args.args)
+    if args.args and _already_migrated(fn):
+        return "SKIP", None, "already migrated (derivation present)"
 
     lines = src.split("\n")
     def_i = fn.lineno - 1
@@ -198,6 +238,12 @@ def classify_and_rewrite(src):
         return "ADD_ARG", "\n".join(lines), "added parameter %r" % name
 
     param = args.args[0].arg
+    if param == TICK_NAME or param.startswith("_" + TICK_NAME):
+        # Already migrated, or already named sensibly. Renaming it again would
+        # be pure churn -- and would burn a new version of every sketch on a
+        # re-run, since _free_name() sees the existing `tick` and proposes
+        # `_tick`.
+        return "SKIP", None, "parameter already named %r" % param
     reads = [n for n in ast.walk(fn)
              if isinstance(n, ast.Name) and n.id == param and isinstance(n.ctx, ast.Load)]
     name = _free_name(src)
@@ -270,6 +316,9 @@ def main():
     ap.add_argument("--write-diffs", metavar="DIR", help="dump before/after files")
     ap.add_argument("--apply", action="store_true", help="re-upload rewritten sketches")
     ap.add_argument("--scope", choices=SCOPES, help="limit to one world")
+    ap.add_argument("--classes", default="all",
+                    help="which classes to rewrite: 'all', 'safe' (ADD_ARG+RENAME, "
+                         "publishable before the firmware ships), or a comma-separated list")
     opts = ap.parse_args()
     if not (opts.report or opts.write_diffs or opts.apply):
         opts.report = True
@@ -277,6 +326,18 @@ def main():
     token = os.environ.get("WORLD_ADMIN_TOKEN")
     if opts.apply and not token:
         sys.exit("--apply needs WORLD_ADMIN_TOKEN in the environment")
+
+    if opts.classes == "all":
+        want = set(CLASSES)
+    elif opts.classes == "safe":
+        want = set(FIRMWARE_AGNOSTIC)
+    else:
+        want = {c.strip().upper() for c in opts.classes.split(",")}
+        bad = want - set(CLASSES)
+        if bad:
+            sys.exit("unknown class(es): %s" % ", ".join(sorted(bad)))
+    if want != set(CLASSES):
+        print("limiting rewrites to: %s" % ", ".join(sorted(want)))
 
     counts = dict.fromkeys(CLASSES, 0)
     failures = []
@@ -294,9 +355,15 @@ def main():
                 continue
             cls, new_src, note = classify_and_rewrite(src)
             counts[cls] += 1
+            if cls not in want:
+                continue
             if new_src is None:
                 if opts.verbose and cls == "SKIP":
                     print("  SKIP     %s/%s: %s" % (item["username"], fname, note))
+                continue
+            if new_src == src:
+                counts[cls] -= 1
+                counts["SKIP"] += 1
                 continue
             ok, why = verify(new_src)
             if not ok:


### PR DESCRIPTION
Follow-up to #1310. That PR merged at `577d14be`, but a second commit — the idempotency fix for the migration script, plus `arp.py` — was pushed to the branch shortly *after* the merge, so it never reached `main`. This is that commit, cherry-picked onto current `main`.

> [!WARNING]
> Until this lands, `tulip/server/migrate_world_loop_arg.py` on `main` is **not idempotent**, and the World migration has already been applied once. A second `--apply` would corrupt the 74 rescaled sketches.

## The bug

After a successful pass the loop parameter *is* read — by the derivation the script itself inserted — so a second pass re-classifies those sketches as `RESCALE`, renames `tick` to `_tick` (because `tick` now appears in the source) and inserts a **second** derivation line:

```python
def loop(_tick):
    step = _tick // amyboard.TICKS_PER_STEP     # inserted by run 2
    step = tick // amyboard.TICKS_PER_STEP      # from run 1 -- `tick` is now undefined
```

The 464 signature-only sketches were milder but still wrong: renaming their `tick` parameter to `_tick` would burn a fresh version of each for no change at all.

## The fix

Three guards:

- a loop body already starting with `X = Y // *.TICKS_PER_STEP` is already migrated → SKIP
- a parameter already named `tick` / `_tick*` needs no rename → SKIP
- a rewrite that comes out byte-identical is never uploaded

A `--report` over both live Worlds is now **613 SKIP / 0 to write**, where before this it wanted to rewrite 537.

Also adds `--classes {all,safe,<list>}`. `ADD_ARG` and `RENAME` are firmware-agnostic — the old runner senses the signature and passes a step, which those sketches ignore — so they can ship ahead of the firmware. `RESCALE` cannot: it divides by `TICKS_PER_STEP`, right for a tick and 6× too slow for a step.

## arp.py

Rides along from the same commit. It was the last sketch in the repo reading the millisecond clock, doing exactly what `AMY_AGENTS.md` tells authors not to do:

```diff
-    now = tulip.amy_ticks_ms()
-    if now - last_step_ms < STEP_MS:
-        return
-    last_step_ms = now
+    if (tick // amyboard.TICKS_PER_STEP) % STEP_STEPS:
+        return
```

Drops a global, can't drift, and follows tempo — `STEP_MS = 250` was an 8th note only at 120 BPM. Verified it fires every 24 ticks, 8 times per bar. No sketch in the repo reads a millisecond clock now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
