### PR TITLE
World: tags follow the sketch across versions; tag filter resolves latest first

### DIFF
--- a/tulip/server/amyboardworld_db_api.py
+++ b/tulip/server/amyboardworld_db_api.py
@@ -519,6 +519,41 @@ def _discord_notify(channel_id: str, content: str) -> None:
         return
 
 
+def _tags_for_new_version(
+    conn: sqlite3.Connection,
+    table: str,
+    username: str,
+    filename: str,
+    tags: list[str] | None,
+) -> list[str]:
+    """Tags a newly uploaded version of (username, filename) should carry.
+
+    Tags belong to the sketch, not to one upload of it: a new version inherits
+    every tag of the previous live version, so re-saving a #featured sketch (or
+    a migration re-uploading a rewritten one) never silently drops the tag —
+    which is what left the #featured chip serving pre-migration `def loop():`
+    sources in Sep 2026. When the caller supplies tags (the generator passes
+    freshly detected hardware tags), its hardware tags *replace* the inherited
+    ones and its other tags are added.
+    """
+    row = conn.execute(
+        f"""
+        SELECT tags_json FROM {table}
+        WHERE deleted_at_ms IS NULL AND lower(username) = ? AND lower(filename) = ?
+        ORDER BY created_at_ms DESC, id DESC
+        LIMIT 1
+        """,
+        (username.lower(), filename.lower()),
+    ).fetchone()
+    inherited = _parse_tags(row["tags_json"]) if row else []
+    if tags is None:
+        return inherited
+    explicit = _parse_tags(tags)
+    merged = _merge_hardware_tags(inherited, [t for t in explicit if t in HARDWARE_TAGS])
+    merged.extend(t for t in explicit if t not in HARDWARE_TAGS and t not in merged)
+    return merged
+
+
 def _insert_file_row(
     table: str,
     files_dir: Path,
@@ -534,8 +569,8 @@ def _insert_file_row(
 ) -> int:
     ts_ms = _normalize_created_at_ms(created_at_ms)
     digest = hashlib.sha256(contents).hexdigest()
-    tags_json = json.dumps(_parse_tags(tags or []))
     with _open_db() as conn:
+        tags_json = json.dumps(_tags_for_new_version(conn, table, username, filename, tags))
         # Use item_type column only for the environments table.
         if table == "environments":
             cur = conn.execute(
@@ -621,40 +656,46 @@ def _list_file_rows(
     extra_cols = ", item_type" if table == "environments" else ""
     if include_ip:
         extra_cols += ", client_ip"
+    select_cols = f"id, username, filename, description, tags_json, created_at_ms, size_bytes{extra_cols}"
 
-    with _open_db() as conn:
-        rows = conn.execute(
-            f"""
-            SELECT id, username, filename, description, tags_json, created_at_ms, size_bytes{extra_cols}
+    if latest_per_user_env:
+        # Resolve "the latest version of each (username, filename)" over ALL
+        # live rows *before* applying the q/tag/username filters, so a filter
+        # can only ever match the current version of a sketch. Filtering
+        # first and deduping the survivors let a tag that only an older
+        # version carried surface that stale row: after the loop(tick)
+        # migration re-uploaded every sketch, ?tag=featured served the
+        # pre-migration `def loop():` bodies while the plain listing served
+        # the new ones (Sep 2026). Ties on created_at_ms (Discord importer,
+        # backup restores) break toward the highest id, else the *oldest*
+        # duplicate wins — which hid 78 Tulip World sketches behind dead rows
+        # whose blobs were lost in the Feb 2026 Modal->Railway migration.
+        sql = f"""
+            WITH ranked AS (
+                SELECT {select_cols}, deleted_at_ms,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY lower(username), lower(filename)
+                           ORDER BY created_at_ms DESC, id DESC
+                       ) AS version_rank
+                FROM {table}
+                WHERE deleted_at_ms IS NULL
+            )
+            SELECT {select_cols} FROM ranked
+            WHERE version_rank = 1 AND {where_sql}
+            ORDER BY created_at_ms DESC, id DESC
+            LIMIT ?
+        """
+    else:
+        sql = f"""
+            SELECT {select_cols}
             FROM {table}
             WHERE {where_sql}
             ORDER BY created_at_ms DESC, id DESC
             LIMIT ?
-            """,
-            [*params, max(limit * 4, limit)],
-        ).fetchall()
+        """
 
-    if latest_per_user_env:
-        # Keeps the first row per (username, filename), so it depends on the
-        # `id DESC` tie-break above. Uploads that carry an explicit
-        # created_at_ms (the Discord importer, backup restores) can tie
-        # exactly; without the tie-break SQLite resolves the tie by rowid
-        # ascending and the *oldest* duplicate wins. That's what hid 78 Tulip
-        # World sketches behind dead rows whose blobs were lost in the
-        # Feb 2026 Modal->Railway migration.
-        deduped: list[sqlite3.Row] = []
-        seen: set[tuple[str, str]] = set()
-        for row in rows:
-            key = (str(row["username"]).lower(), str(row["filename"]).lower())
-            if key in seen:
-                continue
-            seen.add(key)
-            deduped.append(row)
-            if len(deduped) >= limit:
-                break
-        rows = deduped
-    else:
-        rows = rows[:limit]
+    with _open_db() as conn:
+        rows = conn.execute(sql, [*params, limit]).fetchall()
 
     return {"items": [_file_row_to_public(row, scope) for row in rows]}
 

--- a/tulip/server/backfill_world_tags.py
+++ b/tulip/server/backfill_world_tags.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Carry tags forward from superseded World sketch versions to the latest one.
+
+The migration scripts (migrate_world_loop_arg.py, migrate_world_ticks.py,
+migrate_world_drum_amp.py) historically re-uploaded each rewritten sketch as a
+brand-new version without copying the old row's tags. Tag filters like
+``?tag=featured`` then matched only the stale row, so the #featured chip served
+the pre-migration source (``def loop():``) while the plain listing served the
+migrated one. This script finds every (scope, username, filename) group with more
+than one live version and PATCHes the union of the older rows' tags onto the
+newest row.
+
+    python3 backfill_world_tags.py            # report only
+    python3 backfill_world_tags.py --apply    # write via the admin tags endpoint
+
+The admin token is read from AMYBOARDWORLD_ADMIN_TOKEN (or WORLD_ADMIN_TOKEN);
+run under ``railway run`` to have Railway inject it.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+from urllib.request import Request, urlopen
+
+DEFAULT_URL = "https://tulipcc-production.up.railway.app"
+SCOPES = ("amyboardworld", "tulipworld")
+# Injected at serialization time for OFFICIAL_USERNAMES; never stored.
+VIRTUAL_TAGS = {"official"}
+
+
+def fetch_all(api_url: str, scope: str) -> list[dict]:
+    url = f"{api_url}/api/{scope}/files?limit=5000&latest_per_user_env=false"
+    with urlopen(url, timeout=60) as r:
+        return json.load(r)["items"]
+
+
+def plan(items: list[dict]) -> list[dict]:
+    groups: dict[tuple[str, str], list[dict]] = defaultdict(list)
+    for it in items:
+        groups[(it["username"].lower(), it["filename"].lower())].append(it)
+    out = []
+    for key, rows in groups.items():
+        if len(rows) < 2:
+            continue
+        rows.sort(key=lambda r: (r["time"], r["id"]), reverse=True)
+        latest, older = rows[0], rows[1:]
+        have = [t for t in latest.get("tags", []) if t not in VIRTUAL_TAGS]
+        want = list(have)
+        for r in older:
+            for t in r.get("tags", []):
+                if t not in VIRTUAL_TAGS and t not in want:
+                    want.append(t)
+        if want != have:
+            out.append({"id": latest["id"], "filename": latest["filename"],
+                        "username": latest["username"], "from": [r["id"] for r in older],
+                        "was": have, "tags": want})
+    return out
+
+
+def patch_tags(api_url: str, scope: str, item_id: int, tags: list[str], token: str) -> None:
+    body = json.dumps({"tags": tags}).encode()
+    req = Request(f"{api_url}/api/{scope}/files/{item_id}/tags", data=body, method="PATCH")
+    req.add_header("Content-Type", "application/json")
+    req.add_header("X-Admin-Token", token)
+    with urlopen(req, timeout=60) as r:
+        r.read()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url", default=DEFAULT_URL)
+    ap.add_argument("--scope", choices=SCOPES)
+    ap.add_argument("--apply", action="store_true")
+    opts = ap.parse_args()
+
+    token = os.environ.get("AMYBOARDWORLD_ADMIN_TOKEN") or os.environ.get("WORLD_ADMIN_TOKEN")
+    if opts.apply and not token:
+        print("--apply needs AMYBOARDWORLD_ADMIN_TOKEN in the environment", file=sys.stderr)
+        return 2
+
+    total = 0
+    for scope in (opts.scope,) if opts.scope else SCOPES:
+        changes = plan(fetch_all(opts.url, scope))
+        print(f"[{scope}] {len(changes)} latest rows missing tags from older versions")
+        for c in changes:
+            print(f"  #{c['id']} {c['username']}/{c['filename']}: {c['was']} -> {c['tags']} (from {c['from']})")
+            if opts.apply:
+                patch_tags(opts.url, scope, c["id"], c["tags"], token)
+        total += len(changes)
+    print(("applied" if opts.apply else "would apply") + f" {total} tag updates")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tulip/server/test_tag_versions.py
+++ b/tulip/server/test_tag_versions.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Tags follow the sketch, not one upload of it.
+
+Regression tests for the Sep 2026 #featured bug: the loop(tick) migration
+re-uploaded every World sketch as a new version without its tags, and the
+listing applied ?tag= *before* resolving the latest version per
+(username, filename). The #featured chip therefore served the old, tagged
+row (`def loop():`) while the plain listing served the migrated one.
+
+Two guarantees:
+  1. A tag filter can only ever match the latest live version of a sketch.
+  2. A new version uploaded through _insert_file_row inherits the previous
+     version's tags (hardware tags are replaced when the caller detects them).
+
+Run: python3 tulip/server/test_tag_versions.py
+(requires the server deps: fastapi, pydantic, requests).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+_TMP = Path(tempfile.mkdtemp(prefix="worldtags-"))
+os.environ["AMYBOARDWORLD_DB_PATH"] = str(_TMP / "world.db")
+os.environ["AMYBOARDWORLD_FILES_DIR"] = str(_TMP / "abw")
+os.environ["TULIPWORLD_FILES_DIR"] = str(_TMP / "tw")
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import amyboardworld_db_api as m  # noqa: E402
+
+_failures = 0
+
+
+def check(name: str, cond: bool) -> None:
+    global _failures
+    print(f"[{'ok  ' if cond else 'FAIL'}] {name}")
+    if not cond:
+        _failures += 1
+
+
+def insert(item_id: int, username: str, filename: str, created_at_ms: int,
+           tags: list[str] = ()) -> None:
+    with m._open_db() as conn:
+        conn.execute(
+            "INSERT INTO environments(id, username, filename, description, tags_json, "
+            "created_at_ms, size_bytes, sha256, blob_path, client_ip, item_type) "
+            "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [item_id, username, filename, "", json.dumps(list(tags)), created_at_ms, 1,
+             "x", f"/blobs/{item_id:09d}-{filename}", "", "environment"])
+        conn.commit()
+
+
+def ids(**kw) -> list[int]:
+    args = dict(limit=500, q="", tag="", username="", latest_per_user_env=True,
+                item_type="")
+    args.update(kw)
+    return [i["id"] for i in m.list_amyboard_files(**args)["items"]]
+
+
+def tags_of(item_id: int) -> list[str]:
+    with m._open_db() as conn:
+        row = conn.execute("SELECT tags_json FROM environments WHERE id = ?",
+                           (item_id,)).fetchone()
+    return json.loads(row["tags_json"])
+
+
+def main() -> int:
+    m._ensure_schema()
+    t0 = 1783515468941
+
+    # --- 1. listing: the tag filter must not resurrect a superseded version.
+    insert(920, "generator", "dx7_groove_128_bpm.py", t0, ["featured"])
+    insert(1187, "generator", "dx7_groove_128_bpm.py", t0 + 10**9)  # migrated, untagged
+    check("plain listing serves the latest version", ids() == [1187])
+    check("?tag=featured does not surface the stale tagged version",
+          920 not in ids(tag="featured"))
+    check("?tag=featured on an untagged latest version finds nothing",
+          ids(tag="featured") == [])
+    check("?q= cannot match a stale version either",
+          ids(q="dx7_groove") == [1187])
+
+    # Tagging the latest version makes it show up under the chip.
+    with m._open_db() as conn:
+        conn.execute("UPDATE environments SET tags_json = ? WHERE id = 1187",
+                     (json.dumps(["featured"]),))
+        conn.commit()
+    check("?tag=featured serves the latest version once it carries the tag",
+          ids(tag="featured") == [1187])
+
+    # Deleting the latest version falls back to the previous live one.
+    with m._open_db() as conn:
+        conn.execute("UPDATE environments SET deleted_at_ms = 1 WHERE id = 1187")
+        conn.commit()
+    check("soft-deleting the latest version reveals the previous one",
+          ids() == [920] and ids(tag="featured") == [920])
+
+    # latest_per_user_env=False still returns every live version.
+    with m._open_db() as conn:
+        conn.execute("UPDATE environments SET deleted_at_ms = NULL WHERE id = 1187")
+        conn.commit()
+    check("latest_per_user_env=False lists all live versions",
+          sorted(ids(latest_per_user_env=False)) == [920, 1187])
+
+    # --- 2. upload: a new version inherits the previous version's tags.
+    insert(422, "FlowRain", "SuperSaw.py", t0, ["featured", "display"])
+    new_id = m._insert_file_row("environments", m.AMYBOARD_FILES_DIR, "FlowRain",
+                                "v2", "SuperSaw.py", b"def loop(tick):\n    pass\n")
+    check("re-uploaded sketch inherits featured + hardware tags",
+          tags_of(new_id) == ["featured", "display"])
+    check("...and the new version is what ?tag=featured now serves",
+          ids(tag="featured", username="flowrain") == [new_id])
+
+    # Username lookup is case-insensitive, like the listing's dedup key.
+    newer_id = m._insert_file_row("environments", m.AMYBOARD_FILES_DIR, "flowrain",
+                                  "v3", "SuperSaw.py", b"x = 1\n")
+    check("inheritance matches username case-insensitively",
+          tags_of(newer_id) == ["featured", "display"])
+
+    # Caller-supplied hardware tags replace inherited ones; other tags are kept.
+    gen_id = m._insert_file_row("environments", m.AMYBOARD_FILES_DIR, "FlowRain",
+                                "v4", "SuperSaw.py", b"x = 2\n", tags=["cv"])
+    check("detected hardware tags replace inherited hardware tags, featured survives",
+          tags_of(gen_id) == ["featured", "cv"])
+
+    # A brand-new sketch with no prior version gets exactly the caller's tags.
+    fresh = m._insert_file_row("environments", m.AMYBOARD_FILES_DIR, "generator",
+                               "new", "brand_new.py", b"x = 3\n", tags=["encoder"])
+    check("first version of a sketch carries only the supplied tags",
+          tags_of(fresh) == ["encoder"])
+    fresh2 = m._insert_file_row("environments", m.AMYBOARD_FILES_DIR, "someone",
+                                "new", "plain.py", b"x = 4\n")
+    check("first version with no tags is untagged", tags_of(fresh2) == [])
+
+    print()
+    if _failures:
+        print(f"{_failures} FAILED")
+        return 1
+    print("all ok")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## The bug

Downloading `dx7_groove_128_bpm` from AMYboard World's **#featured** chip gave the pre-migration source (`def loop():`), while browsing the plain list gave the migrated one (`def loop(tick):`). Same for Dan vs Brian — it depended on which route you clicked, not on browser cache.

Row 920 (original, tagged `featured`, `def loop():`) and row 1187 (loop-arg migration re-upload, no tags, `def loop(tick):`) both exist for `generator/dx7_groove_128_bpm.py`. The migration scripts re-upload each rewritten sketch as a new version without copying tags, and `_list_file_rows` applied `?tag=` **before** deduping to the latest version per `(username, filename)`. So the featured filter only ever saw the stale row and served it.

Scope in production: **all 17 featured sketches** plus **257 hardware-tagged generator sketches** (`#display`, `#cv`, …) have their tags stuck on a superseded version.

## Server fixes

- **Listing** — `_list_file_rows` now ranks versions with a window function over all live rows first (`ROW_NUMBER() OVER (PARTITION BY lower(username), lower(filename) ORDER BY created_at_ms DESC, id DESC)`), then applies q / tag / username filters to the `rank = 1` rows. A filter can only ever match a sketch's current version. Keeps the highest-id tie-break from #1345-era dedup fix; `latest_per_user_env=false` is unchanged.
- **Upload** — `_insert_file_row` inherits the previous live version's tags (case-insensitive username match). Caller-supplied hardware tags (the generator's detector) replace inherited hardware tags; `featured` and other curation tags survive. This also fixes a regular user re-saving their featured sketch from the web silently losing the tag, and means the migration scripts need no changes.

## Data backfill

`tulip/server/backfill_world_tags.py` copies the union of superseded versions' tags onto the latest version via the admin tags endpoint. Report mode by default; `--apply` writes. Token from `AMYBOARDWORLD_ADMIN_TOKEN` (e.g. `railway run python3 tulip/server/backfill_world_tags.py --apply`). Report mode against production currently plans 274 updates in amyboardworld, 0 in tulipworld.

## Tests

`tulip/server/test_tag_versions.py` (new, 13 checks) — stale tagged version never surfaces under `?tag=` or `?q=`, soft-deleting the latest reveals the previous, `latest_per_user_env=false` still lists all, inheritance on re-upload incl. case-insensitive usernames and hardware-tag replacement. `test_latest_dedup.py` and `test_hardware_tags.py` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
