### PR TITLE
web: reset the timebase by sending the event, not via a C binding

### DIFF
--- a/docs/amy_c_api_surface.md
+++ b/docs/amy_c_api_surface.md
@@ -27,7 +27,7 @@ Legend for the platform columns: **Py** = pyamy.c, **MP** = modtulip.c,
 | `void amy_add_message(char*)` | ✅ `send_wire` | ✅ `tulip.amy_send` | ✅ cwrap `['string']` → `amy_js_message` module | `amy.override_send` routes to each |
 | `void amy_add_message_from_sysex(char*)` | ✅ `send_wire_from_sysex` | ✅ inside `tulip.amy_send_sysex` (ring-buffer slot + AK ack) | ➖ (web sends sysex *to* hardware instead) | — |
 | `uint32_t amy_sysclock()` | ✅ `ticks_ms` | ✅ `tulip.amy_ticks_ms` | ✅ cwrap → `amy_sysclock` module → `tulip.amy_ticks_ms`, `amy.ticks_ms` | `tulip.amy_ticks_ms()` everywhere |
-| `void amy_reset_sysclock()` | ➖ | ➖ | ➖ (no longer bound — see below) | C-only since amy#1081 |
+| `void amy_reset_sysclock()` | ➖ | ➖ | ➖ | C hosts only; see note below |
 | `float amy_get_render_load()` | ✅ `render_load` | ✅ `tulip.amy_render_load` | ❌ missing on web | |
 | `void amy_set_render_load_threshold(float)` | ✅ | ✅ `tulip.amy_set_render_load_threshold` | ❌ missing on web | |
 | `void *yield_synth_commands(uint8_t synth, char *s, size_t len, bool include_fx, void *state)` | ✅ looped in `get_synth_commands` | ✅ looped in `tulip.amy_get_synth_commands` | ✅ looped in JS `get_synth_commands()` w/ manual `_malloc` + heap-string readback, installed as a Python lambda | three hand-written copies of the same generator loop |
@@ -95,10 +95,10 @@ generated from a field map later.
 - `dump_state`: CPython + web, **not exposed to MicroPython**.
 - `get_synth_commands`: the generator loop is hand-written **three times** with
   three different buffer strategies (C stack buffer ×2, JS heap malloc).
-- `amy_reset_sysclock`: no longer bound anywhere. amy#1081 made
-  RESET_TIMEBASE an ordinary event, so each binding implements
-  `reset_sysclock()` natively as a send of that reset bit; both `spss.js`
-  copies do the same. The C function still exists for C hosts.
+- `amy_reset_sysclock`: not bound to any scripting layer. RESET_TIMEBASE is
+  an ordinary event, so `reset_sysclock()` is written natively in each
+  binding as a send of that reset bit, and both `spss.js` copies do the
+  same. The C function exists for C hosts.
 - Input-buffer functions: exported to WASM but the JS side has rotted into
   comments.
 - Naming: `ticks_ms` (Py) vs `tulip.amy_ticks_ms` (MP) vs `amy.ticks_ms` (web

--- a/docs/amy_c_api_surface.md
+++ b/docs/amy_c_api_surface.md
@@ -27,7 +27,7 @@ Legend for the platform columns: **Py** = pyamy.c, **MP** = modtulip.c,
 | `void amy_add_message(char*)` | ✅ `send_wire` | ✅ `tulip.amy_send` | ✅ cwrap `['string']` → `amy_js_message` module | `amy.override_send` routes to each |
 | `void amy_add_message_from_sysex(char*)` | ✅ `send_wire_from_sysex` | ✅ inside `tulip.amy_send_sysex` (ring-buffer slot + AK ack) | ➖ (web sends sysex *to* hardware instead) | — |
 | `uint32_t amy_sysclock()` | ✅ `ticks_ms` | ✅ `tulip.amy_ticks_ms` | ✅ cwrap → `amy_sysclock` module → `tulip.amy_ticks_ms`, `amy.ticks_ms` | `tulip.amy_ticks_ms()` everywhere |
-| `void amy_reset_sysclock()` | ➖ | ➖ | ✅ (called from JS `runCodeBlock`) | — |
+| `void amy_reset_sysclock()` | ➖ | ➖ | ➖ (no longer bound — see below) | C-only since amy#1081 |
 | `float amy_get_render_load()` | ✅ `render_load` | ✅ `tulip.amy_render_load` | ❌ missing on web | |
 | `void amy_set_render_load_threshold(float)` | ✅ | ✅ `tulip.amy_set_render_load_threshold` | ❌ missing on web | |
 | `void *yield_synth_commands(uint8_t synth, char *s, size_t len, bool include_fx, void *state)` | ✅ looped in `get_synth_commands` | ✅ looped in `tulip.amy_get_synth_commands` | ✅ looped in JS `get_synth_commands()` w/ manual `_malloc` + heap-string readback, installed as a Python lambda | three hand-written copies of the same generator loop |
@@ -95,7 +95,10 @@ generated from a field map later.
 - `dump_state`: CPython + web, **not exposed to MicroPython**.
 - `get_synth_commands`: the generator loop is hand-written **three times** with
   three different buffer strategies (C stack buffer ×2, JS heap malloc).
-- `amy_reset_sysclock`: web-only, never exposed to Python anywhere.
+- `amy_reset_sysclock`: no longer bound anywhere. amy#1081 made
+  RESET_TIMEBASE an ordinary event, so each binding implements
+  `reset_sysclock()` natively as a send of that reset bit; both `spss.js`
+  copies do the same. The C function still exists for C hosts.
 - Input-buffer functions: exported to WASM but the JS side has rotted into
   comments.
 - Naming: `ticks_ms` (Py) vs `tulip.amy_ticks_ms` (MP) vs `amy.ticks_ms` (web

--- a/tulip/amyboardweb/static/spss.js
+++ b/tulip/amyboardweb/static/spss.js
@@ -936,8 +936,8 @@ if (typeof amyModule === 'function') _amy_wasm_ready = amyModule().then(async fu
   );
   amy_bleep = amy_c_api.bleep;
   amy_add_message = amy_c_api.send_wire;
-  // Native, not a C binding: amy dropped the reset_sysclock C entry point
-  // (amy#1081) because RESET_TIMEBASE is an ordinary event.
+  // RESET_TIMEBASE is an ordinary AMY event and amy's C API doesn't bind
+  // reset_sysclock, so send the event.
   amy_reset_sysclock = function() { amy_add_message('S' + AMY.RESET_TIMEBASE + 'Z'); };
   amy_ticks = amy_c_api.sequencer_ticks;
   amy_sysclock = amy_c_api.ticks_ms;

--- a/tulip/amyboardweb/static/spss.js
+++ b/tulip/amyboardweb/static/spss.js
@@ -936,7 +936,9 @@ if (typeof amyModule === 'function') _amy_wasm_ready = amyModule().then(async fu
   );
   amy_bleep = amy_c_api.bleep;
   amy_add_message = amy_c_api.send_wire;
-  amy_reset_sysclock = amy_c_api.reset_sysclock;
+  // Native, not a C binding: amy dropped the reset_sysclock C entry point
+  // (amy#1081) because RESET_TIMEBASE is an ordinary event.
+  amy_reset_sysclock = function() { amy_add_message('S' + AMY.RESET_TIMEBASE + 'Z'); };
   amy_ticks = amy_c_api.sequencer_ticks;
   amy_sysclock = amy_c_api.ticks_ms;
   amy_process_single_midi_byte = amy_c_api.process_single_midi_byte;

--- a/tulip/web/static/spss.js
+++ b/tulip/web/static/spss.js
@@ -43,7 +43,10 @@ amyModule().then(async function(am) {
   );
   amy_bleep = amy_c_api.bleep;
   amy_add_message = amy_c_api.send_wire;
-  amy_reset_sysclock = amy_c_api.reset_sysclock;
+  // Native, not a C binding: amy dropped the reset_sysclock C entry point
+  // (amy#1081) because RESET_TIMEBASE is an ordinary event. 16384 is
+  // RESET_TIMEBASE in src/amy.h; this page has no AMY constants object.
+  amy_reset_sysclock = function() { amy_add_message('S16384Z'); };
   amy_ticks = amy_c_api.sequencer_ticks;
   amy_sysclock = amy_c_api.ticks_ms;
   amy_process_single_midi_byte = amy_c_api.process_single_midi_byte;

--- a/tulip/web/static/spss.js
+++ b/tulip/web/static/spss.js
@@ -43,9 +43,9 @@ amyModule().then(async function(am) {
   );
   amy_bleep = amy_c_api.bleep;
   amy_add_message = amy_c_api.send_wire;
-  // Native, not a C binding: amy dropped the reset_sysclock C entry point
-  // (amy#1081) because RESET_TIMEBASE is an ordinary event. 16384 is
-  // RESET_TIMEBASE in src/amy.h; this page has no AMY constants object.
+  // RESET_TIMEBASE is an ordinary AMY event and amy's C API doesn't bind
+  // reset_sysclock, so send the event. 16384 is RESET_TIMEBASE in
+  // src/amy.h; this page has no AMY constants object to name it.
   amy_reset_sysclock = function() { amy_add_message('S16384Z'); };
   amy_ticks = amy_c_api.sequencer_ticks;
   amy_sysclock = amy_c_api.ticks_ms;


### PR DESCRIPTION
Companion to [shorepine/amy#1081](https://github.com/shorepine/amy/pull/1081), which drops the `amy_reset_sysclock` C entry point from the scripting bindings now that `RESET_TIMEBASE` travels as an ordinary event.

Both `spss.js` copies do `amy_reset_sysclock = amy_c_api.reset_sysclock;`. After that amy change the binding resolves to `undefined`, and Tulip Web's `runCodeBlock()` — which resets the timebase before **every** run — would throw on the first run.

Each copy now sends the event itself:

- `tulip/amyboardweb/static/spss.js` has the `AMY` constants object in scope (it already uses `AMY.RESET_SYNTHS` elsewhere), so it sends `AMY.RESET_TIMEBASE`.
- `tulip/web/static/spss.js` has no constants object, so it sends the literal `S16384Z` with a comment naming the bit.

**Ordering:** this is safe to merge *before* the amy pin moves — the wire bit is unchanged, so sending the event works against the currently pinned amy exactly as it will after. Merging it first means the pin bump can't land in a window where Tulip Web is broken.

Also updates `docs/amy_c_api_surface.md`, which listed `amy_reset_sysclock` as a web-only binding it no longer is.

Verified both files still parse (`node --check`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)