### PR TITLE
AMYboard Web: make World upload validation alerts visible

### DIFF
--- a/tulip/amyboardweb/static/editor/index.html
+++ b/tulip/amyboardweb/static/editor/index.html
@@ -975,6 +975,9 @@
   </head>
 
   <body>
+    <!-- Global alert box: must live outside the tab panes, since Bootstrap
+         sets inactive .tab-pane to display:none and would hide it. -->
+    <div class="alert fixed-top d-none" style="z-index: 10000;" id="alert_box"></div>
     <nav id="navScroll" class="navbar navbar-expand-lg navbar-dark fixed-top scrolled" tabindex="0">
       <div class="container">
         <a class="navbar-brand pe-4 fs-4" href="/editor/">
@@ -1678,7 +1681,6 @@
               </div>
             </div>
             <div class="tab-pane fade" id="environment-pane" role="tabpanel" aria-labelledby="environment-tab">
-              <div class="alert fixed-top d-none" id="alert_box"></div>
               <!-- Terminal REPL — hidden by default under disclosure triangle -->
               <details class="mb-3" id="repl-disclosure">
                 <summary class="repl-summary">Terminal REPL</summary>
@@ -1851,7 +1853,7 @@
                         <div class="form-text">1-20 chars: A-Z, a-z, 0-9.</div>
                       </div>
                       <div class="col-12 col-md-4">
-                        <label for="editor_filename" class="form-label mb-1">Sketch name (no spaces!)</label>
+                        <label for="editor_filename" class="form-label mb-1">Sketch name (no spaces or dots)</label>
                         <input type="text" id="editor_filename" class="small form-control" maxlength="20" placeholder="my_sketch" />
                         <div class="form-text">1-20 chars: A-Z, a-z, 0-9, -, _.</div>
                       </div>


### PR DESCRIPTION
## Summary

A user reported that pressing **Upload** on the AMYboard World tab \"does nothing\" while it works for everyone else. Their sketch name was `AB_Shell_v0.3.5`. The dots fail the client-side name check (letters, digits, `-`, `_` only, same rule the server enforces), and the resulting `show_alert()` was never visible.

**Root cause:** the global `#alert_box` div lived inside the Environment tab pane. Bootstrap sets inactive `.tab-pane` to `display:none`, so any alert fired from a different tab (the World tab's upload validation, in this case) set its text, was hidden by its parent, and cleared itself 3 s later without ever being painted. Every validation error on the World tab was silent, not just this one.

**Fix:**
- Move `#alert_box` to the top of `<body>`, outside the tab content, with an inline z-index above modals so it also shows over the welcome / admin-token dialogs.
- Update the Sketch name label to say \"no spaces or dots\".

Note: the page links `amyrepl.css` relatively from `/editor/`, which 307s in production, so the `.alert-fixed` class defined there is never loaded. That is why the z-index is inline here rather than via that class.

## Test plan

- [x] Reproduced on amyboard.com: World tab, username `schinji`, name `AB_Shell_v0.3.5`, click Upload. Alert text was set but element was 0×0 with parent `display:none`.
- [x] Applied the same DOM move in-page: the red alert renders full-width at the top, above the navbar and the open welcome modal.
- [ ] Confirm on the PR preview (`amyboard-pr-<N>.vercel.app/editor/`) that a dotted sketch name shows the alert and a valid name still uploads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)