### PR TITLE
AMYboard I2C follower: frame messages instead of dispatching raw reads

### DIFF
--- a/tulip/amyboard/amyboard_support.c
+++ b/tulip/amyboard/amyboard_support.c
@@ -68,14 +68,58 @@ esp_err_t i2c_follower_init() {
 
 uint8_t i2c_buffer[MAX_MESSAGE_LEN];
 
+// AMY message framing for the I2C follower. The ESP-IDF slave driver hands us
+// a byte ring with no transaction boundaries: an AMY message longer than one
+// host write arrives split across reads, and back-to-back short messages can
+// arrive coalesced in one read. So accumulate bytes and dispatch only complete
+// messages. A message ends at 'Z' -- except a message carrying 'u' (patch
+// string), which is itself a concatenation of Z-terminated messages and so
+// ends at the doubled 'ZZ' (last inner terminator + the message's own; a host
+// must always end a u-message with ZZ). Each complete message is dispatched
+// on its own, so a leading 'H' (ticks scheduling) stays the first byte and a
+// 'u' can't swallow a following message.
+//
+// Known limits of a byte scan (fine for real wire traffic, documented so
+// nobody rediscovers them): a 'u' byte inside any argument triggers the ZZ
+// rule, and a patch string with interior ZZs (mapping commands stored inside
+// a patch, like the firmware drum kits in amy's patches.h -- those load by
+// K number, they don't travel over the wire) ends at its first ZZ.
+static uint8_t i2c_msg[MAX_MESSAGE_LEN];
+static size_t i2c_msg_len = 0;
+static uint8_t i2c_msg_has_u = 0;
+static uint8_t i2c_msg_resync = 0;
+
+static void i2c_accumulate_byte(uint8_t b) {
+    if(i2c_msg_resync) {
+        // Recovering from an oversized message: discard up to and including
+        // the next 'Z', then start clean.
+        if(b == 'Z') i2c_msg_resync = 0;
+        return;
+    }
+    if(i2c_msg_len >= MAX_MESSAGE_LEN - 1) {
+        // Longer than AMY's own message limit, so it could never parse (or a
+        // terminator was lost to a dropped byte). Drop it and resync at the
+        // next 'Z' rather than wedging the stream waiting for a terminator.
+        fprintf(stderr, "amyboard i2c: message exceeds %d bytes, dropping\n", MAX_MESSAGE_LEN - 1);
+        i2c_msg_len = 0;
+        i2c_msg_has_u = 0;
+        i2c_msg_resync = 1;
+        return;
+    }
+    i2c_msg[i2c_msg_len++] = b;
+    if(b == 'u') i2c_msg_has_u = 1;
+    if(b == 'Z' && (!i2c_msg_has_u || (i2c_msg_len >= 2 && i2c_msg[i2c_msg_len - 2] == 'Z'))) {
+        i2c_msg[i2c_msg_len] = 0;
+        amy_add_message((char*)i2c_msg);
+        i2c_msg_len = 0;
+        i2c_msg_has_u = 0;
+    }
+}
+
 void i2c_check_for_data() {
     while(1) {
         size_t size = i2c_slave_read_buffer(I2C_FOLLOWER_NUM, i2c_buffer, MAX_MESSAGE_LEN, 10 / portTICK_PERIOD_MS);
-        if(size>0) {
-            i2c_buffer[size] = 0;
-            //fprintf(stderr, "%s\n", i2c_buffer);
-            amy_add_message((char*)i2c_buffer);
-        }
+        for(size_t i = 0; i < size; i++) i2c_accumulate_byte(i2c_buffer[i]);
     }
 }
 


### PR DESCRIPTION
## Problem

The I2C follower dispatched every `i2c_slave_read_buffer()` result straight to `amy_add_message()`. The ESP-IDF slave driver's byte ring carries no transaction boundaries, so any host message longer than one I2C write arrived as fragments, each dispatched as a complete message — and a fragment that lost its `i<synth>` prefix was applied to oscillator 0 of the first synth (`amy.c`: unset osc defaults to 0). An external host project (Raspberry Pi at 32 bytes/write driving the board at 0x3F) reported exactly this: editing any track corrupted synth 1, only for messages too big for one write (~200-byte `patch_string` voice loads). Reads that coalesced two messages also silently dropped the second message's leading-`H` scheduling, and `i2c_buffer[size] = 0` wrote one past the end of the buffer when a read returned `MAX_MESSAGE_LEN` bytes.

## Fix

Accumulate bytes and dispatch only complete messages:

- A message ends at `Z` — except one carrying `u` (patch string), which ends at the doubled `ZZ`, since a patch string is a concatenation of Z-terminated messages and hosts terminate u-messages with `ZZ`. The check reads the accumulator, so a `ZZ` straddling two reads works.
- Each complete message dispatches on its own, preserving leading-`H` scheduling and keeping a `u` from swallowing a coalesced follower (`u` consumes to end-of-string in `parse.c`).
- An oversized or unterminated message (> 1023 bytes can never parse anyway) is dropped with a stderr log and the framer resyncs at the next `Z`, so a lost terminator or a stray `u` byte in an argument can't wedge the stream.
- The off-by-one NUL write is gone.

Known limit, documented in the code comment: a byte scan can't frame a patch string with interior `ZZ`s (mapping commands embedded in a patch, like amy's stored drum kits in `patches.h`) — those load by `K` number and don't travel over the wire, and stock firmware couldn't receive any multi-write message at all, so this is no regression.

## Verification

- `idf.py -DMICROPY_BOARD=AMYBOARD build` compiles clean.
- The framer block, extracted verbatim from the source, passes host-side tests: a message split at every chunk size 1–8, three coalesced messages (H preserved), a u-patch split at every chunk size 1–32, a realistic 210-byte load in 32-byte writes followed by a short message, overflow + resync recovery, a stray `Z`, and `ZZ` across a read boundary.
- Not yet exercised on hardware with an external I2C host.

Follow-up (separate): the link is write-only in practice — the TX ring is installed but nothing ever writes to it, so a host can't poll firmware version/capabilities to confirm framed firmware is running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)